### PR TITLE
Remove unnecessary compilations causing duplicate metric generators

### DIFF
--- a/src/Generators/Microsoft.Gen.MetadataExtractor/Microsoft.Gen.MetadataExtractor.csproj
+++ b/src/Generators/Microsoft.Gen.MetadataExtractor/Microsoft.Gen.MetadataExtractor.csproj
@@ -17,22 +17,34 @@
     <MinMutationScore>85</MinMutationScore>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\Shared\TypeDeclarationSyntaxReceiver.cs" LinkBase="Shared" />
-    <Compile Include="..\Shared\GeneratorUtilities.cs" LinkBase="Shared" />
+  <ItemGroup Label="Shared">
     <Compile Include="..\Shared\ClassDeclarationSyntaxReceiver.cs" LinkBase="Shared" />
-    <Compile Include="..\Shared\EmitterBase.cs" LinkBase="Shared" />
-    <Compile Include="..\Shared\ParserUtilities.cs" LinkBase="Shared" />
     <Compile Include="..\Shared\DiagDescriptorsBase.cs" LinkBase="Shared" />
+    <Compile Include="..\Shared\EmitterBase.cs" LinkBase="Shared" />
+    <Compile Include="..\Shared\GeneratorUtilities.cs" LinkBase="Shared" />
+    <Compile Include="..\Shared\ParserUtilities.cs" LinkBase="Shared" />
     <Compile Include="..\Shared\StringBuilderPool.cs" LinkBase="Shared" />
+    <Compile Include="..\Shared\TypeDeclarationSyntaxReceiver.cs" LinkBase="Shared" />
+  </ItemGroup>
+
+  <ItemGroup Label="Microsoft.Gen.ComplianceReports">
     <Compile Include="..\Microsoft.Gen.ComplianceReports\Model\*.cs" LinkBase="Microsoft.Gen.ComplianceReports" />
     <Compile Include="..\Microsoft.Gen.ComplianceReports\*.cs" LinkBase="Microsoft.Gen.ComplianceReports" />
-    <Compile Include="..\Microsoft.Gen.Metrics\Exceptions\*.cs" LinkBase="Microsoft.Gen.Metrics" />
+  </ItemGroup>
+
+  <ItemGroup Label="Microsoft.Gen.MetricsReports">
     <Compile Include="..\Microsoft.Gen.MetricsReports\*.cs" LinkBase="Microsoft.Gen.MetricsReports" />
+  </ItemGroup>
+
+  <ItemGroup Label="Microsoft.Gen.Metrics">
+    <Compile Include="..\Microsoft.Gen.Metrics\Exceptions\*.cs" LinkBase="Microsoft.Gen.Metrics" />
     <Compile Include="..\Microsoft.Gen.Metrics\Model\*.cs" LinkBase="Microsoft.Gen.Metrics" />
-    <Compile Include="..\Microsoft.Gen.Metrics\*.cs" LinkBase="Microsoft.Gen.Metrics" />
-    <Compile Include="..\Microsoft.Gen.Shared\*.cs" LinkBase="Microsoft.Gen.Metrics" />
-    <Compile Include="..\Microsoft.Gen.Shared\*.cs" LinkBase="Microsoft.Gen.Metrics" />
+    <Compile Include="..\Microsoft.Gen.Metrics\Parser.cs" LinkBase="Microsoft.Gen.Metrics" />
+    <Compile Include="..\Microsoft.Gen.Metrics\StrongTypeAttributeParameters.cs" LinkBase="Microsoft.Gen.Metrics" />
+    <Compile Include="..\Microsoft.Gen.Metrics\SymbolLoader.cs" LinkBase="Microsoft.Gen.Metrics" />
+    <Compile Include="..\Microsoft.Gen.Metrics\SymbolHolder.cs" LinkBase="Microsoft.Gen.Metrics" />
+    <Compile Include="..\Microsoft.Gen.Metrics\DiagDescriptors.cs" LinkBase="Microsoft.Gen.Metrics" />
+    <Compile Include="..\Microsoft.Gen.Metrics\Resources.Designer.cs" LinkBase="Microsoft.Gen.Metrics"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow up to #5894

This pull request includes changes to the `Microsoft.Gen.MetadataExtractor.csproj` file to specify only required dependencies in compile includes, preventing duplicate metric generators from being created.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5916)