### PR TITLE
Reinstate caching in schema generation

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Text.Json.Nodes;
 
+#pragma warning disable S1067 // Expressions should not be too complex
+
 namespace Microsoft.Extensions.AI;
 
 /// <summary>
 /// Provides options for configuring the behavior of <see cref="AIJsonUtilities"/> JSON schema creation functionality.
 /// </summary>
-public sealed class AIJsonSchemaCreateOptions
+public sealed class AIJsonSchemaCreateOptions : IEquatable<AIJsonSchemaCreateOptions>
 {
     /// <summary>
     /// Gets the default options instance.
@@ -40,4 +42,21 @@ public sealed class AIJsonSchemaCreateOptions
     /// Gets a value indicating whether to mark all properties as required in the schema.
     /// </summary>
     public bool RequireAllProperties { get; init; } = true;
+
+    /// <inheritdoc/>
+    public bool Equals(AIJsonSchemaCreateOptions? other)
+    {
+        return other is not null &&
+            TransformSchemaNode == other.TransformSchemaNode &&
+            IncludeTypeInEnumSchemas == other.IncludeTypeInEnumSchemas &&
+            DisallowAdditionalProperties == other.DisallowAdditionalProperties &&
+            IncludeSchemaKeyword == other.IncludeSchemaKeyword &&
+            RequireAllProperties == other.RequireAllProperties;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is AIJsonSchemaCreateOptions other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => (TransformSchemaNode, IncludeTypeInEnumSchemas, DisallowAdditionalProperties, IncludeSchemaKeyword, RequireAllProperties).GetHashCode();
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -19,6 +20,7 @@ using Microsoft.Shared.Diagnostics;
 #pragma warning disable S1075 // URIs should not be hardcoded
 #pragma warning disable SA1118 // Parameter should not span multiple lines
 #pragma warning disable S109 // Magic numbers should not be used
+#pragma warning disable S1067 // Expressions should not be too complex
 
 namespace Microsoft.Extensions.AI;
 
@@ -40,6 +42,12 @@ public static partial class AIJsonUtilities
 
     /// <summary>The uri used when populating the $schema keyword in inferred schemas.</summary>
     private const string SchemaKeywordUri = "https://json-schema.org/draft/2020-12/schema";
+
+    /// <summary>The maximum number of schema entries to cache per JsonSerializerOptions instance.</summary>
+    private const int InnerCacheSoftLimit = 512;
+
+    /// <summary>A global cache for generated schemas, weakly keyed on JsonSerializerOptions instances.</summary>
+    private static readonly ConditionalWeakTable<JsonSerializerOptions, ConcurrentDictionary<JsonSchemaCacheKey, JsonElement>> _schemaCache = new();
 
     // List of keywords used by JsonSchemaExporter but explicitly disallowed by some AI vendors.
     // cf. https://platform.openai.com/docs/guides/structured-outputs#some-type-specific-keywords-are-not-yet-supported
@@ -65,58 +73,64 @@ public static partial class AIJsonUtilities
         serializerOptions ??= DefaultOptions;
         inferenceOptions ??= AIJsonSchemaCreateOptions.Default;
         title ??= method.Name;
-        description ??= method.GetCustomAttribute<DescriptionAttribute>()?.Description;
 
-        JsonObject parameterSchemas = new();
-        JsonArray? requiredProperties = null;
-        foreach (ParameterInfo parameter in method.GetParameters())
+        JsonSchemaCacheKey cacheKey = new(member: method, title, description, hasDefaultValue: false, defaultValue: null, inferenceOptions);
+        return GetOrAddSchema(serializerOptions, cacheKey, CreateSchema);
+
+        static JsonElement CreateSchema(JsonSchemaCacheKey key, JsonSerializerOptions serializerOptions)
         {
-            if (string.IsNullOrWhiteSpace(parameter.Name))
+            JsonObject parameterSchemas = new();
+            JsonArray? requiredProperties = null;
+            foreach (ParameterInfo parameter in ((MethodBase)key.Member!).GetParameters())
             {
-                Throw.ArgumentException(nameof(parameter), "Parameter is missing a name.");
+                if (string.IsNullOrWhiteSpace(parameter.Name))
+                {
+                    Throw.ArgumentException(nameof(parameter), "Parameter is missing a name.");
+                }
+
+                JsonNode parameterSchema = CreateJsonSchemaCore(
+                    type: parameter.ParameterType,
+                    parameterName: parameter.Name,
+                    description: parameter.GetCustomAttribute<DescriptionAttribute>(inherit: true)?.Description,
+                    hasDefaultValue: parameter.HasDefaultValue,
+                    defaultValue: parameter.HasDefaultValue ? parameter.DefaultValue : null,
+                    serializerOptions,
+                    key.Options);
+
+                parameterSchemas.Add(parameter.Name, parameterSchema);
+                if (!parameter.IsOptional)
+                {
+                    (requiredProperties ??= []).Add((JsonNode)parameter.Name);
+                }
             }
 
-            JsonNode parameterSchema = CreateJsonSchemaCore(
-                type: parameter.ParameterType,
-                parameterName: parameter.Name,
-                description: parameter.GetCustomAttribute<DescriptionAttribute>(inherit: true)?.Description,
-                hasDefaultValue: parameter.HasDefaultValue,
-                defaultValue: parameter.HasDefaultValue ? parameter.DefaultValue : null,
-                serializerOptions,
-                inferenceOptions);
-
-            parameterSchemas.Add(parameter.Name, parameterSchema);
-            if (!parameter.IsOptional)
+            JsonObject schema = new();
+            if (key.Options.IncludeSchemaKeyword)
             {
-                (requiredProperties ??= []).Add((JsonNode)parameter.Name);
+                schema[SchemaPropertyName] = SchemaKeywordUri;
             }
+
+            if (!string.IsNullOrWhiteSpace(key.Title))
+            {
+                schema[TitlePropertyName] = key.Title;
+            }
+
+            string? description = key.Description ?? key.Member.GetCustomAttribute<DescriptionAttribute>()?.Description;
+            if (!string.IsNullOrWhiteSpace(description))
+            {
+                schema[DescriptionPropertyName] = description;
+            }
+
+            schema[TypePropertyName] = "object"; // Method schemas always hardcode the type as "object".
+            schema[PropertiesPropertyName] = parameterSchemas;
+
+            if (requiredProperties is not null)
+            {
+                schema[RequiredPropertyName] = requiredProperties;
+            }
+
+            return JsonSerializer.SerializeToElement(schema, JsonContext.Default.JsonNode);
         }
-
-        JsonObject schema = new();
-        if (inferenceOptions.IncludeSchemaKeyword)
-        {
-            schema[SchemaPropertyName] = SchemaKeywordUri;
-        }
-
-        if (!string.IsNullOrWhiteSpace(title))
-        {
-            schema[TitlePropertyName] = title;
-        }
-
-        if (!string.IsNullOrWhiteSpace(description))
-        {
-            schema[DescriptionPropertyName] = description;
-        }
-
-        schema[TypePropertyName] = "object"; // Method schemas always hardcode the type as "object".
-        schema[PropertiesPropertyName] = parameterSchemas;
-
-        if (requiredProperties is not null)
-        {
-            schema[RequiredPropertyName] = requiredProperties;
-        }
-
-        return JsonSerializer.SerializeToElement(schema, JsonContext.Default.JsonNode);
     }
 
     /// <summary>Creates a JSON schema for the specified type.</summary>
@@ -137,21 +151,18 @@ public static partial class AIJsonUtilities
     {
         serializerOptions ??= DefaultOptions;
         inferenceOptions ??= AIJsonSchemaCreateOptions.Default;
-        JsonNode schema = CreateJsonSchemaCore(type, parameterName: null, description, hasDefaultValue, defaultValue, serializerOptions, inferenceOptions);
-        return JsonSerializer.SerializeToElement(schema, JsonContext.Default.JsonNode);
+
+        JsonSchemaCacheKey cacheKey = new(member: type, title: null, description, hasDefaultValue, defaultValue, inferenceOptions);
+        return GetOrAddSchema(serializerOptions, cacheKey, CreateSchema);
+        static JsonElement CreateSchema(JsonSchemaCacheKey key, JsonSerializerOptions serializerOptions)
+        {
+            JsonNode schema = CreateJsonSchemaCore((Type?)key.Member, parameterName: null, key.Description, key.HasDefaultValue, key.DefaultValue, serializerOptions, key.Options);
+            return JsonSerializer.SerializeToElement(schema, JsonContext.Default.JsonNode);
+        }
     }
 
     /// <summary>Gets the default JSON schema to be used by types or functions.</summary>
     internal static JsonElement DefaultJsonSchema { get; } = ParseJsonElement("{}"u8);
-
-    /// <summary>Validates the provided JSON schema document.</summary>
-    internal static void ValidateSchemaDocument(JsonElement document, [CallerArgumentExpression("document")] string? paramName = null)
-    {
-        if (document.ValueKind is not JsonValueKind.Object or JsonValueKind.False or JsonValueKind.True)
-        {
-            Throw.ArgumentException(paramName ?? "schema", "The schema document must be an object or a boolean value.");
-        }
-    }
 
 #if !NET9_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access",
@@ -411,6 +422,68 @@ public static partial class AIJsonUtilities
         return -1;
     }
 #endif
+
+    private static JsonElement GetOrAddSchema(JsonSerializerOptions serializerOptions, JsonSchemaCacheKey cacheKey, Func<JsonSchemaCacheKey, JsonSerializerOptions, JsonElement> schemaFactory)
+    {
+        ConcurrentDictionary<JsonSchemaCacheKey, JsonElement> innerCache = _schemaCache.GetOrCreateValue(serializerOptions);
+        if (innerCache.TryGetValue(cacheKey, out JsonElement schema))
+        {
+            return schema;
+        }
+
+        if (innerCache.Count >= InnerCacheSoftLimit)
+        {
+            return schemaFactory(cacheKey, serializerOptions);
+        }
+
+#if NET
+        return innerCache.GetOrAdd(cacheKey, schemaFactory, serializerOptions);
+#else
+        return innerCache.GetOrAdd(cacheKey, cacheKey => schemaFactory(cacheKey, serializerOptions));
+#endif
+    }
+
+    private readonly struct JsonSchemaCacheKey : IEquatable<JsonSchemaCacheKey>
+    {
+        public JsonSchemaCacheKey(MemberInfo? member, string? title, string? description, bool hasDefaultValue, object? defaultValue, AIJsonSchemaCreateOptions options)
+        {
+            Debug.Assert(member is Type or MethodBase or null, "Must be type or method");
+            Member = member;
+            Title = title;
+            Description = description;
+            HasDefaultValue = hasDefaultValue;
+            DefaultValue = defaultValue;
+            Options = options;
+        }
+
+        public MemberInfo? Member { get; }
+        public string? Title { get; }
+        public string? Description { get; }
+        public bool HasDefaultValue { get; }
+        public object? DefaultValue { get; }
+        public AIJsonSchemaCreateOptions Options { get; }
+
+        public override bool Equals(object? obj) => obj is JsonSchemaCacheKey key && Equals(key);
+        public bool Equals(JsonSchemaCacheKey other) =>
+            Member == other.Member &&
+            Title == other.Title &&
+            Description == other.Description &&
+            HasDefaultValue == other.HasDefaultValue &&
+            Equals(DefaultValue, other.DefaultValue) &&
+            Options.TransformSchemaNode == other.Options.TransformSchemaNode &&
+            Options.IncludeTypeInEnumSchemas == other.Options.IncludeTypeInEnumSchemas &&
+            Options.DisallowAdditionalProperties == other.Options.DisallowAdditionalProperties &&
+            Options.IncludeSchemaKeyword == other.Options.IncludeSchemaKeyword &&
+            Options.RequireAllProperties == other.Options.RequireAllProperties;
+
+        public override int GetHashCode() =>
+            (Member, Title, Description, HasDefaultValue, DefaultValue,
+             Options.TransformSchemaNode, Options.IncludeTypeInEnumSchemas,
+             Options.DisallowAdditionalProperties, Options.IncludeSchemaKeyword,
+             Options.RequireAllProperties)
+            .GetHashCode();
+    }
+
     private static JsonElement ParseJsonElement(ReadOnlySpan<byte> utf8Json)
     {
         Utf8JsonReader reader = new(utf8Json);

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.Utilities.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.Utilities.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.Shared.Diagnostics;
 
@@ -30,4 +31,25 @@ public static partial class AIFunctionFactory
     private static Regex InvalidNameCharsRegex() => _invalidNameCharsRegex;
     private static readonly Regex _invalidNameCharsRegex = new("[^0-9A-Za-z_]", RegexOptions.Compiled);
 #endif
+
+    /// <summary>Invokes the MethodInfo with the specified target object and arguments.</summary>
+    private static object? ReflectionInvoke(MethodInfo method, object? target, object?[]? arguments)
+    {
+#if NET
+        return method.Invoke(target, BindingFlags.DoNotWrapExceptions, binder: null, arguments, culture: null);
+#else
+        try
+        {
+            return method.Invoke(target, BindingFlags.Default, binder: null, arguments, culture: null);
+        }
+        catch (TargetInvocationException e) when (e.InnerException is not null)
+        {
+            // If we're targeting .NET Framework, such that BindingFlags.DoNotWrapExceptions
+            // is ignored, the original exception will be wrapped in a TargetInvocationException.
+            // Unwrap it and throw that original exception, maintaining its stack information.
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+            return null;
+        }
+#endif
+    }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.Utilities.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.Utilities.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Buffers;
+using System.IO;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.Shared.Diagnostics;
@@ -48,8 +51,87 @@ public static partial class AIFunctionFactory
             // is ignored, the original exception will be wrapped in a TargetInvocationException.
             // Unwrap it and throw that original exception, maintaining its stack information.
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(e.InnerException).Throw();
-            return null;
+            throw;
         }
 #endif
+    }
+
+    /// <summary>
+    /// Implements a simple write-only memory stream that uses pooled buffers.
+    /// </summary>
+    private sealed class PooledMemoryStream : Stream
+    {
+        private const int DefaultBufferSize = 4096;
+        private byte[] _buffer;
+        private int _position;
+
+        public PooledMemoryStream(int initialCapacity = DefaultBufferSize)
+        {
+            _buffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
+            _position = 0;
+        }
+
+        public ReadOnlySpan<byte> GetBuffer() => _buffer.AsSpan(0, _position);
+        public override bool CanWrite => true;
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override long Length => _position;
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            EnsureNotDisposed();
+            EnsureCapacity(_position + count);
+
+            Buffer.BlockCopy(buffer, offset, _buffer, _position, count);
+            _position += count;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_buffer is not null)
+            {
+                ArrayPool<byte>.Shared.Return(_buffer);
+                _buffer = null!;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void EnsureCapacity(int requiredCapacity)
+        {
+            if (requiredCapacity <= _buffer.Length)
+            {
+                return;
+            }
+
+            int newCapacity = Math.Max(requiredCapacity, _buffer.Length * 2);
+            byte[] newBuffer = ArrayPool<byte>.Shared.Rent(newCapacity);
+            Buffer.BlockCopy(_buffer, 0, newBuffer, 0, _position);
+
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = newBuffer;
+        }
+
+        private void EnsureNotDisposed()
+        {
+            if (_buffer is null)
+            {
+                Throw();
+                static void Throw() => throw new ObjectDisposedException(nameof(PooledMemoryStream));
+            }
+        }
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
@@ -179,12 +179,12 @@ public static partial class AIFunctionFactory
 
         public ReflectionAIFunctionDescriptor FunctionDescriptor { get; }
         public object? Target { get; }
+        public override IReadOnlyDictionary<string, object?> AdditionalProperties { get; }
         public override string Name => FunctionDescriptor.Name;
         public override string Description => FunctionDescriptor.Description;
         public override MethodInfo UnderlyingMethod => FunctionDescriptor.Method;
         public override JsonElement JsonSchema => FunctionDescriptor.JsonSchema;
         public override JsonSerializerOptions JsonSerializerOptions => FunctionDescriptor.JsonSerializerOptions;
-        public override IReadOnlyDictionary<string, object?> AdditionalProperties { get; }
         protected override async Task<object?> InvokeCoreAsync(
             IEnumerable<KeyValuePair<string, object?>>? arguments,
             CancellationToken cancellationToken)

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
@@ -441,7 +441,7 @@ public static partial class AIFunctionFactory
                     {
                         await ((Task)ThrowIfNullResult(taskObj)).ConfigureAwait(false);
                         object? result = ReflectionInvoke(taskResultGetter, taskObj, null);
-                        return await SerializeAsync(result, returnTypeInfo, cancellationToken).ConfigureAwait(false);
+                        return await SerializeResultAsync(result, returnTypeInfo, cancellationToken).ConfigureAwait(false);
                     };
                 }
 
@@ -456,16 +456,16 @@ public static partial class AIFunctionFactory
                         var task = (Task)ReflectionInvoke(valueTaskAsTask, ThrowIfNullResult(taskObj), null)!;
                         await task.ConfigureAwait(false);
                         object? result = ReflectionInvoke(asTaskResultGetter, task, null);
-                        return await SerializeAsync(result, returnTypeInfo, cancellationToken).ConfigureAwait(false);
+                        return await SerializeResultAsync(result, returnTypeInfo, cancellationToken).ConfigureAwait(false);
                     };
                 }
             }
 
             // For everything else, just serialize the result as-is.
             returnTypeInfo = serializerOptions.GetTypeInfo(returnType);
-            return (result, cancellationToken) => SerializeAsync(result, returnTypeInfo, cancellationToken);
+            return (result, cancellationToken) => SerializeResultAsync(result, returnTypeInfo, cancellationToken);
 
-            static async ValueTask<object?> SerializeAsync(object? result, JsonTypeInfo returnTypeInfo, CancellationToken cancellationToken)
+            static async ValueTask<object?> SerializeResultAsync(object? result, JsonTypeInfo returnTypeInfo, CancellationToken cancellationToken)
             {
                 if (returnTypeInfo.Kind is JsonTypeInfoKind.None)
                 {

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
@@ -42,7 +44,7 @@ public static partial class AIFunctionFactory
     {
         _ = Throw.IfNull(method);
 
-        return new ReflectionAIFunction(method.Method, method.Target, options ?? _defaultOptions);
+        return ReflectionAIFunction.Build(method.Method, method.Target, options ?? _defaultOptions);
     }
 
     /// <summary>Creates an <see cref="AIFunction"/> instance for a method, specified via a delegate.</summary>
@@ -68,12 +70,12 @@ public static partial class AIFunctionFactory
             ? _defaultOptions
             : new()
             {
-                SerializerOptions = serializerOptions ?? _defaultOptions.SerializerOptions,
                 Name = name,
-                Description = description
+                Description = description,
+                SerializerOptions = serializerOptions,
             };
 
-        return new ReflectionAIFunction(method.Method, method.Target, createOptions);
+        return ReflectionAIFunction.Build(method.Method, method.Target, createOptions);
     }
 
     /// <summary>
@@ -100,7 +102,7 @@ public static partial class AIFunctionFactory
     public static AIFunction Create(MethodInfo method, object? target, AIFunctionFactoryOptions? options)
     {
         _ = Throw.IfNull(method);
-        return new ReflectionAIFunction(method, target, options ?? _defaultOptions);
+        return ReflectionAIFunction.Build(method, target, options ?? _defaultOptions);
     }
 
     /// <summary>
@@ -129,44 +131,23 @@ public static partial class AIFunctionFactory
     {
         _ = Throw.IfNull(method);
 
-        AIFunctionFactoryOptions? createOptions = serializerOptions is null && name is null && description is null
+        AIFunctionFactoryOptions createOptions = serializerOptions is null && name is null && description is null
             ? _defaultOptions
             : new()
             {
-                SerializerOptions = serializerOptions ?? _defaultOptions.SerializerOptions,
                 Name = name,
-                Description = description
+                Description = description,
+                SerializerOptions = serializerOptions,
             };
 
-        return new ReflectionAIFunction(method, target, createOptions);
+        return ReflectionAIFunction.Build(method, target, createOptions);
     }
 
     private sealed class ReflectionAIFunction : AIFunction
     {
-        private readonly MethodInfo _method;
-        private readonly object? _target;
-        private readonly Func<IReadOnlyDictionary<string, object?>, AIFunctionContext?, object?>[] _parameterMarshallers;
-        private readonly Func<object?, ValueTask<object?>> _returnMarshaller;
-        private readonly JsonTypeInfo? _returnTypeInfo;
-        private readonly bool _needsAIFunctionContext;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ReflectionAIFunction"/> class for a method, specified via an <see cref="MethodInfo"/> instance
-        /// and an optional target object if the method is an instance method.
-        /// </summary>
-        /// <param name="method">The method to be represented via the created <see cref="AIFunction"/>.</param>
-        /// <param name="target">
-        /// The target object for the <paramref name="method"/> if it represents an instance method.
-        /// This should be <see langword="null"/> if and only if <paramref name="method"/> is a static method.
-        /// </param>
-        /// <param name="options">Function creation options.</param>
-        public ReflectionAIFunction(MethodInfo method, object? target, AIFunctionFactoryOptions options)
+        public static ReflectionAIFunction Build(MethodInfo method, object? target, AIFunctionFactoryOptions options)
         {
             _ = Throw.IfNull(method);
-            _ = Throw.IfNull(options);
-
-            JsonSerializerOptions serializerOptions = options.SerializerOptions ?? AIJsonUtilities.DefaultOptions;
-            serializerOptions.MakeReadOnly();
 
             if (method.ContainsGenericParameters)
             {
@@ -178,86 +159,37 @@ public static partial class AIFunctionFactory
                 Throw.ArgumentNullException(nameof(target), "Target must not be null for an instance method.");
             }
 
-            _method = method;
-            _target = target;
+            ReflectionAIFunctionDescriptor functionDescriptor = ReflectionAIFunctionDescriptor.GetOrCreate(method, options);
 
-            // Get the function name to use.
-            string? functionName = options.Name;
-            if (functionName is null)
+            if (target is null && options.AdditionalProperties is null)
             {
-                functionName = SanitizeMemberName(method.Name!);
-
-                const string AsyncSuffix = "Async";
-                if (IsAsyncMethod(method) &&
-                    functionName.EndsWith(AsyncSuffix, StringComparison.Ordinal) &&
-                    functionName.Length > AsyncSuffix.Length)
-                {
-                    functionName = functionName.Substring(0, functionName.Length - AsyncSuffix.Length);
-                }
-
-                static bool IsAsyncMethod(MethodInfo method)
-                {
-                    Type t = method.ReturnType;
-
-                    if (t == typeof(Task) || t == typeof(ValueTask))
-                    {
-                        return true;
-                    }
-
-                    if (t.IsGenericType)
-                    {
-                        t = t.GetGenericTypeDefinition();
-                        if (t == typeof(Task<>) || t == typeof(ValueTask<>) || t == typeof(IAsyncEnumerable<>))
-                        {
-                            return true;
-                        }
-                    }
-
-                    return false;
-                }
+                // We can use a cached value for static methods not specifying additional properties.
+                return functionDescriptor.CachedDefaultInstance ??= new(functionDescriptor, target, options);
             }
 
-            // Get marshaling delegates for parameters.
-            ParameterInfo[] parameters = method.GetParameters();
-            _parameterMarshallers = new Func<IReadOnlyDictionary<string, object?>, AIFunctionContext?, object?>[parameters.Length];
-            bool sawAIContextParameter = false;
-            for (int i = 0; i < parameters.Length; i++)
-            {
-                _parameterMarshallers[i] = GetParameterMarshaller(serializerOptions, parameters[i], ref sawAIContextParameter);
-            }
-
-            _needsAIFunctionContext = sawAIContextParameter;
-
-            // Get the return type and a marshaling func for the return value.
-            _returnMarshaller = GetReturnMarshaller(method, out Type returnType);
-            _returnTypeInfo = returnType != typeof(void) ? serializerOptions.GetTypeInfo(returnType) : null;
-
-            Name = functionName;
-            Description = options.Description ?? method.GetCustomAttribute<DescriptionAttribute>(inherit: true)?.Description ?? string.Empty;
-            UnderlyingMethod = method;
-            AdditionalProperties = options.AdditionalProperties ?? EmptyReadOnlyDictionary<string, object?>.Instance;
-            JsonSerializerOptions = serializerOptions;
-            JsonSchema = AIJsonUtilities.CreateFunctionJsonSchema(
-                method,
-                title: Name,
-                description: Description,
-                options.SerializerOptions,
-                options.JsonSchemaCreateOptions);
+            return new(functionDescriptor, target, options);
         }
 
-        public override string Name { get; }
-        public override string Description { get; }
-        public override MethodInfo? UnderlyingMethod { get; }
-        public override IReadOnlyDictionary<string, object?> AdditionalProperties { get; }
-        public override JsonSerializerOptions JsonSerializerOptions { get; }
-        public override JsonElement JsonSchema { get; }
+        private ReflectionAIFunction(ReflectionAIFunctionDescriptor functionDescriptor, object? target, AIFunctionFactoryOptions options)
+        {
+            FunctionDescriptor = functionDescriptor;
+            Target = target;
+            AdditionalProperties = options.AdditionalProperties ?? EmptyReadOnlyDictionary<string, object?>.Instance;
+        }
 
-        /// <inheritdoc />
+        public ReflectionAIFunctionDescriptor FunctionDescriptor { get; }
+        public object? Target { get; }
+        public override string Name => FunctionDescriptor.Name;
+        public override string Description => FunctionDescriptor.Description;
+        public override MethodInfo UnderlyingMethod => FunctionDescriptor.Method;
+        public override JsonElement JsonSchema => FunctionDescriptor.JsonSchema;
+        public override JsonSerializerOptions JsonSerializerOptions => FunctionDescriptor.JsonSerializerOptions;
+        public override IReadOnlyDictionary<string, object?> AdditionalProperties { get; }
         protected override async Task<object?> InvokeCoreAsync(
             IEnumerable<KeyValuePair<string, object?>>? arguments,
             CancellationToken cancellationToken)
         {
-            var paramMarshallers = _parameterMarshallers;
+            var paramMarshallers = FunctionDescriptor.ParameterMarshallers;
             object?[] args = paramMarshallers.Length != 0 ? new object?[paramMarshallers.Length] : [];
 
             IReadOnlyDictionary<string, object?> argDict =
@@ -269,7 +201,7 @@ public static partial class AIFunctionFactory
 #else
                     ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 #endif
-            AIFunctionContext? context = _needsAIFunctionContext ?
+            AIFunctionContext? context = FunctionDescriptor.RequiresAIFunctionContext ?
                 new() { CancellationToken = cancellationToken } :
                 null;
 
@@ -278,30 +210,111 @@ public static partial class AIFunctionFactory
                 args[i] = paramMarshallers[i](argDict, context);
             }
 
-            object? result = await _returnMarshaller(ReflectionInvoke(_method, _target, args)).ConfigureAwait(false);
+            return await FunctionDescriptor.ReturnParameterMarshaller(ReflectionInvoke(FunctionDescriptor.Method, Target, args), cancellationToken).ConfigureAwait(false);
+        }
+    }
 
-            switch (_returnTypeInfo)
+    /// <summary>
+    /// A descriptor for a .NET method-backed AIFunction that precomputes its marshalling delegates and JSON schema.
+    /// </summary>
+    private sealed class ReflectionAIFunctionDescriptor
+    {
+        private const int InnerCacheSoftLimit = 512;
+        private static readonly ConditionalWeakTable<JsonSerializerOptions, ConcurrentDictionary<DescriptorKey, ReflectionAIFunctionDescriptor>> _descriptorCache = new();
+
+        /// <summary>
+        /// Gets or creates a descriptors using the specified method and options.
+        /// </summary>
+        public static ReflectionAIFunctionDescriptor GetOrCreate(MethodInfo method, AIFunctionFactoryOptions options)
+        {
+            JsonSerializerOptions serializerOptions = options.SerializerOptions ?? AIJsonUtilities.DefaultOptions;
+            AIJsonSchemaCreateOptions schemaOptions = options.JsonSchemaCreateOptions ?? AIJsonSchemaCreateOptions.Default;
+            serializerOptions.MakeReadOnly();
+            ConcurrentDictionary<DescriptorKey, ReflectionAIFunctionDescriptor> innerCache = _descriptorCache.GetOrCreateValue(serializerOptions);
+
+            DescriptorKey key = new(method, options.Name, options.Description, schemaOptions);
+            if (innerCache.TryGetValue(key, out ReflectionAIFunctionDescriptor? descriptor))
             {
-                case null:
-                    Debug.Assert(
-                        UnderlyingMethod?.ReturnType == typeof(void) ||
-                        UnderlyingMethod?.ReturnType == typeof(Task) ||
-                        UnderlyingMethod?.ReturnType == typeof(ValueTask), "The return parameter should be void or non-generic task.");
+                return descriptor;
+            }
 
-                    return null;
+            descriptor = new(key, serializerOptions);
+            return innerCache.Count < InnerCacheSoftLimit
+                ? innerCache.GetOrAdd(key, descriptor)
+                : descriptor;
+        }
 
-                case { Kind: JsonTypeInfoKind.None }:
-                    // Special-case trivial contracts to avoid the more expensive general-purpose serialization path.
-                    return JsonSerializer.SerializeToElement(result, _returnTypeInfo);
+        private ReflectionAIFunctionDescriptor(DescriptorKey key, JsonSerializerOptions serializerOptions)
+        {
+            // Get marshaling delegates for parameters.
+            ParameterInfo[] parameters = key.Method.GetParameters();
+            ParameterMarshallers = new Func<IReadOnlyDictionary<string, object?>, AIFunctionContext?, object?>[parameters.Length];
+            bool foundAIFunctionContextParameter = false;
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                ParameterMarshallers[i] = GetParameterMarshaller(serializerOptions, parameters[i], ref foundAIFunctionContextParameter);
+            }
 
-                default:
+            // Get a marshaling delegate for the return value.
+            ReturnParameterMarshaller = GetReturnParameterMarshaller(key.Method, serializerOptions);
+
+            Method = key.Method;
+            Name = key.Name ?? GetFunctionName(key.Method);
+            Description = key.Description ?? key.Method.GetCustomAttribute<DescriptionAttribute>(inherit: true)?.Description ?? string.Empty;
+            RequiresAIFunctionContext = foundAIFunctionContextParameter;
+            JsonSerializerOptions = serializerOptions;
+            JsonSchema = AIJsonUtilities.CreateFunctionJsonSchema(
+                key.Method,
+                Name,
+                Description,
+                serializerOptions,
+                key.SchemaOptions);
+        }
+
+        public string Name { get; }
+        public string Description { get; }
+        public MethodInfo Method { get; }
+        public JsonSerializerOptions JsonSerializerOptions { get; }
+        public JsonElement JsonSchema { get; }
+        public Func<IReadOnlyDictionary<string, object?>, AIFunctionContext?, object?>[] ParameterMarshallers { get; }
+        public Func<object?, CancellationToken, ValueTask<object?>> ReturnParameterMarshaller { get; }
+        public bool RequiresAIFunctionContext { get; }
+        public ReflectionAIFunction? CachedDefaultInstance { get; set; }
+
+        private static string GetFunctionName(MethodInfo method)
+        {
+            // Get the function name to use.
+            string name = SanitizeMemberName(method.Name);
+
+            const string AsyncSuffix = "Async";
+            if (IsAsyncMethod(method) &&
+                name.EndsWith(AsyncSuffix, StringComparison.Ordinal) &&
+                name.Length > AsyncSuffix.Length)
+            {
+                name = name.Substring(0, name.Length - AsyncSuffix.Length);
+            }
+
+            return name;
+
+            static bool IsAsyncMethod(MethodInfo method)
+            {
+                Type t = method.ReturnType;
+
+                if (t == typeof(Task) || t == typeof(ValueTask))
                 {
-                    // Serialize asynchronously to support potential IAsyncEnumerable responses.
-                    using MemoryStream stream = new();
-                    await JsonSerializer.SerializeAsync(stream, result, _returnTypeInfo, cancellationToken).ConfigureAwait(false);
-                    Utf8JsonReader reader = new(stream.GetBuffer().AsSpan(0, (int)stream.Length));
-                    return JsonElement.ParseValue(ref reader);
+                    return true;
                 }
+
+                if (t.IsGenericType)
+                {
+                    t = t.GetGenericTypeDefinition();
+                    if (t == typeof(Task<>) || t == typeof(ValueTask<>) || t == typeof(IAsyncEnumerable<>))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
         }
 
@@ -311,7 +324,7 @@ public static partial class AIFunctionFactory
         private static Func<IReadOnlyDictionary<string, object?>, AIFunctionContext?, object?> GetParameterMarshaller(
             JsonSerializerOptions serializerOptions,
             ParameterInfo parameter,
-            ref bool sawAIFunctionContext)
+            ref bool foundAIFunctionContextParameter)
         {
             if (string.IsNullOrWhiteSpace(parameter.Name))
             {
@@ -321,12 +334,12 @@ public static partial class AIFunctionFactory
             // Special-case an AIFunctionContext parameter.
             if (parameter.ParameterType == typeof(AIFunctionContext))
             {
-                if (sawAIFunctionContext)
+                if (foundAIFunctionContextParameter)
                 {
                     Throw.ArgumentException(nameof(parameter), $"Only one {nameof(AIFunctionContext)} parameter is permitted.");
                 }
 
-                sawAIFunctionContext = true;
+                foundAIFunctionContextParameter = true;
 
                 return static (_, ctx) =>
                 {
@@ -386,16 +399,21 @@ public static partial class AIFunctionFactory
         /// <summary>
         /// Gets a delegate for handling the result value of a method, converting it into the <see cref="Task{FunctionResult}"/> to return from the invocation.
         /// </summary>
-        private static Func<object?, ValueTask<object?>> GetReturnMarshaller(MethodInfo method, out Type returnType)
+        private static Func<object?, CancellationToken, ValueTask<object?>> GetReturnParameterMarshaller(MethodInfo method, JsonSerializerOptions serializerOptions)
         {
-            // Handle each known return type for the method
-            returnType = method.ReturnType;
+            Type returnType = method.ReturnType;
+            JsonTypeInfo returnTypeInfo;
+
+            // Void
+            if (returnType == typeof(void))
+            {
+                return static (_, _) => default;
+            }
 
             // Task
             if (returnType == typeof(Task))
             {
-                returnType = typeof(void);
-                return async static result =>
+                return async static (result, _) =>
                 {
                     await ((Task)ThrowIfNullResult(result)).ConfigureAwait(false);
                     return null;
@@ -405,8 +423,7 @@ public static partial class AIFunctionFactory
             // ValueTask
             if (returnType == typeof(ValueTask))
             {
-                returnType = typeof(void);
-                return async static result =>
+                return async static (result, _) =>
                 {
                     await ((ValueTask)ThrowIfNullResult(result)).ConfigureAwait(false);
                     return null;
@@ -419,11 +436,12 @@ public static partial class AIFunctionFactory
                 if (returnType.GetGenericTypeDefinition() == typeof(Task<>))
                 {
                     MethodInfo taskResultGetter = GetMethodFromGenericMethodDefinition(returnType, _taskGetResult);
-                    returnType = taskResultGetter.ReturnType;
-                    return async result =>
+                    returnTypeInfo = serializerOptions.GetTypeInfo(taskResultGetter.ReturnType);
+                    return async (taskObj, cancellationToken) =>
                     {
-                        await ((Task)ThrowIfNullResult(result)).ConfigureAwait(false);
-                        return ReflectionInvoke(taskResultGetter, result, null);
+                        await ((Task)ThrowIfNullResult(taskObj)).ConfigureAwait(false);
+                        object? result = ReflectionInvoke(taskResultGetter, taskObj, null);
+                        return await SerializeAsync(result, returnTypeInfo, cancellationToken).ConfigureAwait(false);
                     };
                 }
 
@@ -432,42 +450,38 @@ public static partial class AIFunctionFactory
                 {
                     MethodInfo valueTaskAsTask = GetMethodFromGenericMethodDefinition(returnType, _valueTaskAsTask);
                     MethodInfo asTaskResultGetter = GetMethodFromGenericMethodDefinition(valueTaskAsTask.ReturnType, _taskGetResult);
-                    returnType = asTaskResultGetter.ReturnType;
-                    return async result =>
+                    returnTypeInfo = serializerOptions.GetTypeInfo(asTaskResultGetter.ReturnType);
+                    return async (taskObj, cancellationToken) =>
                     {
-                        var task = (Task)ReflectionInvoke(valueTaskAsTask, ThrowIfNullResult(result), null)!;
+                        var task = (Task)ReflectionInvoke(valueTaskAsTask, ThrowIfNullResult(taskObj), null)!;
                         await task.ConfigureAwait(false);
-                        return ReflectionInvoke(asTaskResultGetter, task, null);
+                        object? result = ReflectionInvoke(asTaskResultGetter, task, null);
+                        return await SerializeAsync(result, returnTypeInfo, cancellationToken).ConfigureAwait(false);
                     };
                 }
             }
 
-            // For everything else, just use the result as-is.
-            return result => new ValueTask<object?>(result);
+            // For everything else, just serialize the result as-is.
+            returnTypeInfo = serializerOptions.GetTypeInfo(returnType);
+            return (result, cancellationToken) => SerializeAsync(result, returnTypeInfo, cancellationToken);
+
+            static async ValueTask<object?> SerializeAsync(object? result, JsonTypeInfo returnTypeInfo, CancellationToken cancellationToken)
+            {
+                if (returnTypeInfo.Kind is JsonTypeInfoKind.None)
+                {
+                    // Special-case trivial contracts to avoid the more expensive general-purpose serialization path.
+                    return JsonSerializer.SerializeToElement(result, returnTypeInfo);
+                }
+
+                // Serialize asynchronously to support potential IAsyncEnumerable responses.
+                using MemoryStream stream = new();
+                await JsonSerializer.SerializeAsync(stream, result, returnTypeInfo, cancellationToken).ConfigureAwait(false);
+                Utf8JsonReader reader = new(stream.GetBuffer().AsSpan(0, (int)stream.Length));
+                return JsonElement.ParseValue(ref reader);
+            }
 
             // Throws an exception if a result is found to be null unexpectedly
             static object ThrowIfNullResult(object? result) => result ?? throw new InvalidOperationException("Function returned null unexpectedly.");
-        }
-
-        /// <summary>Invokes the MethodInfo with the specified target object and arguments.</summary>
-        private static object? ReflectionInvoke(MethodInfo method, object? target, object?[]? arguments)
-        {
-#if NET
-            return method.Invoke(target, BindingFlags.DoNotWrapExceptions, binder: null, arguments, culture: null);
-#else
-            try
-            {
-                return method.Invoke(target, BindingFlags.Default, binder: null, arguments, culture: null);
-            }
-            catch (TargetInvocationException e) when (e.InnerException is not null)
-            {
-                // If we're targeting .NET Framework, such that BindingFlags.DoNotWrapExceptions
-                // is ignored, the original exception will be wrapped in a TargetInvocationException.
-                // Unwrap it and throw that original exception, maintaining its stack information.
-                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(e.InnerException).Throw();
-                return null;
-            }
-#endif
         }
 
         private static readonly MethodInfo _taskGetResult = typeof(Task<>).GetProperty(nameof(Task<int>.Result), BindingFlags.Instance | BindingFlags.Public)!.GetMethod!;
@@ -485,5 +499,7 @@ public static partial class AIFunctionFactory
             return specializedType.GetMethods(All).First(m => m.MetadataToken == genericMethodDefinition.MetadataToken);
 #endif
         }
+
+        private record struct DescriptorKey(MethodInfo Method, string? Name, string? Description, AIJsonSchemaCreateOptions SchemaOptions);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
@@ -65,6 +65,53 @@ public static class AIJsonUtilitiesTests
     }
 
     [Fact]
+    public static void AIJsonSchemaCreateOptions_UsesStructuralEquality()
+    {
+        AssertEqual(new AIJsonSchemaCreateOptions(), new AIJsonSchemaCreateOptions());
+
+        foreach (PropertyInfo property in typeof(AIJsonSchemaCreateOptions).GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            AIJsonSchemaCreateOptions options1 = new AIJsonSchemaCreateOptions();
+            AIJsonSchemaCreateOptions options2 = new AIJsonSchemaCreateOptions();
+            switch (property.GetValue(AIJsonSchemaCreateOptions.Default))
+            {
+                case bool booleanFlag:
+                    property.SetValue(options1, !booleanFlag);
+                    property.SetValue(options2, !booleanFlag);
+                    break;
+
+                case null when property.PropertyType == typeof(Func<AIJsonSchemaCreateContext, JsonNode, JsonNode>):
+                    Func<AIJsonSchemaCreateContext, JsonNode, JsonNode> transformer = static (context, schema) => (JsonNode)true;
+                    property.SetValue(options1, transformer);
+                    property.SetValue(options2, transformer);
+                    break;
+
+                default:
+                    Assert.Fail($"Unexpected property type: {property.PropertyType}");
+                    break;
+            }
+
+            AssertEqual(options1, options2);
+            AssertNotEqual(AIJsonSchemaCreateOptions.Default, options1);
+        }
+
+        static void AssertEqual(AIJsonSchemaCreateOptions x, AIJsonSchemaCreateOptions y)
+        {
+            Assert.Equal(x.GetHashCode(), y.GetHashCode());
+            Assert.Equal(x, x);
+            Assert.Equal(y, y);
+            Assert.Equal(x, y);
+            Assert.Equal(y, x);
+        }
+
+        static void AssertNotEqual(AIJsonSchemaCreateOptions x, AIJsonSchemaCreateOptions y)
+        {
+            Assert.NotEqual(x, y);
+            Assert.NotEqual(y, x);
+        }
+    }
+
+    [Fact]
     public static void CreateJsonSchema_DefaultParameters_GeneratesExpectedJsonSchema()
     {
         JsonElement expected = JsonDocument.Parse("""


### PR DESCRIPTION
I spent a bit of time investigating the performance of `AIFunctionFactory.Create` where I discovered that schema generation is the most expensive factor by far is schema derivation. Even though the schema generation routines used to employ a caching mechanism in the past, this got removed during the recent refactorings since it no longer is necessary for leaf clients to resolve schemas on the fly.

This PR reinstates a different version of the caching mechanism for the purpose of speeding up `AIFunctionFactory.Create` when applied multiple times on the same delegate.

## Benchmarks

```C#
[MemoryDiagnoser]
public class Benchmark
{
    private static readonly Func<string, int, MyPoco?, MyPoco> _delegate = MyFunc;

    [Benchmark]
    public JsonElement CreateFunctionSchema() => AIJsonUtilities.CreateFunctionJsonSchema(_delegate.Method);

    [Benchmark]
    public JsonElement CreateFunctionSchema_CustomDescription() => AIJsonUtilities.CreateFunctionJsonSchema(_delegate.Method, description: "custom description");

    [Benchmark]
    public JsonElement CreateFunctionSchema_NewOptions() => AIJsonUtilities.CreateFunctionJsonSchema(_delegate.Method, serializerOptions: new(JsonSerializerOptions.Default));

    [Benchmark]
    public AIFunction CreateAIFunction() => AIFunctionFactory.Create(_delegate);

    [Benchmark]
    public AIFunction CreateAIFunction_CustomDescription() => AIFunctionFactory.Create(_delegate, description: "custom description");

    [Benchmark]
    public AIFunction CreateAIFunction_NewOptions() => AIFunctionFactory.Create(_delegate, serializerOptions: new(JsonSerializerOptions.Default));

    [Description("My awesome function")]
    public static MyPoco MyFunc([Description("Parameter 1")]string param1, int param2 = 42, MyPoco? other = null) => throw new NotImplementedException();

    public record MyPoco(int X, int Y);
}
```

### Main

| Method                                 | Mean     | Error     | StdDev    | Gen0   | Allocated |
|--------------------------------------- |---------:|----------:|----------:|-------:|----------:|
| CreateFunctionSchema                   | 6.345 us | 0.0848 us | 0.0708 us | 2.4109 |   9.95 KB |
| CreateFunctionSchema_CustomDescription | 6.041 us | 0.0357 us | 0.0298 us | 2.3499 |    9.7 KB |
| CreateFunctionSchema_NewOptions        | 6.438 us | 0.0260 us | 0.0230 us | 2.1973 |    9.1 KB |
| CreateAIFunction                       | 6.706 us | 0.0344 us | 0.0322 us | 2.5940 |  10.65 KB |
| CreateAIFunction_CustomDescription     | 6.298 us | 0.0393 us | 0.0368 us | 2.5330 |  10.45 KB |
| CreateAIFunction_CustomOptions         | 6.683 us | 0.0300 us | 0.0281 us | 2.3804 |   9.85 KB |


### PR

| Method                                 | Mean        | Error     | StdDev    | Gen0   | Allocated |
|--------------------------------------- |------------:|----------:|----------:|-------:|----------:|
| CreateFunctionSchema                   | 6,679.98 ns | 35.900 ns | 31.824 ns | 2.4109 |   10193 B |
| CreateFunctionSchema_CustomDescription | 6,126.56 ns | 43.308 ns | 38.391 ns | 2.3499 |    9929 B |
| CreateFunctionSchema_NewOptions        | 6,494.00 ns | 59.036 ns | 52.334 ns | 2.1973 |    9318 B |
| CreateAIFunction                       |    20.20 ns |  0.097 ns |  0.081 ns |      - |         - |
| CreateAIFunction_CustomDescription     |    28.19 ns |  0.182 ns |  0.171 ns | 0.0134 |      56 B |
| CreateAIFunction_NewOptions            | 7,309.19 ns | 72.739 ns | 64.481 ns | 2.5635 |   10854 B |



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5908)