### PR TITLE
Improve debugger display for ChatMessage

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatMessage.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatMessage.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Microsoft.Shared.Diagnostics;
@@ -9,6 +10,7 @@ using Microsoft.Shared.Diagnostics;
 namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a chat message used by an <see cref="IChatClient" />.</summary>
+[DebuggerDisplay("[{Role}] {ContentForDebuggerDisplay}{EllipsesForDebuggerDisplay,nq}")]
 public class ChatMessage
 {
     private IList<AIContent>? _contents;
@@ -111,4 +113,12 @@ public class ChatMessage
 
     /// <inheritdoc/>
     public override string ToString() => Contents.ConcatText();
+
+    /// <summary>Gets a <see cref="AIContent"/> object to display in the debugger display.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private AIContent? ContentForDebuggerDisplay => _contents is { Count: > 0 } ? _contents[0] : null;
+
+    /// <summary>Gets an indication for the debugger display of whether there's more content.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string EllipsesForDebuggerDisplay => _contents is { Count: > 1 } ? ", ..." : string.Empty;
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatRole.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatRole.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -14,6 +15,7 @@ namespace Microsoft.Extensions.AI;
 /// Describes the intended purpose of a message within a chat interaction.
 /// </summary>
 [JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
 public readonly struct ChatRole : IEquatable<ChatRole>
 {
     /// <summary>Gets the role that instructs or sets the behavior of the system.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataContent.cs
@@ -203,7 +203,9 @@ public class DataContent : AIContent
             const int MaxLength = 80;
 
             string uri = Uri;
-            return uri.Length <= MaxLength ? uri : $"{uri.Substring(0, MaxLength)}...";
+            return uri.Length <= MaxLength ?
+                $"Data = {uri}" :
+                $"Data = {uri.Substring(0, MaxLength)}...";
         }
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/FunctionCallContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/FunctionCallContent.cs
@@ -102,13 +102,16 @@ public sealed class FunctionCallContent : AIContent
     {
         get
         {
-            string display = CallId is not null ?
-                $"CallId = {CallId}, " :
-                string.Empty;
+            string display = "FunctionCall = ";
+
+            if (CallId is not null)
+            {
+                display += $"{CallId}, ";
+            }
 
             display += Arguments is not null ?
-                $"Call = {Name}({string.Join(", ", Arguments)})" :
-                $"Call = {Name}()";
+                $"{Name}({string.Join(", ", Arguments)})" :
+                $"{Name}()";
 
             return display;
         }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/FunctionResultContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/FunctionResultContent.cs
@@ -67,13 +67,16 @@ public sealed class FunctionResultContent : AIContent
     {
         get
         {
-            string display = CallId is not null ?
-                $"CallId = {CallId}, " :
-                string.Empty;
+            string display = "FunctionResult = ";
+
+            if (CallId is not null)
+            {
+                display += $"{CallId}, ";
+            }
 
             display += Exception is not null ?
-                $"Error = {Exception.Message}" :
-                $"Result = {Result?.ToString() ?? string.Empty}";
+                $"{Exception.GetType().Name}(\"{Exception.Message}\")" :
+                $"{Result?.ToString() ?? "(null)"}";
 
             return display;
         }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/TextContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/TextContent.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.AI;
@@ -8,6 +9,7 @@ namespace Microsoft.Extensions.AI;
 /// <summary>
 /// Represents text content in a chat.
 /// </summary>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
 public sealed class TextContent : AIContent
 {
     private string? _text;
@@ -33,4 +35,7 @@ public sealed class TextContent : AIContent
 
     /// <inheritdoc/>
     public override string ToString() => Text;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => $"Text = \"{Text}\"";
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/UsageContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/UsageContent.cs
@@ -39,5 +39,5 @@ public class UsageContent : AIContent
 
     /// <summary>Gets a string representing this instance to display in the debugger.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private string DebuggerDisplay => _details.DebuggerDisplay;
+    private string DebuggerDisplay => $"Usage = {_details.DebuggerDisplay}";
 }


### PR DESCRIPTION
Before:
<img width="341" alt="before" src="https://github.com/user-attachments/assets/d959b447-8ab4-4968-a2b1-8ba664544858" />

After:
<img width="669" alt="after" src="https://github.com/user-attachments/assets/ca8e733d-2636-476a-be0a-b38389836b4b" />

We can subsequently change exactly how it's implemented and what's displayed, maybe JSON serializing the AIContent instead of doing something custom for each type. But it's much easier to debug with this than with what was there before.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5988)