### PR TITLE
AI Template Preview 1 - ID cleanup & link to survey

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/.template.config/template.json
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": [ "Common", "AI", "Web" ],
-  "identity": "Microsoft.Extensions.AI.Templates.Chat.CSharp",
+  "identity": "Microsoft.Extensions.AI.Templates.WebChat.CSharp",
   "name": "AI Chat Web App",
   "description": "A project template for creating an AI chat application, which uses retrieval-augmented generation (RAG) to chat with your own data.",
   "shortName": "aichatweb",

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor
@@ -1,13 +1,13 @@
 <div class="surveyContainer">
-    <span class="tool-icon" aria-hidden="true">
+    <div class="tool-icon" aria-hidden="true">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125" />
         </svg>
-    </span>
+    </div>
 
-    <span>
+    <div>
         How well is this template working for you? Please take our
         <a target="_blank" href="https://aka.ms/dotnet-chat-template-survey">brief survey</a>
         and tell us what you think.
-    </span>
+    </div>
 </div>

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor
@@ -1,4 +1,4 @@
-<div class="surveyContainer" role="alert">
+<div class="surveyContainer">
     <span class="tool-icon" aria-hidden="true">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125" />
@@ -6,14 +6,8 @@
     </span>
 
     <span>
-        <strong>@Title</strong>
-        Please take our
+        How well is this template working for you? Please take our
         <a target="_blank" href="https://aka.ms/dotnet-chat-template-survey">brief survey</a>
         and tell us what you think.
     </span>
 </div>
-
-@code {
-    [Parameter]
-    public string Title { get; set; } = "";
-}

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor
@@ -14,7 +14,6 @@
 </div>
 
 @code {
-    // Demonstrates how a parent component can supply parameters
     [Parameter]
     public string Title { get; set; } = "";
 }

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor
@@ -1,0 +1,20 @@
+<div class="surveyContainer" role="alert">
+    <span class="tool-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125" />
+        </svg>
+    </span>
+
+    <span>
+        <strong>@Title</strong>
+        Please take our
+        <a target="_blank" href="https://aka.ms/dotnet-chat-template-survey">brief survey</a>
+        and tell us what you think.
+    </span>
+</div>
+
+@code {
+    // Demonstrates how a parent component can supply parameters
+    [Parameter]
+    public string Title { get; set; } = "";
+}

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor.css
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor.css
@@ -1,12 +1,11 @@
 ﻿.surveyContainer {
-    align-items: center;
     display: flex;
+    align-items: center;
+    justify-content: center;
     font-size: 0.9em;
-    margin-left: auto;
-    margin-right: auto;
-    margin-top: 0.75rem;
+    margin: 0.5rem auto -0.7rem auto;
     max-width: 1024px;
-    padding: 0.5rem;
+    color: #444;
 }
 
     .surveyContainer a {

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor.css
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor.css
@@ -1,7 +1,7 @@
 ﻿.surveyContainer {
     align-items: center;
-    background-color: rgb(254 249 195);
     display: flex;
+    font-size: 0.9em;
     margin-left: auto;
     margin-right: auto;
     margin-top: 0.75rem;

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor.css
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor.css
@@ -1,0 +1,21 @@
+﻿.surveyContainer {
+    align-items: center;
+    background-color: rgb(254 249 195);
+    display: flex;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 0.75rem;
+    max-width: 1024px;
+    padding: 0.5rem;
+}
+
+    .surveyContainer a {
+        text-decoration: underline;
+    }
+
+    .surveyContainer .tool-icon {
+        margin-top: 0.25rem;
+        margin-right: 0.25rem;
+        width: 1.25rem;
+        height: 1.25rem;
+    }

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor.css
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor.css
@@ -1,7 +1,7 @@
 ﻿.surveyContainer {
     display: flex;
-    align-items: center;
     justify-content: center;
+    gap: 0.5rem;
     font-size: 0.9em;
     margin: 0.5rem auto -0.7rem auto;
     max-width: 1024px;
@@ -13,8 +13,8 @@
     }
 
     .surveyContainer .tool-icon {
-        margin-top: 0.25rem;
-        margin-right: 0.25rem;
+        margin-top: 0.15rem;
         width: 1.25rem;
         height: 1.25rem;
+        flex-shrink: 0;
     }

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/Chat.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/Chat.razor
@@ -11,7 +11,8 @@
 
 <ChatMessageList Messages="@messages" InProgressMessage="@currentResponseMessage">
     <NoMessagesContent>
-        <div>To get started, try asking about these example documents. You can replace these with your own data and remove or replace this message.</div>
+        <div>To get started, try asking about these example documents.</div>
+        <div>You can replace these with your own data and remove or replace this message.</div>
         <ChatCitation File="Example_Emergency_Survival_Kit.pdf"/>
         <ChatCitation File="Example_GPS_Watch.pdf"/>
     </NoMessagesContent>
@@ -20,7 +21,7 @@
 <div class="chat-container">
     <ChatSuggestions OnSelected="@AddUserMessageAsync" @ref="@chatSuggestions" />
     <ChatInput OnSend="@AddUserMessageAsync" @ref="@chatInput" />
-    <SurveyPrompt Title="How well is this template working for you?" />
+    <SurveyPrompt />
 </div>
 
 @code {

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/Chat.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/Chat.razor
@@ -11,8 +11,7 @@
 
 <ChatMessageList Messages="@messages" InProgressMessage="@currentResponseMessage">
     <NoMessagesContent>
-        <div>To get started, try asking about these example documents.</div>
-        <div>You can replace these with your own data and remove or replace this message.</div>
+        <div>To get started, try asking about these example documents. You can replace these with your own data and replace this message.</div>
         <ChatCitation File="Example_Emergency_Survival_Kit.pdf"/>
         <ChatCitation File="Example_GPS_Watch.pdf"/>
     </NoMessagesContent>
@@ -21,7 +20,7 @@
 <div class="chat-container">
     <ChatSuggestions OnSelected="@AddUserMessageAsync" @ref="@chatSuggestions" />
     <ChatInput OnSend="@AddUserMessageAsync" @ref="@chatInput" />
-    <SurveyPrompt />
+    <SurveyPrompt /> @* Remove this line to eliminate the template survey message *@
 </div>
 
 @code {

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/Chat.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/Chat.razor
@@ -20,6 +20,7 @@
 <div class="chat-container">
     <ChatSuggestions OnSelected="@AddUserMessageAsync" @ref="@chatSuggestions" />
     <ChatInput OnSend="@AddUserMessageAsync" @ref="@chatInput" />
+    <SurveyPrompt Title="How well is this template working for you?" />
 </div>
 
 @code {

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/ChatHeader.razor.css
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/ChatHeader.razor.css
@@ -1,5 +1,4 @@
 .chat-header-container {
-    position: sticky; 
     top: 0; 
     padding: 1.5rem; 
 }
@@ -12,4 +11,10 @@
     width: 1.25rem;
     height: 1.25rem;
     color: rgb(55, 65, 81);
+}
+
+@media (min-width: 768px) {
+    .chat-header-container {
+        position: sticky;
+    }
 }

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/ChatHeader.razor.css
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/ChatHeader.razor.css
@@ -7,6 +7,11 @@
     margin-bottom: 1.5rem; 
 }
 
+h1 {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .new-chat-icon {
     width: 1.25rem;
     height: 1.25rem;

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/ChatMessageList.razor.css
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Pages/Chat/ChatMessageList.razor.css
@@ -13,7 +13,7 @@
     text-align: center;
     font-size: 1.25rem;
     color: #999;
-    margin-top: 10vh;
+    margin-top: calc(40vh - 18rem);
 }
 
 chat-messages > ::deep div:last-of-type {


### PR DESCRIPTION
A couple random items that came from discussions today, about final updates before we publish a preview 1 of the AI template.
* Changed the template ID to reflect this is a webChat template, and leave us open to future chat templates
* Added a survey prompt with an aka.ms link for a feedback survey (the link goes nowhere for now).

![image](https://github.com/user-attachments/assets/f67041f1-88f4-4fe9-8bf0-eafff2da8910)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5994)