### PR TITLE
Fix chat template content generation build flakiness

### DIFF
--- a/src/ProjectTemplates/GenerateTemplateContent/GenerateTemplateContent.csproj
+++ b/src/ProjectTemplates/GenerateTemplateContent/GenerateTemplateContent.csproj
@@ -1,7 +1,10 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$(MSBuildThisFileDirectory)..\GeneratedContent.props" />
 
   <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+
     <!-- Used for incremental builds. When versions or dependencies of templates change, this file is updated and causes a re-build. -->
     <_GeneratedContentPropertiesHashFile>$(IntermediateOutputPath)$(MSBuildProjectName).content.g.cache</_GeneratedContentPropertiesHashFile>
   </PropertyGroup>
@@ -38,7 +41,7 @@
   -->
   <Target Name="_GenerateContent"
           DependsOnTargets="_ComputeGeneratedContentPropertiesHash"
-          BeforeTargets="CoreCompile"
+          BeforeTargets="PrepareForBuild"
           Inputs="$(MSBuildAllProjects);$(_GeneratedContentPropertiesHashFile);@(GeneratedContent)"
           Outputs="@(GeneratedContent->'%(OutputPath)')">
 
@@ -51,4 +54,5 @@
       <Output TaskParameter="ResolvedOutputPath" ItemName="Content" />
     </GenerateFileFromTemplate>
   </Target>
+
 </Project>

--- a/src/ProjectTemplates/GeneratedContent.props
+++ b/src/ProjectTemplates/GeneratedContent.props
@@ -1,0 +1,34 @@
+<Project>
+
+  <PropertyGroup>
+    <_MicrosoftExtensionsAIVersion>9.3.0-preview.1.25114.11</_MicrosoftExtensionsAIVersion>
+
+    <!-- Specify package version variables used in template content. -->
+    <GeneratedContentProperties>
+      $(GeneratedContentProperties);
+      OllamaSharpVersion=$(OllamaSharpVersion);
+      OpenAIVersion=$(OpenAIVersion);
+      AzureAIProjectsVersion=$(AzureAIProjectsVersion);
+      AzureAIOpenAIVersion=$(AzureAIOpenAIVersion);
+      AzureIdentityVersion=$(AzureIdentityVersion);
+      MicrosoftEntityFrameworkCoreSqliteVersion=$(MicrosoftEntityFrameworkCoreSqliteVersion);
+      MicrosoftExtensionsAIVersion=$(_MicrosoftExtensionsAIVersion);
+      MicrosoftSemanticKernelCoreVersion=$(MicrosoftSemanticKernelCoreVersion);
+      PdfPigVersion=$(PdfPigVersion);
+      SystemLinqAsyncVersion=$(SystemLinqAsyncVersion);
+      AzureSearchDocumentsVersion=$(AzureSearchDocumentsVersion);
+      MicrosoftSemanticKernelConnectorsAzureAISearchVersion=$(MicrosoftSemanticKernelConnectorsAzureAISearchVersion);
+    </GeneratedContentProperties>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <_ChatWithCustomDataWebContentRoot>$(MSBuildThisFileDirectory)Microsoft.Extensions.AI.Templates\src\ChatWithCustomData\ChatWithCustomData.Web\</_ChatWithCustomDataWebContentRoot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <GeneratedContent
+      Include="$(_ChatWithCustomDataWebContentRoot)ChatWithCustomData.Web.csproj.in"
+      OutputPath="$(_ChatWithCustomDataWebContentRoot)ChatWithCustomData.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/Microsoft.Extensions.AI.Templates.csproj
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/Microsoft.Extensions.AI.Templates.csproj
@@ -22,31 +22,15 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <_MicrosoftExtensionsAIVersion>9.3.0-preview.1.25114.11</_MicrosoftExtensionsAIVersion>
-
-    <!-- Specify package version variables used in template content. -->
-    <GeneratedContentProperties>
-      $(GeneratedContentProperties);
-      OllamaSharpVersion=$(OllamaSharpVersion);
-      OpenAIVersion=$(OpenAIVersion);
-      AzureAIProjectsVersion=$(AzureAIProjectsVersion);
-      AzureAIOpenAIVersion=$(AzureAIOpenAIVersion);
-      AzureIdentityVersion=$(AzureIdentityVersion);
-      MicrosoftEntityFrameworkCoreSqliteVersion=$(MicrosoftEntityFrameworkCoreSqliteVersion);
-      MicrosoftExtensionsAIVersion=$(_MicrosoftExtensionsAIVersion);
-      MicrosoftSemanticKernelCoreVersion=$(MicrosoftSemanticKernelCoreVersion);
-      PdfPigVersion=$(PdfPigVersion);
-      SystemLinqAsyncVersion=$(SystemLinqAsyncVersion);
-      AzureSearchDocumentsVersion=$(AzureSearchDocumentsVersion);
-      MicrosoftSemanticKernelConnectorsAzureAISearchVersion=$(MicrosoftSemanticKernelConnectorsAzureAISearchVersion);
-    </GeneratedContentProperties>
-  </PropertyGroup>
-
+  <!--
+    Reference the GenerateTemplateContent project so that template content gets generated prior
+    to building this project.
+  -->
   <ItemGroup>
-    <GeneratedContent
-      Include="src\ChatWithCustomData\ChatWithCustomData.Web\ChatWithCustomData.Web.csproj.in"
-      OutputPath="src\ChatWithCustomData\ChatWithCustomData.Web\ChatWithCustomData.Web.csproj" />
+    <ProjectReference
+      Include="..\GenerateTemplateContent\GenerateTemplateContent.csproj"
+      ReferenceOutputAssembly="false"
+      PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since the `Microsoft.Extensions.AI.Templates` project is multi-targeted, the task to generate template content was running multiple times (sometimes in parallel), so the following error was happening in the `GenerateTemplateContent` task:

```text
System.IO.IOException: The process cannot access the file '<repo-root>\src\ProjectTemplates\Microsoft.Extensions.AI.Templates\src\ChatWithCustomData\ChatWithCustomData.Web\ChatWithCustomData.Web.csproj' because it is being used by another process.
```

This PR fixes the issue by moving template content generation into a separate project that only targets netstandard2.0 and is referenced by `Microsoft.Extensions.AI.Templates`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5990)