### PR TITLE
Upgrade `slngen` to avoid crash with newer versions of VS

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.visualstudio.slngen.tool": {
-      "version": "12.0.10",
+      "version": "12.0.11",
       "commands": [
         "slngen"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.visualstudio.slngen.tool": {
-      "version": "11.1.0",
+      "version": "12.0.10",
       "commands": [
         "slngen"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.visualstudio.slngen.tool": {
-      "version": "12.0.11",
+      "version": "12.0.13",
       "commands": [
         "slngen"
       ]


### PR DESCRIPTION
See https://github.com/dotnet/msbuild/issues/11394.

Upgrading `slngen` avoids this crash. Without it, VS usage is broken for newer versions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5932)