### PR TITLE
Fix RTC evaluator

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/Microsoft.Extensions.AI.Evaluation.Quality.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/Microsoft.Extensions.AI.Evaluation.Quality.csproj
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Extensions.AI.Evaluation\Microsoft.Extensions.AI.Evaluation.csproj" />
-    <ProjectReference Include="..\Microsoft.Extensions.AI\Microsoft.Extensions.AI.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/Utilities/JsonOutputFixer.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/Utilities/JsonOutputFixer.cs
@@ -74,6 +74,6 @@ internal static class JsonOutputFixer
                 chatOptions,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        return response.Message.Text;
+        return response.Message.Text?.Trim();
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/Directory.Build.targets
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/Directory.Build.targets
@@ -68,7 +68,7 @@ internal static class Constants
   </Target>
 
   <!-- Generate a version file that can be accessed from the script that builds the Azure DevOps Extension pacakge. -->
-  <Target Name="StampVSIXPackageVersion" BeforeTargets="CoreCompile">
+  <Target Name="StampVSIXPackageVersion" BeforeTargets="DispatchToInnerBuilds">
     <PropertyGroup>
       <_VSIXPackageVersionFile>$(MSBuildThisFileDirectory)\TypeScript\azure-devops-report\VSIXPackageVersion.json</_VSIXPackageVersionFile>
 

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/AdditionalContextTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/AdditionalContextTests.cs
@@ -101,7 +101,7 @@ public class AdditionalContextTests
             new EquivalenceEvaluatorContext(
                 """
                 The distance between Earth and Venus varies significantly due to the elliptical orbits of both planets
-                around the Sun. At their closest approach, known as inferior conjunction, Venus can be about 23.6
+                around the Sun. At their closest approach, known as inferior conjunction, Venus can be about 24.8
                 million miles away from Earth. At their furthest point, when Venus is on the opposite side of the Sun
                 from Earth, known as superior conjunction, the distance can be about 162 million miles. These distances
                 can vary slightly due to the specific orbital positions of the planets at any given time.
@@ -110,7 +110,7 @@ public class AdditionalContextTests
         var groundingContextForGroundednessEvaluator =
             new GroundednessEvaluatorContext(
                 """
-                Distance between Venus and Earth at inferior conjunction: About 23.6 million miles.
+                Distance between Venus and Earth at inferior conjunction: About 24.8 million miles.
                 Distance between Venus and Earth at superior conjunction: About 162 million miles.
                 """);
 

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/RelevanceTruthAndCompletenessEvaluatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/RelevanceTruthAndCompletenessEvaluatorTests.cs
@@ -73,15 +73,15 @@ public class RelevanceTruthAndCompletenessEvaluatorTests
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(promptMessage, responseMessage);
 
-        Assert.False(result.ContainsDiagnostics(d => d.Severity >= EvaluationDiagnosticSeverity.Warning));
+        Assert.False(result.ContainsDiagnostics(d => d.Severity >= EvaluationDiagnosticSeverity.Informational));
 
         NumericMetric relevance = result.Get<NumericMetric>(RelevanceTruthAndCompletenessEvaluator.RelevanceMetricName);
         NumericMetric truth = result.Get<NumericMetric>(RelevanceTruthAndCompletenessEvaluator.TruthMetricName);
         NumericMetric completeness = result.Get<NumericMetric>(RelevanceTruthAndCompletenessEvaluator.CompletenessMetricName);
 
-        Assert.True(relevance.Value >= 4, string.Format("Relevance - Reasoning: {0}", relevance.Diagnostics.Single().Message));
-        Assert.True(truth.Value >= 4, string.Format("Truth - Reasoning: {0}", truth.Diagnostics.Single().Message));
-        Assert.True(completeness.Value >= 4, string.Format("Completeness - Reasoning: {0}", completeness.Diagnostics.Single().Message));
+        Assert.True(relevance.Value >= 4);
+        Assert.True(truth.Value >= 4);
+        Assert.True(completeness.Value >= 4);
     }
 
     [ConditionalFact]
@@ -106,6 +106,7 @@ public class RelevanceTruthAndCompletenessEvaluatorTests
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(promptMessage, responseMessage);
 
+        Assert.True(result.ContainsDiagnostics(d => d.Severity == EvaluationDiagnosticSeverity.Informational));
         Assert.False(result.ContainsDiagnostics(d => d.Severity >= EvaluationDiagnosticSeverity.Warning));
 
         NumericMetric relevance = result.Get<NumericMetric>(RelevanceTruthAndCompletenessEvaluator.RelevanceMetricName);


### PR DESCRIPTION
Turns out that the JSON schema supplied as part of structured output was conflicting with the instructions in the prompt. This was causing the evaluator to include the `reasoning` property in the JSON response even when `includeReasoning` was set to `false` (in which case the included prompt does not contain any instructions / examples related to reasoning).

For now, the fix is to refrain from using structured output for this prompt. In the future we can look to improve the prompt and / or split out the types used when `includeReasoning` is `true` v/s `false` so that a matching schema is passed down to `IChatClient.GetResponseAsync<T>` in each case.

Also includes a change to ensure that the VSIX target runs only once for the overall build (as opposed to once per target framework).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5971)