### PR TITLE
Move Azure DevOps extension build until after the transport package build

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -51,11 +51,6 @@ steps:
             $(_OfficialBuildIdArgs)
     displayName: Build
 
-  - ${{ if eq(parameters.isWindows, 'true') }}:
-    - pwsh: |
-          $(Build.SourcesDirectory)/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/azure-devops-report/build.ps1 -OutputPath $(Build.Arcade.VSIXOutputPath)
-      displayName: Build Azure DevOps plugin
-
   - ${{ if ne(parameters.skipTests, 'true') }}:
     - script: $(Build.SourcesDirectory)/.dotnet/dotnet dotnet-coverage collect
               --settings $(Build.SourcesDirectory)/eng/CodeCoverage.config
@@ -109,6 +104,10 @@ steps:
               /bl:${{ parameters.repoLogPath }}/transport.binlog
               $(_OfficialBuildIdArgs)
       displayName: Build and publish docs transport package
+
+    - pwsh: |
+          $(Build.SourcesDirectory)/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/azure-devops-report/build.ps1 -OutputPath $(Build.Arcade.VSIXOutputPath)
+      displayName: Build Azure DevOps plugin
 
     - script: ${{ parameters.buildScript }}
               -pack


### PR DESCRIPTION
This is to fix this break on main branch builds. Apparently, the vsix package is being included in the transport package build and causing a failure there. Moving the step after that should still work properly and keep it out of the way.

```
##[error].packages\microsoft.dotnet.arcade.sdk\9.0.0-beta.25111.5\tools\Publish.proj(219,5): error : (NETCORE_ENGINEERING_TELEMETRY=Publish) Item to sign 'pbw.microsoft-extensions-ai-evaluation-report-9.3.0.2512511.vsix' was not found in the artifacts
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5973)