### PR TITLE
HybridCache: enforce L2 expiration 

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.TagInvalidation.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.TagInvalidation.cs
@@ -194,6 +194,10 @@ internal partial class DefaultHybridCache
         static async ValueTask<bool> AwaitedAsync(Task<long> pending, long timestamp) => timestamp <= await pending.ConfigureAwait(false);
     }
 
+    internal static TimeSpan TicksToTimeSpan(long ticks) => TimeSpan.FromTicks(ticks);
+
+    internal long CurrentTimestamp() => _clock.GetUtcNow().UtcTicks;
+
     internal void DebugInvalidateTag(string tag, Task<long> pending)
     {
         if (tag == TagSet.WildcardTag)
@@ -205,8 +209,6 @@ internal partial class DefaultHybridCache
             _tagInvalidationTimes[tag] = pending;
         }
     }
-
-    internal long CurrentTimestamp() => _clock.GetUtcNow().UtcTicks;
 
     internal void PrefetchTags(TagSet tags)
     {

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/ExpirationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/ExpirationTests.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Internal;
+using Xunit.Abstractions;
+using static Microsoft.Extensions.Caching.Hybrid.Tests.DistributedCacheTests;
+using static Microsoft.Extensions.Caching.Hybrid.Tests.L2Tests;
+
+namespace Microsoft.Extensions.Caching.Hybrid.Tests;
+public class ExpirationTests(ITestOutputHelper log)
+{
+    [Fact]
+    public async Task ExpirationRespected()
+    {
+        // we want set up separate cache instances with a shared L2 to show relative expiration
+        // being respected
+        var clock = new FakeTime();
+        using var l1 = new MemoryCache(new MemoryCacheOptions { Clock = clock });
+        var l2 = new LoggingCache(log, new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions { Clock = clock })));
+
+        Guid guid0;
+        string key = nameof(ExpirationRespected);
+        Func<CancellationToken, ValueTask<Guid>> callback = static _ => new(Guid.NewGuid());
+        HybridCacheEntryOptions options = new() { Expiration = TimeSpan.FromMinutes(2), LocalCacheExpiration = TimeSpan.FromMinutes(1) };
+
+        ServiceCollection services = new();
+        services.AddSingleton<ISystemClock>(clock);
+        services.AddSingleton<TimeProvider>(clock);
+        services.AddSingleton<IMemoryCache>(l1);
+        services.AddSingleton<IDistributedCache>(l2);
+        services.AddHybridCache();
+        using var provider = services.BuildServiceProvider();
+        var cache = provider.GetRequiredService<HybridCache>();
+
+        guid0 = await cache.GetOrCreateAsync(key, callback, options);
+
+        // should be fine immediately
+        Assert.Equal(guid0, await cache.GetOrCreateAsync(key, callback, options));
+
+        clock.Add(TimeSpan.FromSeconds(45)); // should still be fine from L1 (L1 has 1 minute expiration)
+        Assert.Equal(guid0, await cache.GetOrCreateAsync(key, callback, options));
+
+        clock.Add(TimeSpan.FromSeconds(45)); // should still be fine from L2 (L1 now expired, but fetches from L2 and detects 0:30 remaining, which limits L1 to 0:30)
+        Assert.Equal(guid0, await cache.GetOrCreateAsync(key, callback, options));
+
+        clock.Add(TimeSpan.FromSeconds(45)); // should now be expired
+        Assert.NotEqual(guid0, await cache.GetOrCreateAsync(key, callback, options));
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/L2Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/L2Tests.cs
@@ -258,14 +258,14 @@ public class L2Tests(ITestOutputHelper log) : IClassFixture<TestEventListener>
         void IDistributedCache.Set(string key, byte[] value, DistributedCacheEntryOptions options)
         {
             Interlocked.Increment(ref ProtectedOpCount);
-            Log.WriteLine($"Set (byte[]): {key}");
+            Log.WriteLine($"Set (byte[]): {key} (expiry: {options.AbsoluteExpirationRelativeToNow})");
             Tail.Set(key, value, options);
         }
 
         Task IDistributedCache.SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token)
         {
             Interlocked.Increment(ref ProtectedOpCount);
-            Log.WriteLine($"SetAsync (byte[]): {key}");
+            Log.WriteLine($"SetAsync (byte[]): {key} (expiry: {options.AbsoluteExpirationRelativeToNow})");
             return Tail.SetAsync(key, value, options, token);
         }
     }

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/ServiceConstructionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/ServiceConstructionTests.cs
@@ -224,19 +224,19 @@ public class ServiceConstructionTests : IClassFixture<TestEventListener>
 
     // local expiration; per-item wins; expiration bleeds into local expiration (but not the other way around)
     [InlineData(false, null, null, null, true, 42, null, null, 42, 42)]
-    [InlineData(false, null, null, null, true, 42, 43, null, 42, 43)]
+    [InlineData(false, null, null, null, true, 43, 42, null, 43, 42)]
     [InlineData(false, null, null, null, true, null, 43, null, null, 43)]
 
     // global expiration; expiration bleeds into local expiration (but not the other way around)
     [InlineData(true, 42, null, null, false, null, null, null, 42, 42)]
-    [InlineData(true, 42, 43, null, false, null, null, null, 42, 43)]
+    [InlineData(true, 43, 42, null, false, null, null, null, 43, 42)]
     [InlineData(true, null, 43, null, false, null, null, null, null, 43)]
 
     // both expirations specified; expiration bleeds into local expiration (but not the other way around)
-    [InlineData(true, 42, 43, null, true, null, null, null, 42, 43)]
-    [InlineData(true, 42, 43, null, true, 44, null, null, 44, 44)]
-    [InlineData(true, 42, 43, null, true, 44, 45, null, 44, 45)]
-    [InlineData(true, 42, 43, null, true, null, 45, null, 42, 45)]
+    [InlineData(true, 43, 42, null, true, null, null, null, 43, 42)]
+    [InlineData(true, 43, 42, null, true, 44, null, null, 44, 44)]
+    [InlineData(true, 43, 42, null, true, 45, 44, null, 45, 44)]
+    [InlineData(true, 43, 42, null, true, null, 45, null, 43, 45)]
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters",
         Justification = "Most pragmatic and readable way of expressing multiple scenarios.")]
@@ -293,7 +293,7 @@ public class ServiceConstructionTests : IClassFixture<TestEventListener>
         }
     }
 
-    private class CustomMemoryDistributedCache : MemoryDistributedCache
+    internal class CustomMemoryDistributedCache : MemoryDistributedCache
     {
         public CustomMemoryDistributedCache(IOptions<MemoryDistributedCacheOptions> options)
             : base(options)


### PR DESCRIPTION
fix #5824

L1 expiration was being allowed to exceed the original L2 expiration, via either:

1. intentional (mis)configuration with larger L1 expiration
2. loading from L2 into L1 *inside* the local expiration window, which should trim to L2, but was just applying L1 window

Docs explicitly say "not exceeding the remaining overall cache lifetime", so we should not allow this in either case
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5987)