### PR TITLE
Make MetadataExtractor & MetricsReports in Microsoft.Extensions.AuditReports create directories [Same as ComplianceReport]

### DIFF
--- a/src/Generators/Microsoft.Gen.MetadataExtractor/MetadataReportsGenerator.cs
+++ b/src/Generators/Microsoft.Gen.MetadataExtractor/MetadataReportsGenerator.cs
@@ -80,7 +80,7 @@ public sealed class MetadataReportsGenerator : ISourceGenerator
             // Report diagnostic:
             var diagnostic = new DiagnosticDescriptor(
                 DiagnosticIds.AuditReports.AUDREPGEN000,
-                "MetricsReports generator couldn't resolve output path for the report. It won't be generated.",
+                "MetadataReport generator couldn't resolve output path for the report. It won't be generated.",
                 "Both <MetadataReportOutputPath> and <OutputPath> MSBuild properties are not set. The report won't be generated.",
                 nameof(DiagnosticIds.AuditReports),
                 DiagnosticSeverity.Info,
@@ -105,6 +105,8 @@ public sealed class MetadataReportsGenerator : ISourceGenerator
             .Append((string.IsNullOrEmpty(metadataReport.metricReport) ? "[]" : metadataReport.metricReport) + " }");
 
 #pragma warning disable RS1035 // Do not use APIs banned for analyzers
+        _ = Directory.CreateDirectory(path);
+
         File.WriteAllText(Path.Combine(path, _fileName), reportStringBuilder.ToString(), Encoding.UTF8);
 #pragma warning restore RS1035 // Do not use APIs banned for analyzers
 

--- a/src/Generators/Microsoft.Gen.MetricsReports/MetricsReportsGenerator.cs
+++ b/src/Generators/Microsoft.Gen.MetricsReports/MetricsReportsGenerator.cs
@@ -81,6 +81,8 @@ public class MetricsReportsGenerator : ISourceGenerator
         // Suppressing until this issue is addressed in https://github.com/dotnet/extensions/issues/5390
 
 #pragma warning disable RS1035 // Do not use APIs banned for analyzers
+        _ = Directory.CreateDirectory(path);
+
         File.WriteAllText(Path.Combine(path, _fileName), report, Encoding.UTF8);
 #pragma warning restore RS1035 // Do not use APIs banned for analyzers
     }

--- a/test/Generators/Microsoft.Gen.MetadataExtractor/Unit/GeneratorTests.cs
+++ b/test/Generators/Microsoft.Gen.MetadataExtractor/Unit/GeneratorTests.cs
@@ -176,7 +176,7 @@ public class GeneratorTests(ITestOutputHelper output)
             var options = new Dictionary<string, string>
             {
                 ["build_property.projectdir"] = projectDir,
-                ["build_property.MetadataReportOutputPath"] = fullReportPath
+                ["build_property.outputpath"] = outputPath
             };
 
             var diags = await RunGenerator(await File.ReadAllTextAsync(inputFile), options);


### PR DESCRIPTION
When working with `Microsoft.Extensions.AuditReports` package, I noticed some inconsistency while creating reports on the file system. 

`ComplianceReports` Creates directories if they were not found, while `MetadataExtractor` & `MetricsReports` Do not.
This pull request fix this inconsistency and enabling them all to create directory when needed.

Furthermore , it fixes some string naming bug & tweak unit test case `Should_UseProjectDir_WhenOutputPathIsRelative` in the `Microsoft.Gen.MetadataExtractor.Unit.Tests` namespace.

this Asp.net repository holds a sample https://github.com/IbrahimMNada/MetaDataExtractorTesting
of **Microsoft.Extensions.AuditReports** working with locally packed packages for testing

and here is a screen shot of the unit tests : 

<img width="927" alt="image" src="https://github.com/user-attachments/assets/0e2fd134-387a-4bec-9177-83338c1e0008" />


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5919)