### PR TITLE
Add a link to the Brief Survey from the template's README

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/Components/Layout/SurveyPrompt.razor
@@ -6,7 +6,7 @@
     </div>
 
     <div>
-        How well is this template working for you? Please take our
+        How well is this template working for you? Please take a
         <a target="_blank" href="https://aka.ms/dotnet-chat-template-survey">brief survey</a>
         and tell us what you think.
     </div>

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/README.md
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/README.md
@@ -1,6 +1,6 @@
 # AI Chat with Custom Data
 
-This project is an AI chat application that demonstrates how to chat with custom data using an AI language model. Please note that this template is currently in an early preview stage. If you have feedback, please let us know!
+This project is an AI chat application that demonstrates how to chat with custom data using an AI language model. Please note that this template is currently in an early preview stage. If you have feedback, please take our [brief survey](https://aka.ms/dotnet-chat-template-survey).
 
 >[!NOTE]
 > Before running this project you need to configure the API keys or endpoints for the providers you have chosen. See below for details specific to your choices.

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/README.md
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web/README.md
@@ -1,6 +1,6 @@
 # AI Chat with Custom Data
 
-This project is an AI chat application that demonstrates how to chat with custom data using an AI language model. Please note that this template is currently in an early preview stage. If you have feedback, please take our [brief survey](https://aka.ms/dotnet-chat-template-survey).
+This project is an AI chat application that demonstrates how to chat with custom data using an AI language model. Please note that this template is currently in an early preview stage. If you have feedback, please take a [brief survey](https://aka.ms/dotnet-chat-template-survey).
 
 >[!NOTE]
 > Before running this project you need to configure the API keys or endpoints for the providers you have chosen. See below for details specific to your choices.


### PR DESCRIPTION
I was tempted to also add a link to https://github.com/dotnet/extensions/issues, but decided against it so that we can funnel customers through the survey link. If we do want to direct folks to file issues, I considered creating an issue template but also decided against that since that issue template would only be needed for a short time but the link to it would be baked into the product.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6015)