### PR TITLE
Fix various build failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,6 +112,14 @@ variables:
     - name: _Sign
       value: true
 
+  # Enable source index only for main branch builds
+  - ${{ if and(ne(variables['runAsPublic'], 'true'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+    - name: enableSourceIndex
+      value: true
+  - ${{ else }}:
+    - name: enableSourceIndex
+      value: false
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -145,7 +153,7 @@ extends:
         parameters:
           enableMicrobuild: true
           enableTelemetry: true
-          enableSourceIndex: true
+          enableSourceIndex: ${{ variables['enableSourceIndex'] }}
           runAsPublic: ${{ variables['runAsPublic'] }}
           # Publish build logs
           enablePublishBuildArtifacts: true

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -95,15 +95,14 @@ steps:
             artifactName: "$(Agent.JobName)_CodeCoverageResults"
 
   - ${{ if eq(parameters.isWindows, 'true') }}:
+    # Publishing will happen in a subsequent step
     - script: ${{ parameters.buildScript }}
               -projects $(Build.SourcesDirectory)/src/Packages/Microsoft.Internal.Extensions.DotNetApiDocs.Transport/Microsoft.Internal.Extensions.DotNetApiDocs.Transport.proj
-              -restore -build
               -pack
-              -publish $(_PublishArgs)
               -configuration ${{ parameters.buildConfig }}
               /bl:${{ parameters.repoLogPath }}/transport.binlog
               $(_OfficialBuildIdArgs)
-      displayName: Build and publish docs transport package
+      displayName: Pack docs transport package
 
     - pwsh: |
           $(Build.SourcesDirectory)/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/azure-devops-report/build.ps1 -OutputPath $(Build.Arcade.VSIXOutputPath)


### PR DESCRIPTION
Address various build failures observed in the internal CI for the dev branch (e.g., https://dev.azure.com/dnceng/internal/_build/results?buildId=2655494&view=results).

* Restrict sourceindex only to internal/main
* Remove duplicate restore/build/publish calls

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6039)