### PR TITLE
Use structured output for RTC evaluator

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/Microsoft.Extensions.AI.Evaluation.Quality.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/Microsoft.Extensions.AI.Evaluation.Quality.csproj
@@ -11,7 +11,8 @@
     <Stage>preview</Stage>
     <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
     <EnablePackageValidation>false</EnablePackageValidation>
-    <MinCodeCoverage>7</MinCodeCoverage>
+    <!-- The evaluators in this assembly need AI and the tests that cover them are not being run in CI at the moment. -->
+    <MinCodeCoverage>0</MinCodeCoverage>
     <MinMutationScore>0</MinMutationScore>
   </PropertyGroup>
 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/Microsoft.Extensions.AI.Evaluation.Quality.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/Microsoft.Extensions.AI.Evaluation.Quality.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Extensions.AI.Evaluation\Microsoft.Extensions.AI.Evaluation.csproj" />
+    <ProjectReference Include="..\Microsoft.Extensions.AI\Microsoft.Extensions.AI.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/Utilities/JsonOutputFixer.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/Utilities/JsonOutputFixer.cs
@@ -68,9 +68,6 @@ internal static class JsonOutputFixer
             new ChatMessage(ChatRole.User, fixPrompt)
         };
 
-        // TASK: Explore supplying the target json type as a type parameter to the IChatClient.GetResponseAsync<T>()
-        // extension method. Tracked by https://github.com/dotnet/extensions/issues/5888.
-
         ChatResponse response =
             await chatConfig.ChatClient.GetResponseAsync(
                 messages,

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/AdditionalContextTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/AdditionalContextTests.cs
@@ -1,0 +1,144 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.Extensions.AI.Evaluation.Quality;
+using Microsoft.Extensions.AI.Evaluation.Reporting;
+using Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
+using Microsoft.TestUtilities;
+using Xunit;
+
+namespace Microsoft.Extensions.AI.Evaluation.Integration.Tests;
+
+public class AdditionalContextTests
+{
+    private static readonly ChatOptions _chatOptions;
+    private static readonly ReportingConfiguration? _reportingConfiguration;
+
+    static AdditionalContextTests()
+    {
+        _chatOptions =
+            new ChatOptions
+            {
+                Temperature = 0.0f,
+                ResponseFormat = ChatResponseFormat.Text
+            };
+
+        if (Settings.Current.Configured)
+        {
+            IEvaluator groundednessEvaluator = new GroundednessEvaluator();
+            IEvaluator equivalenceEvaluator = new EquivalenceEvaluator();
+
+            _reportingConfiguration =
+                DiskBasedReportingConfiguration.Create(
+                    storageRootPath: Settings.Current.StorageRootPath,
+                    evaluators: [groundednessEvaluator, equivalenceEvaluator],
+                    chatConfiguration: Setup.CreateChatConfiguration(),
+                    executionName: Constants.Version);
+        }
+    }
+
+    [ConditionalFact]
+    public async Task AdditionalContextIsNotPassed()
+    {
+        SkipIfNotConfigured();
+
+        await using ScenarioRun scenarioRun =
+                await _reportingConfiguration.CreateScenarioRunAsync(
+                    scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(AdditionalContextTests)}.{nameof(AdditionalContextIsNotPassed)}");
+
+        IChatClient chatClient = scenarioRun.ChatConfiguration!.ChatClient;
+
+        var messages = new List<ChatMessage>();
+        string prompt = @"How far in miles is the planet Venus from the Earth at its closest and furthest points?";
+        ChatMessage promptMessage = prompt.ToUserMessage();
+        messages.Add(promptMessage);
+
+        ChatResponse response = await chatClient.GetResponseAsync(messages, _chatOptions);
+        ChatMessage responseMessage = response.Message;
+        Assert.NotNull(responseMessage.Text);
+
+        EvaluationResult result =
+            await scenarioRun.EvaluateAsync(
+                promptMessage,
+                responseMessage);
+
+        using var _ = new AssertionScope();
+
+        result.ContainsDiagnostics(d => d.Severity is EvaluationDiagnosticSeverity.Error).Should().BeTrue();
+
+        result.TryGet(EquivalenceEvaluator.EquivalenceMetricName, out NumericMetric? _).Should().BeFalse();
+
+        NumericMetric groundedness = result.Get<NumericMetric>(GroundednessEvaluator.GroundednessMetricName);
+        groundedness.Value.Should().BeGreaterThanOrEqualTo(4);
+    }
+
+    [ConditionalFact]
+    public async Task AdditionalContextIsPassed()
+    {
+        SkipIfNotConfigured();
+
+        await using ScenarioRun scenarioRun =
+                await _reportingConfiguration.CreateScenarioRunAsync(
+                    scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(AdditionalContextTests)}.{nameof(AdditionalContextIsPassed)}");
+
+        IChatClient chatClient = scenarioRun.ChatConfiguration!.ChatClient;
+
+        var messages = new List<ChatMessage>();
+        string prompt = @"How far in miles is the planet Venus from the Earth at its closest and furthest points?";
+        ChatMessage promptMessage = prompt.ToUserMessage();
+        messages.Add(promptMessage);
+
+        ChatResponse response = await chatClient.GetResponseAsync(messages, _chatOptions);
+        ChatMessage responseMessage = response.Message;
+        Assert.NotNull(responseMessage.Text);
+
+        var baselineResponseForEquivalenceEvaluator =
+            new EquivalenceEvaluatorContext(
+                """
+                The distance between Earth and Venus varies significantly due to the elliptical orbits of both planets
+                around the Sun. At their closest approach, known as inferior conjunction, Venus can be about 23.6
+                million miles away from Earth. At their furthest point, when Venus is on the opposite side of the Sun
+                from Earth, known as superior conjunction, the distance can be about 162 million miles. These distances
+                can vary slightly due to the specific orbital positions of the planets at any given time.
+                """);
+
+        var groundingContextForGroundednessEvaluator =
+            new GroundednessEvaluatorContext(
+                """
+                Distance between Venus and Earth at inferior conjunction: About 23.6 million miles.
+                Distance between Venus and Earth at superior conjunction: About 162 million miles.
+                """);
+
+        EvaluationResult result =
+            await scenarioRun.EvaluateAsync(
+                promptMessage,
+                responseMessage,
+                additionalContext: [baselineResponseForEquivalenceEvaluator, groundingContextForGroundednessEvaluator]);
+
+        using var _ = new AssertionScope();
+
+        result.ContainsDiagnostics(d => d.Severity >= EvaluationDiagnosticSeverity.Warning).Should().BeFalse();
+
+        NumericMetric equivalence = result.Get<NumericMetric>(EquivalenceEvaluator.EquivalenceMetricName);
+        equivalence.Value.Should().BeGreaterThanOrEqualTo(3);
+
+        NumericMetric groundedness = result.Get<NumericMetric>(GroundednessEvaluator.GroundednessMetricName);
+        groundedness.Value.Should().BeGreaterThanOrEqualTo(3);
+    }
+
+    [MemberNotNull(nameof(_reportingConfiguration))]
+    private static void SkipIfNotConfigured()
+    {
+        if (!Settings.Current.Configured)
+        {
+            throw new SkipTestException("Test is not configured");
+        }
+
+        Assert.NotNull(_reportingConfiguration);
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/EndToEndTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/EndToEndTests.cs
@@ -17,12 +17,12 @@ using Xunit;
 
 namespace Microsoft.Extensions.AI.Evaluation.Integration.Tests;
 
-public class EvaluatorTests
+public class EndToEndTests
 {
     private static readonly ChatOptions _chatOptions;
     private static readonly ReportingConfiguration? _reportingConfiguration;
 
-    static EvaluatorTests()
+    static EndToEndTests()
     {
         _chatOptions =
             new ChatOptions
@@ -60,14 +60,14 @@ public class EvaluatorTests
         {
             await using ScenarioRun scenarioRun =
                 await _reportingConfiguration.CreateScenarioRunAsync(
-                    scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(EvaluatorTests)}.{nameof(DistanceBetweenEarthAndMoon)}",
+                    scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(EndToEndTests)}.{nameof(DistanceBetweenEarthAndMoon)}",
                     iterationName: i.ToString());
 
             IChatClient chatClient = scenarioRun.ChatConfiguration!.ChatClient;
 
             var messages = new List<ChatMessage>();
             string prompt = "How far in miles is the moon from the earth at its closest and furthest points?";
-            ChatMessage promptMessage = new ChatMessage(ChatRole.User, prompt);
+            ChatMessage promptMessage = prompt.ToUserMessage();
             messages.Add(promptMessage);
 
             ChatResponse response = await chatClient.GetResponseAsync(messages, _chatOptions);
@@ -111,7 +111,7 @@ public class EvaluatorTests
         {
             await using ScenarioRun scenarioRun =
                 await _reportingConfiguration.CreateScenarioRunAsync(
-                    scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(EvaluatorTests)}.{nameof(DistanceBetweenEarthAndVenus)}",
+                    scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(EndToEndTests)}.{nameof(DistanceBetweenEarthAndVenus)}",
                     iterationName: i.ToString());
 
             IChatClient chatClient = scenarioRun.ChatConfiguration!.ChatClient;

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/EvaluatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/EvaluatorTests.cs
@@ -31,13 +31,13 @@ public class EvaluatorTests
                 ResponseFormat = ChatResponseFormat.Text
             };
 
-        var options = new RelevanceTruthAndCompletenessEvaluatorOptions(includeReasoning: true);
-        IEvaluator rtcEvaluator = new RelevanceTruthAndCompletenessEvaluator(options);
-        IEvaluator coherenceEvaluator = new CoherenceEvaluator();
-        IEvaluator fluencyEvaluator = new FluencyEvaluator();
-
         if (Settings.Current.Configured)
         {
+            var options = new RelevanceTruthAndCompletenessEvaluatorOptions(includeReasoning: true);
+            IEvaluator rtcEvaluator = new RelevanceTruthAndCompletenessEvaluator(options);
+            IEvaluator coherenceEvaluator = new CoherenceEvaluator();
+            IEvaluator fluencyEvaluator = new FluencyEvaluator();
+
             _reportingConfiguration =
                 DiskBasedReportingConfiguration.Create(
                     storageRootPath: Settings.Current.StorageRootPath,

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/RelevanceTruthAndCompletenessEvaluatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/RelevanceTruthAndCompletenessEvaluatorTests.cs
@@ -1,0 +1,132 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI.Evaluation.Quality;
+using Microsoft.Extensions.AI.Evaluation.Reporting;
+using Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
+using Microsoft.TestUtilities;
+using Xunit;
+
+namespace Microsoft.Extensions.AI.Evaluation.Integration.Tests;
+
+public class RelevanceTruthAndCompletenessEvaluatorTests
+{
+    private static readonly ChatOptions _chatOptions;
+    private static readonly ReportingConfiguration? _reportingConfigurationWithoutReasoning;
+    private static readonly ReportingConfiguration? _reportingConfigurationWithReasoning;
+
+    static RelevanceTruthAndCompletenessEvaluatorTests()
+    {
+        _chatOptions =
+            new ChatOptions
+            {
+                Temperature = 0.0f,
+                ResponseFormat = ChatResponseFormat.Text
+            };
+
+        if (Settings.Current.Configured)
+        {
+            IEvaluator rtcEvaluatorWithoutReasoning = new RelevanceTruthAndCompletenessEvaluator();
+
+            _reportingConfigurationWithoutReasoning =
+                DiskBasedReportingConfiguration.Create(
+                    storageRootPath: Settings.Current.StorageRootPath,
+                    evaluators: [rtcEvaluatorWithoutReasoning],
+                    chatConfiguration: Setup.CreateChatConfiguration(),
+                    executionName: Constants.Version);
+
+            var options = new RelevanceTruthAndCompletenessEvaluatorOptions(includeReasoning: true);
+            IEvaluator rtcEvaluatorWithReasoning = new RelevanceTruthAndCompletenessEvaluator(options);
+
+            _reportingConfigurationWithReasoning =
+                DiskBasedReportingConfiguration.Create(
+                    storageRootPath: Settings.Current.StorageRootPath,
+                    evaluators: [rtcEvaluatorWithReasoning],
+                    chatConfiguration: Setup.CreateChatConfiguration(),
+                    executionName: Constants.Version);
+        }
+    }
+
+    [ConditionalFact]
+    public async Task WithoutReasoning()
+    {
+        SkipIfNotConfigured();
+
+        await using ScenarioRun scenarioRun =
+            await _reportingConfigurationWithoutReasoning.CreateScenarioRunAsync(
+                scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(RelevanceTruthAndCompletenessEvaluatorTests)}.{nameof(WithoutReasoning)}");
+
+        IChatClient chatClient = scenarioRun.ChatConfiguration!.ChatClient;
+
+        var messages = new List<ChatMessage>();
+        string prompt = @"What is the molecular formula of ammonia?";
+        ChatMessage promptMessage = prompt.ToUserMessage();
+        messages.Add(promptMessage);
+
+        ChatResponse response = await chatClient.GetResponseAsync(messages, _chatOptions);
+        ChatMessage responseMessage = response.Message;
+        Assert.NotNull(responseMessage.Text);
+
+        EvaluationResult result = await scenarioRun.EvaluateAsync(promptMessage, responseMessage);
+
+        Assert.False(result.ContainsDiagnostics(d => d.Severity >= EvaluationDiagnosticSeverity.Warning));
+
+        NumericMetric relevance = result.Get<NumericMetric>(RelevanceTruthAndCompletenessEvaluator.RelevanceMetricName);
+        NumericMetric truth = result.Get<NumericMetric>(RelevanceTruthAndCompletenessEvaluator.TruthMetricName);
+        NumericMetric completeness = result.Get<NumericMetric>(RelevanceTruthAndCompletenessEvaluator.CompletenessMetricName);
+
+        Assert.True(relevance.Value >= 4, string.Format("Relevance - Reasoning: {0}", relevance.Diagnostics.Single().Message));
+        Assert.True(truth.Value >= 4, string.Format("Truth - Reasoning: {0}", truth.Diagnostics.Single().Message));
+        Assert.True(completeness.Value >= 4, string.Format("Completeness - Reasoning: {0}", completeness.Diagnostics.Single().Message));
+    }
+
+    [ConditionalFact]
+    public async Task WithReasoning()
+    {
+        SkipIfNotConfigured();
+
+        await using ScenarioRun scenarioRun =
+            await _reportingConfigurationWithReasoning.CreateScenarioRunAsync(
+                scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(RelevanceTruthAndCompletenessEvaluatorTests)}.{nameof(WithReasoning)}");
+
+        IChatClient chatClient = scenarioRun.ChatConfiguration!.ChatClient;
+
+        var messages = new List<ChatMessage>();
+        string prompt = @"What is the molecular formula of glucose?";
+        ChatMessage promptMessage = prompt.ToUserMessage();
+        messages.Add(promptMessage);
+
+        ChatResponse response = await chatClient.GetResponseAsync(messages, _chatOptions);
+        ChatMessage responseMessage = response.Message;
+        Assert.NotNull(responseMessage.Text);
+
+        EvaluationResult result = await scenarioRun.EvaluateAsync(promptMessage, responseMessage);
+
+        Assert.False(result.ContainsDiagnostics(d => d.Severity >= EvaluationDiagnosticSeverity.Warning));
+
+        NumericMetric relevance = result.Get<NumericMetric>(RelevanceTruthAndCompletenessEvaluator.RelevanceMetricName);
+        NumericMetric truth = result.Get<NumericMetric>(RelevanceTruthAndCompletenessEvaluator.TruthMetricName);
+        NumericMetric completeness = result.Get<NumericMetric>(RelevanceTruthAndCompletenessEvaluator.CompletenessMetricName);
+
+        Assert.True(relevance.Value >= 4, string.Format("Relevance - Reasoning: {0}", relevance.Diagnostics.Single().Message));
+        Assert.True(truth.Value >= 4, string.Format("Truth - Reasoning: {0}", truth.Diagnostics.Single().Message));
+        Assert.True(completeness.Value >= 4, string.Format("Completeness - Reasoning: {0}", completeness.Diagnostics.Single().Message));
+    }
+
+    [MemberNotNull(nameof(_reportingConfigurationWithReasoning))]
+    [MemberNotNull(nameof(_reportingConfigurationWithoutReasoning))]
+    private static void SkipIfNotConfigured()
+    {
+        if (!Settings.Current.Configured)
+        {
+            throw new SkipTestException("Test is not configured");
+        }
+
+        Assert.NotNull(_reportingConfigurationWithReasoning);
+        Assert.NotNull(_reportingConfigurationWithoutReasoning);
+    }
+}


### PR DESCRIPTION
Also change the base types so that derived types have more control over whether or not structured output should be used.

Also adds some tests to ensure that the RTC works well both when the returned JSON contains reasoning elements as well as if it does not.

Addresses #5888
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5945)