### PR TITLE
Upgrade workflows to issue-labeler v1.0.1

### DIFF
--- a/.github/workflows/labeler-build-predictor.yml
+++ b/.github/workflows/labeler-build-predictor.yml
@@ -12,6 +12,6 @@ jobs:
   build-predictor:
     permissions:
       actions: write
-    uses: dotnet/issue-labeler/.github/workflows/build-predictor.yml@3fe21fbd027653d2263d259333b154d33c157572 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/build-predictor.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
     with:
       rebuild: ${{ inputs.rebuild }}

--- a/.github/workflows/labeler-cache-retention.yml
+++ b/.github/workflows/labeler-cache-retention.yml
@@ -10,4 +10,4 @@ jobs:
   cache-retention:
     # Do not run the workflow on forks outside the 'dotnet' org
     if: ${{ github.repository_owner == 'dotnet' }}
-    uses: dotnet/issue-labeler/.github/workflows/cache-retention.yml@3fe21fbd027653d2263d259333b154d33c157572 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/cache-retention.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ github.repository_owner == 'dotnet' && (inputs.issue_numbers || github.event.issue.number) }}
     permissions:
       issues: write
-    uses: dotnet/issue-labeler/.github/workflows/predict-issues.yml@3fe21fbd027653d2263d259333b154d33c157572 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/predict-issues.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
     with:
       model_cache_key: ${{ inputs.model_cache_key }}
       issue_numbers: ${{ inputs.issue_numbers || github.event.issue.number }}

--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -35,7 +35,7 @@ jobs:
     if: ${{ github.repository_owner == 'dotnet' && (inputs.pull_numbers || github.event.number) }}
     permissions:
       pull-requests: write
-    uses: dotnet/issue-labeler/.github/workflows/predict-pulls.yml@3fe21fbd027653d2263d259333b154d33c157572 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/predict-pulls.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
     with:
       model_cache_key: ${{ inputs.model_cache_key }}
       pull_numbers: ${{ inputs.pull_numbers || github.event.number }}

--- a/.github/workflows/labeler-promote.yml
+++ b/.github/workflows/labeler-promote.yml
@@ -29,14 +29,14 @@ permissions:
 jobs:
   labeler-promote-issues:
     if: ${{ inputs.promote_issues }}
-    uses: dotnet/issue-labeler/.github/workflows/promote-issues.yml@3fe21fbd027653d2263d259333b154d33c157572 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/promote-issues.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
     with:
       model_cache_key: ${{ inputs.model_cache_key }}
       backup_cache_key: ${{ inputs.backup_cache_key }}
 
   labeler-promote-pulls:
     if: ${{ inputs.promote_pulls }}
-    uses: dotnet/issue-labeler/.github/workflows/promote-pulls.yml@3fe21fbd027653d2263d259333b154d33c157572 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/promote-pulls.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
     with:
       model_cache_key: ${{ inputs.model_cache_key }}
       backup_cache_key: ${{ inputs.backup_cache_key }}

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -46,7 +46,7 @@ jobs:
       issues: read
       pull-requests: read
       actions: write
-    uses: dotnet/issue-labeler/.github/workflows/train.yml@3fe21fbd027653d2263d259333b154d33c157572 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/train.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
     with:
       download_issues: ${{ inputs.download_issues }}
       train_issues: ${{ inputs.train_issues }}


### PR DESCRIPTION
While capturing the documentation for the issue-labeler [onboarding](https://github.com/dotnet/issue-labeler/wiki/Onboarding) / [release](https://github.com/dotnet/issue-labeler/wiki/Release-Process) / [upgrade ](https://github.com/dotnet/issue-labeler/wiki/Upgrade-Process) procedures, I recognized v1.0.0 of issue-labeler didn't pin all workflows to a specific version. v1.0.1 resolves this, and it's the version of issue-labeler we'll roll out to the other repositories.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6050)