### PR TITLE
Address M.E.VectorData feedback for IEmbeddingGenerator

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/AIContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/AIContent.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.AI;
 [JsonDerivedType(typeof(FunctionCallContent), typeDiscriminator: "functionCall")]
 [JsonDerivedType(typeof(FunctionResultContent), typeDiscriminator: "functionResult")]
 [JsonDerivedType(typeof(TextContent), typeDiscriminator: "text")]
+[JsonDerivedType(typeof(UriContent), typeDiscriminator: "uri")]
 [JsonDerivedType(typeof(UsageContent), typeDiscriminator: "usage")]
 public class AIContent
 {

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataContent.cs
@@ -28,18 +28,18 @@ namespace Microsoft.Extensions.AI;
 [DebuggerDisplay("{DebuggerDisplay,nq}")]
 public class DataContent : AIContent
 {
-    // Design notes:
-    // - Ideally DataContent would be based in terms of Uri. However, Uri has a length limitation that makes it prohibitive
-    //   for the kinds of data URIs necessary to support here. As such, this type is based in strings.
+    // Design note:
+    // Ideally DataContent would be based in terms of Uri. However, Uri has a length limitation that makes it prohibitive
+    // for the kinds of data URIs necessary to support here. As such, this type is based in strings.
+
+    /// <summary>Parsed data URI information.</summary>
+    private readonly DataUriParser.DataUri? _dataUri;
 
     /// <summary>The string-based representation of the URI, including any data in the instance.</summary>
     private string? _uri;
 
     /// <summary>The data, lazily initialized if the data is provided in a data URI.</summary>
     private ReadOnlyMemory<byte>? _data;
-
-    /// <summary>Parsed data URI information.</summary>
-    private DataUriParser.DataUri? _dataUri;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DataContent"/> class.
@@ -120,15 +120,17 @@ public class DataContent : AIContent
     }
 
     /// <summary>
-    /// Determines whether the <see cref="MediaType"/> has the specified prefix.
+    /// Determines whether the <see cref="MediaType"/>'s top-level type matches the specified <paramref name="topLevelType"/>.
     /// </summary>
-    /// <param name="prefix">The media type prefix.</param>
-    /// <returns><see langword="true"/> if the <see cref="MediaType"/> has the specified prefix; otherwise, <see langword="false"/>.</returns>
+    /// <param name="topLevelType">The type to compare against <see cref="MediaType"/>.</param>
+    /// <returns><see langword="true"/> if the type portion of <see cref="MediaType"/> matches the specified value; otherwise, false.</returns>
     /// <remarks>
-    /// This performs an ordinal case-insensitive comparison of the <see cref="MediaType"/> against the specified <paramref name="prefix"/>.
+    /// A media type is primarily composed of two parts, a "type" and a "subtype", separated by a slash ("/").
+    /// The type portion is also referred to as the "top-level type"; for example,
+    /// "image/png" has a top-level type of "image". <see cref="HasTopLevelMediaType"/> compares
+    /// the specified <paramref name="topLevelType"/> against the type portion of <see cref="MediaType"/>.
     /// </remarks>
-    public bool MediaTypeStartsWith(string prefix) =>
-        MediaType.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) is true;
+    public bool HasTopLevelMediaType(string topLevelType) => DataUriParser.HasTopLevelMediaType(MediaType, topLevelType);
 
     /// <summary>Gets the data URI for this <see cref="DataContent"/>.</summary>
     /// <remarks>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataContent.cs
@@ -8,17 +8,17 @@ using System.Text.Json.Serialization;
 using Microsoft.Shared.Diagnostics;
 
 #pragma warning disable S3996 // URI properties should not be strings
+#pragma warning disable CA1054 // URI-like parameters should not be strings
 #pragma warning disable CA1056 // URI-like properties should not be strings
 
 namespace Microsoft.Extensions.AI;
 
 /// <summary>
-/// Represents data content, such as an image or audio.
+/// Represents binary content with an associated media type (also known as MIME type).
 /// </summary>
 /// <remarks>
 /// <para>
-/// The represented content may either be the actual bytes stored in this instance, or it may
-/// be a URI that references the location of the content.
+/// The content represents in-memory data. For references to data at a remote URI, use <see cref="UriContent"/> instead.
 /// </para>
 /// <para>
 /// <see cref="Uri"/> always returns a valid URI string, even if the instance was constructed from
@@ -28,9 +28,9 @@ namespace Microsoft.Extensions.AI;
 [DebuggerDisplay("{DebuggerDisplay,nq}")]
 public class DataContent : AIContent
 {
-    // Design note:
-    // Ideally DataContent would be based in terms of Uri. However, Uri has a length limitation that makes it prohibitive
-    // for the kinds of data URIs necessary to support here. As such, this type is based in strings.
+    // Design notes:
+    // - Ideally DataContent would be based in terms of Uri. However, Uri has a length limitation that makes it prohibitive
+    //   for the kinds of data URIs necessary to support here. As such, this type is based in strings.
 
     /// <summary>The string-based representation of the URI, including any data in the instance.</summary>
     private string? _uri;
@@ -44,8 +44,15 @@ public class DataContent : AIContent
     /// <summary>
     /// Initializes a new instance of the <see cref="DataContent"/> class.
     /// </summary>
-    /// <param name="uri">The URI of the content. This can be a data URI.</param>
-    /// <param name="mediaType">The media type (also known as MIME type) represented by the content.</param>
+    /// <param name="uri">The data URI containing the content.</param>
+    /// <param name="mediaType">
+    /// The media type (also known as MIME type) represented by the content. If not provided,
+    /// it must be provided as part of the <paramref name="uri"/>.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="uri"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="uri"/> is not a data URI.</exception>
+    /// <exception cref="ArgumentException"><paramref name="uri"/> did not contain a media type and <paramref name="mediaType"/> was not supplied.</exception>
+    /// <exception cref="ArgumentException"><paramref name="mediaType"/> is an invalid media type.</exception>
     public DataContent(Uri uri, string? mediaType = null)
         : this(Throw.IfNull(uri).ToString(), mediaType)
     {
@@ -54,42 +61,48 @@ public class DataContent : AIContent
     /// <summary>
     /// Initializes a new instance of the <see cref="DataContent"/> class.
     /// </summary>
-    /// <param name="uri">The URI of the content. This can be a data URI.</param>
+    /// <param name="uri">The data URI containing the content.</param>
     /// <param name="mediaType">The media type (also known as MIME type) represented by the content.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="uri"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="uri"/> is not a data URI.</exception>
+    /// <exception cref="ArgumentException"><paramref name="uri"/> did not contain a media type and <paramref name="mediaType"/> was not supplied.</exception>
+    /// <exception cref="ArgumentException"><paramref name="mediaType"/> is an invalid media type.</exception>
     [JsonConstructor]
     public DataContent([StringSyntax(StringSyntaxAttribute.Uri)] string uri, string? mediaType = null)
     {
         _uri = Throw.IfNullOrWhitespace(uri);
 
-        ValidateMediaType(ref mediaType);
-        MediaType = mediaType;
-
-        if (uri.StartsWith(DataUriParser.Scheme, StringComparison.OrdinalIgnoreCase))
+        if (!uri.StartsWith(DataUriParser.Scheme, StringComparison.OrdinalIgnoreCase))
         {
-            _dataUri = DataUriParser.Parse(uri.AsMemory());
+            Throw.ArgumentException(nameof(uri), "The provided URI is not a data URI.");
+        }
 
-            // If the data URI contains a media type that's different from a non-null media type
-            // explicitly provided, prefer the one explicitly provided as an override.
-            if (MediaType is not null)
+        _dataUri = DataUriParser.Parse(uri.AsMemory());
+
+        if (mediaType is null)
+        {
+            mediaType = _dataUri.MediaType;
+            if (mediaType is null)
             {
-                if (MediaType != _dataUri.MediaType)
-                {
-                    // Extract the bytes from the data URI and null out the uri.
-                    // Then we'll lazily recreate it later if needed based on the updated media type.
-                    _data = _dataUri.ToByteArray();
-                    _dataUri = null;
-                    _uri = null;
-                }
-            }
-            else
-            {
-                MediaType = _dataUri.MediaType;
+                Throw.ArgumentNullException(nameof(mediaType), $"{nameof(uri)} did not contain a media type, and {nameof(mediaType)} was not provided.");
             }
         }
-        else if (!System.Uri.TryCreate(uri, UriKind.Absolute, out _))
+        else
         {
-            throw new UriFormatException("The URI is not well-formed.");
+            if (mediaType != _dataUri.MediaType)
+            {
+                // If the data URI contains a media type that's different from a non-null media type
+                // explicitly provided, prefer the one explicitly provided as an override.
+
+                // Extract the bytes from the data URI and null out the uri.
+                // Then we'll lazily recreate it later if needed based on the updated media type.
+                _data = _dataUri.ToByteArray();
+                _dataUri = null;
+                _uri = null;
+            }
         }
+
+        MediaType = DataUriParser.ThrowIfInvalidMediaType(mediaType);
     }
 
     /// <summary>
@@ -97,10 +110,11 @@ public class DataContent : AIContent
     /// </summary>
     /// <param name="data">The byte contents.</param>
     /// <param name="mediaType">The media type (also known as MIME type) represented by the content.</param>
-    public DataContent(ReadOnlyMemory<byte> data, string? mediaType = null)
+    /// <exception cref="ArgumentNullException"><paramref name="mediaType"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="mediaType"/> is empty or composed entirely of whitespace.</exception>
+    public DataContent(ReadOnlyMemory<byte> data, string mediaType)
     {
-        ValidateMediaType(ref mediaType);
-        MediaType = mediaType;
+        MediaType = DataUriParser.ThrowIfInvalidMediaType(mediaType);
 
         _data = data;
     }
@@ -109,20 +123,14 @@ public class DataContent : AIContent
     /// Determines whether the <see cref="MediaType"/> has the specified prefix.
     /// </summary>
     /// <param name="prefix">The media type prefix.</param>
-    /// <returns><see langword="true"/> if the <see cref="MediaType"/> has the specified prefix, otherwise <see langword="false"/>.</returns>
-    public bool MediaTypeStartsWith(string prefix)
-        => MediaType?.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) is true;
+    /// <returns><see langword="true"/> if the <see cref="MediaType"/> has the specified prefix; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This performs an ordinal case-insensitive comparison of the <see cref="MediaType"/> against the specified <paramref name="prefix"/>.
+    /// </remarks>
+    public bool MediaTypeStartsWith(string prefix) =>
+        MediaType.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) is true;
 
-    /// <summary>Sets <paramref name="mediaType"/> to null if it's empty or composed entirely of whitespace.</summary>
-    private static void ValidateMediaType(ref string? mediaType)
-    {
-        if (!DataUriParser.IsValidMediaType(mediaType.AsSpan(), ref mediaType))
-        {
-            Throw.ArgumentException(nameof(mediaType), "Invalid media type.");
-        }
-    }
-
-    /// <summary>Gets the URI for this <see cref="DataContent"/>.</summary>
+    /// <summary>Gets the data URI for this <see cref="DataContent"/>.</summary>
     /// <remarks>
     /// The returned URI is always a valid URI string, even if the instance was constructed from a <see cref="ReadOnlyMemory{Byte}"/>
     /// or from a <see cref="System.Uri"/>. In the case of a <see cref="ReadOnlyMemory{T}"/>, this property returns a data URI containing
@@ -137,8 +145,8 @@ public class DataContent : AIContent
             {
                 if (_dataUri is null)
                 {
-                    Debug.Assert(Data is not null, "Expected Data to be initialized.");
-                    _uri = string.Concat("data:", MediaType, ";base64,", Convert.ToBase64String(Data.GetValueOrDefault()
+                    Debug.Assert(_data is not null, "Expected _data to be initialized.");
+                    _uri = string.Concat("data:", MediaType, ";base64,", Convert.ToBase64String(_data.GetValueOrDefault()
 #if NET
                         .Span));
 #else
@@ -167,10 +175,9 @@ public class DataContent : AIContent
     /// If the media type was explicitly specified, this property returns that value.
     /// If the media type was not explicitly specified, but a data URI was supplied and that data URI contained a non-default
     /// media type, that media type is returned.
-    /// Otherwise, this property returns null.
     /// </remarks>
-    [JsonPropertyOrder(1)]
-    public string? MediaType { get; private set; }
+    [JsonIgnore]
+    public string MediaType { get; }
 
     /// <summary>Gets the data represented by this instance.</summary>
     /// <remarks>
@@ -181,16 +188,18 @@ public class DataContent : AIContent
     /// no attempt is made to retrieve the data from that URI.
     /// </remarks>
     [JsonIgnore]
-    public ReadOnlyMemory<byte>? Data
+    public ReadOnlyMemory<byte> Data
     {
         get
         {
-            if (_dataUri is not null)
+            if (_data is null)
             {
-                _data ??= _dataUri.ToByteArray();
+                Debug.Assert(_dataUri is not null, "Expected dataUri to be initialized.");
+                _data = _dataUri!.ToByteArray();
             }
 
-            return _data;
+            Debug.Assert(_data is not null, "Expected data to be initialized.");
+            return _data.GetValueOrDefault();
         }
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataUriParser.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataUriParser.cs
@@ -5,10 +5,12 @@ using System;
 #if NET8_0_OR_GREATER
 using System.Buffers.Text;
 #endif
-using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
 using System.Text;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
 
@@ -55,8 +57,9 @@ internal static class DataUriParser
         }
 
         // Validate the media type, if present.
+        ReadOnlySpan<char> span = metadata.Span.Trim();
         string? mediaType = null;
-        if (!IsValidMediaType(metadata.Span.Trim(), ref mediaType))
+        if (!span.IsEmpty && !IsValidMediaType(span, ref mediaType))
         {
             throw new UriFormatException("Invalid data URI format: the media type is not a valid.");
         }
@@ -64,20 +67,25 @@ internal static class DataUriParser
         return new DataUri(data, isBase64, mediaType);
     }
 
-    /// <summary>Validates that a media type is valid, and if successful, ensures we have it as a string.</summary>
-    public static bool IsValidMediaType(ReadOnlySpan<char> mediaTypeSpan, ref string? mediaType)
+    public static string ThrowIfInvalidMediaType(
+        string mediaType, [CallerArgumentExpression(nameof(mediaType))] string parameterName = "")
     {
-        Debug.Assert(
-            mediaType is null || mediaTypeSpan.Equals(mediaType.AsSpan(), StringComparison.Ordinal),
-            "mediaType string should either be null or the same as the span");
+        _ = Throw.IfNullOrWhitespace(mediaType, parameterName);
 
-        // If the media type is empty or all whitespace, normalize it to null.
-        if (mediaTypeSpan.IsWhiteSpace())
+        if (!IsValidMediaType(mediaType))
         {
-            mediaType = null;
-            return true;
+            Throw.ArgumentException(parameterName, $"An invalid media type was specified: '{mediaType}'");
         }
 
+        return mediaType;
+    }
+
+    public static bool IsValidMediaType(string mediaType) =>
+        IsValidMediaType(mediaType.AsSpan(), ref mediaType);
+
+    /// <summary>Validates that a media type is valid, and if successful, ensures we have it as a string.</summary>
+    public static bool IsValidMediaType(ReadOnlySpan<char> mediaTypeSpan, [NotNull] ref string? mediaType)
+    {
         // For common media types, we can avoid both allocating a string for the span and avoid parsing overheads.
         string? knownType = mediaTypeSpan switch
         {
@@ -108,7 +116,7 @@ internal static class DataUriParser
         };
         if (knownType is not null)
         {
-            mediaType ??= knownType;
+            mediaType = knownType;
             return true;
         }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataUriParser.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataUriParser.cs
@@ -12,6 +12,8 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Shared.Diagnostics;
 
+#pragma warning disable CA1307 // Specify StringComparison for clarity
+
 namespace Microsoft.Extensions.AI;
 
 /// <summary>
@@ -123,6 +125,16 @@ internal static class DataUriParser
         // Otherwise, do the full validation using the same logic as HttpClient.
         mediaType ??= mediaTypeSpan.ToString();
         return MediaTypeHeaderValue.TryParse(mediaType, out _);
+    }
+
+    public static bool HasTopLevelMediaType(string mediaType, string topLevelMediaType)
+    {
+        int slashIndex = mediaType.IndexOf('/');
+
+        ReadOnlySpan<char> span = slashIndex < 0 ? mediaType.AsSpan() : mediaType.AsSpan(0, slashIndex);
+        span = span.Trim();
+
+        return span.Equals(topLevelMediaType.AsSpan(), StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>Test whether the value is a base64 string without whitespace.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/UriContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/UriContent.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>
+/// Represents a URL, typically to hosted content such as an image, audio, or video.
+/// </summary>
+/// <remarks>
+/// This class is intended for use with HTTP or HTTPS URIs that reference hosted content.
+/// For data URIs, use <see cref="DataContent"/> instead.
+/// </remarks>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public class UriContent : AIContent
+{
+    /// <summary>The URI represented.</summary>
+    private Uri _uri;
+
+    /// <summary>The MIME type of the data at the referenced URI.</summary>
+    private string _mediaType;
+
+    /// <summary>Initializes a new instance of the <see cref="UriContent"/> class.</summary>
+    /// <param name="uri">The URI to the represented content.</param>
+    /// <param name="mediaType">The media type (also known as MIME type) represented by the content.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="uri"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="mediaType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="mediaType"/> is an invalid media type.</exception>
+    /// <exception cref="UriFormat"><paramref name="uri"/> is an invalid URL.</exception>
+    /// <remarks>
+    /// A media type must be specified, so that consumers know what to do with the content.
+    /// If an exact media type is not known, but the category (e.g. image) is known, a wildcard
+    /// may be used (e.g. "image/*").
+    /// </remarks>
+    public UriContent(string uri, string mediaType)
+        : this(new Uri(Throw.IfNull(uri)), mediaType)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="UriContent"/> class.</summary>
+    /// <param name="uri">The URI to the represented content.</param>
+    /// <param name="mediaType">The media type (also known as MIME type) represented by the content.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="uri"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="mediaType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="mediaType"/> is an invalid media type.</exception>
+    /// <remarks>
+    /// A media type must be specified, so that consumers know what to do with the content.
+    /// If an exact media type is not known, but the category (e.g. image) is known, a wildcard
+    /// may be used (e.g. "image/*").
+    /// </remarks>
+    [JsonConstructor]
+    public UriContent(Uri uri, string mediaType)
+    {
+        _uri = Throw.IfNull(uri);
+        _mediaType = DataUriParser.ThrowIfInvalidMediaType(mediaType);
+    }
+
+    /// <summary>Gets or sets the <see cref="Uri"/> for this content.</summary>
+    public Uri Uri
+    {
+        get => _uri;
+        set => _uri = Throw.IfNull(value);
+    }
+
+    /// <summary>Gets or sets the media type (also known as MIME type) for this content.</summary>
+    public string MediaType
+    {
+        get => _mediaType;
+        set => _mediaType = DataUriParser.ThrowIfInvalidMediaType(value);
+    }
+
+    /// <summary>
+    /// Determines whether the <see cref="MediaType"/> has the specified prefix.
+    /// </summary>
+    /// <param name="prefix">The media type prefix.</param>
+    /// <returns><see langword="true"/> if the <see cref="MediaType"/> has the specified prefix; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This performs an ordinal case-insensitive comparison of the <see cref="MediaType"/> against the specified <paramref name="prefix"/>.
+    /// </remarks>
+    public bool MediaTypeStartsWith(string prefix) =>
+        MediaType.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) is true;
+
+    /// <summary>Gets a string representing this instance to display in the debugger.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => $"Uri = {_uri}";
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/UriContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/UriContent.cs
@@ -74,15 +74,17 @@ public class UriContent : AIContent
     }
 
     /// <summary>
-    /// Determines whether the <see cref="MediaType"/> has the specified prefix.
+    /// Determines whether the <see cref="MediaType"/>'s top-level type matches the specified <paramref name="topLevelType"/>.
     /// </summary>
-    /// <param name="prefix">The media type prefix.</param>
-    /// <returns><see langword="true"/> if the <see cref="MediaType"/> has the specified prefix; otherwise, <see langword="false"/>.</returns>
+    /// <param name="topLevelType">The type to compare against <see cref="MediaType"/>.</param>
+    /// <returns><see langword="true"/> if the type portion of <see cref="MediaType"/> matches the specified value; otherwise, false.</returns>
     /// <remarks>
-    /// This performs an ordinal case-insensitive comparison of the <see cref="MediaType"/> against the specified <paramref name="prefix"/>.
+    /// A media type is primarily composed of two parts, a "type" and a "subtype", separated by a slash ("/").
+    /// The type portion is also referred to as the "top-level type"; for example,
+    /// "image/png" has a top-level type of "image". <see cref="HasTopLevelMediaType"/> compares
+    /// the specified <paramref name="topLevelType"/> against the type portion of <see cref="MediaType"/>.
     /// </remarks>
-    public bool MediaTypeStartsWith(string prefix) =>
-        MediaType.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) is true;
+    public bool HasTopLevelMediaType(string topLevelType) => DataUriParser.HasTopLevelMediaType(MediaType, topLevelType);
 
     /// <summary>Gets a string representing this instance to display in the debugger.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/EmbeddingGeneratorExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/EmbeddingGeneratorExtensions.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Extensions.AI;
 public static class EmbeddingGeneratorExtensions
 {
     /// <summary>Asks the <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/> for an object of type <typeparamref name="TService"/>.</summary>
-    /// <typeparam name="TInput">The type from which embeddings will be generated.</typeparam>
-    /// <typeparam name="TEmbedding">The numeric type of the embedding data.</typeparam>
     /// <typeparam name="TService">The type of the object to be retrieved.</typeparam>
     /// <param name="generator">The generator.</param>
     /// <param name="serviceKey">An optional key that can be used to help identify the target service.</param>
@@ -28,9 +26,8 @@ public static class EmbeddingGeneratorExtensions
     /// The purpose of this method is to allow for the retrieval of strongly typed services that may be provided by the
     /// <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/>, including itself or any services it might be wrapping.
     /// </remarks>
-    public static TService? GetService<TInput, TEmbedding, TService>(
-        this IEmbeddingGenerator<TInput, TEmbedding> generator, object? serviceKey = null)
-        where TEmbedding : Embedding
+    public static TService? GetService<TService>(
+        this IEmbeddingGenerator generator, object? serviceKey = null)
     {
         _ = Throw.IfNull(generator);
 
@@ -41,8 +38,6 @@ public static class EmbeddingGeneratorExtensions
     /// Asks the <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/> for an object of the specified type <paramref name="serviceType"/>
     /// and throws an exception if one isn't available.
     /// </summary>
-    /// <typeparam name="TInput">The type from which embeddings will be generated.</typeparam>
-    /// <typeparam name="TEmbedding">The numeric type of the embedding data.</typeparam>
     /// <param name="generator">The generator.</param>
     /// <param name="serviceType">The type of object being requested.</param>
     /// <param name="serviceKey">An optional key that can be used to help identify the target service.</param>
@@ -54,9 +49,8 @@ public static class EmbeddingGeneratorExtensions
     /// The purpose of this method is to allow for the retrieval of services that are required to be provided by the
     /// <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/>, including itself or any services it might be wrapping.
     /// </remarks>
-    public static object GetRequiredService<TInput, TEmbedding>(
-        this IEmbeddingGenerator<TInput, TEmbedding> generator, Type serviceType, object? serviceKey = null)
-        where TEmbedding : Embedding
+    public static object GetRequiredService(
+        this IEmbeddingGenerator generator, Type serviceType, object? serviceKey = null)
     {
         _ = Throw.IfNull(generator);
         _ = Throw.IfNull(serviceType);
@@ -70,8 +64,6 @@ public static class EmbeddingGeneratorExtensions
     /// Asks the <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/> for an object of type <typeparamref name="TService"/>
     /// and throws an exception if one isn't available.
     /// </summary>
-    /// <typeparam name="TInput">The type from which embeddings will be generated.</typeparam>
-    /// <typeparam name="TEmbedding">The numeric type of the embedding data.</typeparam>
     /// <typeparam name="TService">The type of the object to be retrieved.</typeparam>
     /// <param name="generator">The generator.</param>
     /// <param name="serviceKey">An optional key that can be used to help identify the target service.</param>
@@ -82,9 +74,8 @@ public static class EmbeddingGeneratorExtensions
     /// The purpose of this method is to allow for the retrieval of strongly typed services that are required to be provided by the
     /// <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/>, including itself or any services it might be wrapping.
     /// </remarks>
-    public static TService GetRequiredService<TInput, TEmbedding, TService>(
-        this IEmbeddingGenerator<TInput, TEmbedding> generator, object? serviceKey = null)
-        where TEmbedding : Embedding
+    public static TService GetRequiredService<TService>(
+        this IEmbeddingGenerator generator, object? serviceKey = null)
     {
         _ = Throw.IfNull(generator);
 
@@ -95,42 +86,6 @@ public static class EmbeddingGeneratorExtensions
 
         return service;
     }
-
-    // The following overloads exist purely to work around the lack of partial generic type inference.
-    // Given an IEmbeddingGenerator<TInput, TEmbedding> generator, to call GetService with TService, you still need
-    // to re-specify both TInput and TEmbedding, e.g. generator.GetService<string, Embedding<float>, TService>.
-    // The case of string/Embedding<float> is by far the most common case today, so this overload exists as an
-    // accelerator to allow it to be written simply as generator.GetService<TService>.
-
-    /// <summary>Asks the <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> for an object of type <typeparamref name="TService"/>.</summary>
-    /// <typeparam name="TService">The type of the object to be retrieved.</typeparam>
-    /// <param name="generator">The generator.</param>
-    /// <param name="serviceKey">An optional key that can be used to help identify the target service.</param>
-    /// <returns>The found object, otherwise <see langword="null"/>.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="generator"/> is <see langword="null"/>.</exception>
-    /// <remarks>
-    /// The purpose of this method is to allow for the retrieval of strongly typed services that may be provided by the
-    /// <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/>, including itself or any services it might be wrapping.
-    /// </remarks>
-    public static TService? GetService<TService>(this IEmbeddingGenerator<string, Embedding<float>> generator, object? serviceKey = null) =>
-        GetService<string, Embedding<float>, TService>(generator, serviceKey);
-
-    /// <summary>
-    /// Asks the <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/> for an object of type <typeparamref name="TService"/>
-    /// and throws an exception if one isn't available.
-    /// </summary>
-    /// <typeparam name="TService">The type of the object to be retrieved.</typeparam>
-    /// <param name="generator">The generator.</param>
-    /// <param name="serviceKey">An optional key that can be used to help identify the target service.</param>
-    /// <returns>The found object.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="generator"/> is <see langword="null"/>.</exception>
-    /// <exception cref="InvalidOperationException">No service of the requested type for the specified key is available.</exception>
-    /// <remarks>
-    /// The purpose of this method is to allow for the retrieval of strongly typed services that may be provided by the
-    /// <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/>, including itself or any services it might be wrapping.
-    /// </remarks>
-    public static TService GetRequiredService<TService>(this IEmbeddingGenerator<string, Embedding<float>> generator, object? serviceKey = null) =>
-        GetRequiredService<string, Embedding<float>, TService>(generator, serviceKey);
 
     /// <summary>Generates an embedding vector from the specified <paramref name="value"/>.</summary>
     /// <typeparam name="TInput">The type from which embeddings will be generated.</typeparam>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/IEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/IEmbeddingGenerator.cs
@@ -2,42 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a generator of embeddings.</summary>
-/// <typeparam name="TInput">The type from which embeddings will be generated.</typeparam>
-/// <typeparam name="TEmbedding">The type of embeddings to generate.</typeparam>
 /// <remarks>
-/// <para>
-/// Unless otherwise specified, all members of <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> are thread-safe for concurrent use.
-/// It is expected that all implementations of <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> support being used by multiple requests concurrently.
-/// Instances must not be disposed of while the instance is still in use.
-/// </para>
-/// <para>
-/// However, implementations of <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> may mutate the arguments supplied to
-/// <see cref="GenerateAsync"/>, such as by configuring the options instance. Thus, consumers of the interface either should
-/// avoid using shared instances of these arguments for concurrent invocations or should otherwise ensure by construction that
-/// no <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> instances are used which might employ such mutation.
-/// </para>
+/// This base interface is used to allow for embedding generators to be stored in a non-generic manner.
+/// To use the generator to create embeddings, instances typed as this base interface first need to be
+/// cast to the generic interface <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/>.
 /// </remarks>
-public interface IEmbeddingGenerator<in TInput, TEmbedding> : IDisposable
-    where TEmbedding : Embedding
+public interface IEmbeddingGenerator : IDisposable
 {
-    /// <summary>Generates embeddings for each of the supplied <paramref name="values"/>.</summary>
-    /// <param name="values">The sequence of values for which to generate embeddings.</param>
-    /// <param name="options">The embedding generation options with which to configure the request.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns>The generated embeddings.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="values"/> is <see langword="null"/>.</exception>
-    Task<GeneratedEmbeddings<TEmbedding>> GenerateAsync(
-        IEnumerable<TInput> values,
-        EmbeddingGenerationOptions? options = null,
-        CancellationToken cancellationToken = default);
-
     /// <summary>Asks the <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> for an object of the specified type <paramref name="serviceType"/>.</summary>
     /// <param name="serviceType">The type of object being requested.</param>
     /// <param name="serviceKey">An optional key that can be used to help identify the target service.</param>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/IEmbeddingGenerator{TInput,TEmbedding}.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/IEmbeddingGenerator{TInput,TEmbedding}.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Represents a generator of embeddings.</summary>
+/// <typeparam name="TInput">The type from which embeddings will be generated.</typeparam>
+/// <typeparam name="TEmbedding">The type of embeddings to generate.</typeparam>
+/// <remarks>
+/// <para>
+/// Unless otherwise specified, all members of <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> are thread-safe for concurrent use.
+/// It is expected that all implementations of <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> support being used by multiple requests concurrently.
+/// Instances must not be disposed of while the instance is still in use.
+/// </para>
+/// <para>
+/// However, implementations of <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> may mutate the arguments supplied to
+/// <see cref="GenerateAsync"/>, such as by configuring the options instance. Thus, consumers of the interface either should
+/// avoid using shared instances of these arguments for concurrent invocations or should otherwise ensure by construction that
+/// no <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> instances are used which might employ such mutation.
+/// </para>
+/// </remarks>
+public interface IEmbeddingGenerator<in TInput, TEmbedding> : IEmbeddingGenerator
+    where TEmbedding : Embedding
+{
+    /// <summary>Generates embeddings for each of the supplied <paramref name="values"/>.</summary>
+    /// <param name="values">The sequence of values for which to generate embeddings.</param>
+    /// <param name="options">The embedding generation options with which to configure the request.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The generated embeddings.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="values"/> is <see langword="null"/>.</exception>
+    Task<GeneratedEmbeddings<TEmbedding>> GenerateAsync(
+        IEnumerable<TInput> values,
+        EmbeddingGenerationOptions? options = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
@@ -490,25 +490,25 @@ public sealed class AzureAIInferenceChatClient : IChatClient
                     parts.Add(new ChatMessageTextContentItem(textContent.Text));
                     break;
 
-                case UriContent uriContent when uriContent.MediaTypeStartsWith("image/"):
+                case UriContent uriContent when uriContent.HasTopLevelMediaType("image"):
                     parts.Add(new ChatMessageImageContentItem(uriContent.Uri));
                     break;
 
-                case DataContent dataContent when dataContent.MediaTypeStartsWith("image/"):
+                case DataContent dataContent when dataContent.HasTopLevelMediaType("image"):
                     parts.Add(new ChatMessageImageContentItem(BinaryData.FromBytes(dataContent.Data), dataContent.MediaType));
                     break;
 
-                case UriContent uriContent when uriContent.MediaTypeStartsWith("audio/"):
+                case UriContent uriContent when uriContent.HasTopLevelMediaType("audio"):
                     parts.Add(new ChatMessageAudioContentItem(uriContent.Uri));
                     break;
 
-                case DataContent dataContent when dataContent.MediaTypeStartsWith("audio/"):
+                case DataContent dataContent when dataContent.HasTopLevelMediaType("audio"):
                     AudioContentFormat format;
-                    if (dataContent.MediaTypeStartsWith("audio/mpeg"))
+                    if (dataContent.MediaType.Equals("audio/mpeg", StringComparison.OrdinalIgnoreCase))
                     {
                         format = AudioContentFormat.Mp3;
                     }
-                    else if (dataContent.MediaTypeStartsWith("audio/wav"))
+                    else if (dataContent.MediaType.Equals("audio/wav", StringComparison.OrdinalIgnoreCase))
                     {
                         format = AudioContentFormat.Wav;
                     }

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
@@ -490,42 +490,34 @@ public sealed class AzureAIInferenceChatClient : IChatClient
                     parts.Add(new ChatMessageTextContentItem(textContent.Text));
                     break;
 
-                case DataContent dataContent when dataContent.MediaTypeStartsWith("image/"):
-                    if (dataContent.Data.HasValue)
-                    {
-                        parts.Add(new ChatMessageImageContentItem(BinaryData.FromBytes(dataContent.Data.Value), dataContent.MediaType));
-                    }
-                    else if (dataContent.Uri is string uri)
-                    {
-                        parts.Add(new ChatMessageImageContentItem(new Uri(uri)));
-                    }
+                case UriContent uriContent when uriContent.MediaTypeStartsWith("image/"):
+                    parts.Add(new ChatMessageImageContentItem(uriContent.Uri));
+                    break;
 
+                case DataContent dataContent when dataContent.MediaTypeStartsWith("image/"):
+                    parts.Add(new ChatMessageImageContentItem(BinaryData.FromBytes(dataContent.Data), dataContent.MediaType));
+                    break;
+
+                case UriContent uriContent when uriContent.MediaTypeStartsWith("audio/"):
+                    parts.Add(new ChatMessageAudioContentItem(uriContent.Uri));
                     break;
 
                 case DataContent dataContent when dataContent.MediaTypeStartsWith("audio/"):
-                    if (dataContent.Data.HasValue)
+                    AudioContentFormat format;
+                    if (dataContent.MediaTypeStartsWith("audio/mpeg"))
                     {
-                        AudioContentFormat format;
-                        if (dataContent.MediaTypeStartsWith("audio/mpeg"))
-                        {
-                            format = AudioContentFormat.Mp3;
-                        }
-                        else if (dataContent.MediaTypeStartsWith("audio/wav"))
-                        {
-                            format = AudioContentFormat.Wav;
-                        }
-                        else
-                        {
-                            break;
-                        }
-
-                        parts.Add(new ChatMessageAudioContentItem(BinaryData.FromBytes(dataContent.Data.Value), format));
+                        format = AudioContentFormat.Mp3;
                     }
-                    else if (dataContent.Uri is string uri)
+                    else if (dataContent.MediaTypeStartsWith("audio/wav"))
                     {
-                        parts.Add(new ChatMessageAudioContentItem(new Uri(uri)));
+                        format = AudioContentFormat.Wav;
+                    }
+                    else
+                    {
+                        break;
                     }
 
+                    parts.Add(new ChatMessageAudioContentItem(BinaryData.FromBytes(dataContent.Data), format));
                     break;
             }
         }

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceEmbeddingGenerator.cs
@@ -73,7 +73,7 @@ public sealed class AzureAIInferenceEmbeddingGenerator :
     }
 
     /// <inheritdoc />
-    object? IEmbeddingGenerator<string, Embedding<float>>.GetService(Type serviceType, object? serviceKey)
+    object? IEmbeddingGenerator.GetService(Type serviceType, object? serviceKey)
     {
         _ = Throw.IfNull(serviceType);
 

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
@@ -392,7 +392,7 @@ public sealed class OllamaChatClient : IChatClient
         OllamaChatRequestMessage? currentTextMessage = null;
         foreach (var item in content.Contents)
         {
-            if (item is DataContent dataContent && dataContent.MediaTypeStartsWith("image/"))
+            if (item is DataContent dataContent && dataContent.HasTopLevelMediaType("image"))
             {
                 IList<string> images = currentTextMessage?.Images ?? [];
                 images.Add(Convert.ToBase64String(dataContent.Data

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
@@ -392,10 +392,10 @@ public sealed class OllamaChatClient : IChatClient
         OllamaChatRequestMessage? currentTextMessage = null;
         foreach (var item in content.Contents)
         {
-            if (item is DataContent dataContent && dataContent.MediaTypeStartsWith("image/") && dataContent.Data.HasValue)
+            if (item is DataContent dataContent && dataContent.MediaTypeStartsWith("image/"))
             {
                 IList<string> images = currentTextMessage?.Images ?? [];
-                images.Add(Convert.ToBase64String(dataContent.Data.Value
+                images.Add(Convert.ToBase64String(dataContent.Data
 #if NET
                     .Span));
 #else

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaEmbeddingGenerator.cs
@@ -61,7 +61,7 @@ public sealed class OllamaEmbeddingGenerator : IEmbeddingGenerator<string, Embed
     }
 
     /// <inheritdoc />
-    object? IEmbeddingGenerator<string, Embedding<float>>.GetService(Type serviceType, object? serviceKey)
+    object? IEmbeddingGenerator.GetService(Type serviceType, object? serviceKey)
     {
         _ = Throw.IfNull(serviceType);
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantClient.cs
@@ -299,7 +299,7 @@ internal sealed class OpenAIAssistantClient : IChatClient
                         messageContents.Add(MessageContent.FromText(tc.Text));
                         break;
 
-                    case DataContent dc when dc.MediaTypeStartsWith("image/"):
+                    case DataContent dc when dc.HasTopLevelMediaType("image"):
                         messageContents.Add(MessageContent.FromImageUri(new(dc.Uri)));
                         break;
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIEmbeddingGenerator.cs
@@ -125,7 +125,7 @@ public sealed class OpenAIEmbeddingGenerator : IEmbeddingGenerator<string, Embed
     }
 
     /// <inheritdoc />
-    object? IEmbeddingGenerator<string, Embedding<float>>.GetService(Type serviceType, object? serviceKey)
+    object? IEmbeddingGenerator.GetService(Type serviceType, object? serviceKey)
     {
         _ = Throw.IfNull(serviceType);
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMapper.ChatCompletion.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMapper.ChatCompletion.cs
@@ -566,15 +566,14 @@ internal static partial class OpenAIModelMappers
         }
         else if (contentPart.Kind == ChatMessageContentPartKind.Image)
         {
-            DataContent? imageContent;
-            aiContent = imageContent =
-                contentPart.ImageUri is not null ? new DataContent(contentPart.ImageUri, contentPart.ImageBytesMediaType) :
+            aiContent =
+                contentPart.ImageUri is not null ? new UriContent(contentPart.ImageUri, "image/*") :
                 contentPart.ImageBytes is not null ? new DataContent(contentPart.ImageBytes.ToMemory(), contentPart.ImageBytesMediaType) :
                 null;
 
-            if (imageContent is not null && contentPart.ImageDetailLevel?.ToString() is string detail)
+            if (aiContent is not null && contentPart.ImageDetailLevel?.ToString() is string detail)
             {
-                (imageContent.AdditionalProperties ??= [])[nameof(contentPart.ImageDetailLevel)] = detail;
+                (aiContent.AdditionalProperties ??= [])[nameof(contentPart.ImageDetailLevel)] = detail;
             }
         }
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMapper.ChatMessage.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMapper.ChatMessage.cs
@@ -229,21 +229,21 @@ internal static partial class OpenAIModelMappers
                     parts.Add(ChatMessageContentPart.CreateTextPart(textContent.Text));
                     break;
 
-                case UriContent uriContent when uriContent.MediaTypeStartsWith("image/"):
+                case UriContent uriContent when uriContent.HasTopLevelMediaType("image"):
                     parts.Add(ChatMessageContentPart.CreateImagePart(uriContent.Uri));
                     break;
 
-                case DataContent dataContent when dataContent.MediaTypeStartsWith("image/"):
+                case DataContent dataContent when dataContent.HasTopLevelMediaType("image"):
                     parts.Add(ChatMessageContentPart.CreateImagePart(BinaryData.FromBytes(dataContent.Data), dataContent.MediaType));
                     break;
 
-                case DataContent dataContent when dataContent.MediaTypeStartsWith("audio/"):
+                case DataContent dataContent when dataContent.HasTopLevelMediaType("audio"):
                     var audioData = BinaryData.FromBytes(dataContent.Data);
-                    if (dataContent.MediaTypeStartsWith("audio/mpeg"))
+                    if (dataContent.MediaType.Equals("audio/mpeg", StringComparison.OrdinalIgnoreCase))
                     {
                         parts.Add(ChatMessageContentPart.CreateInputAudioPart(audioData, ChatInputAudioFormat.Mp3));
                     }
-                    else if (dataContent.MediaTypeStartsWith("audio/wav"))
+                    else if (dataContent.MediaType.Equals("audio/wav", StringComparison.OrdinalIgnoreCase))
                     {
                         parts.Add(ChatMessageContentPart.CreateInputAudioPart(audioData, ChatInputAudioFormat.Wav));
                     }

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/EmbeddingGeneratorBuilderServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/EmbeddingGeneratorBuilderServiceCollectionExtensions.cs
@@ -53,6 +53,8 @@ public static class EmbeddingGeneratorBuilderServiceCollectionExtensions
 
         var builder = new EmbeddingGeneratorBuilder<TInput, TEmbedding>(innerGeneratorFactory);
         serviceCollection.Add(new ServiceDescriptor(typeof(IEmbeddingGenerator<TInput, TEmbedding>), builder.Build, lifetime));
+        serviceCollection.Add(new ServiceDescriptor(typeof(IEmbeddingGenerator),
+            static services => services.GetRequiredService<IEmbeddingGenerator<TInput, TEmbedding>>(), lifetime));
         return builder;
     }
 
@@ -103,6 +105,8 @@ public static class EmbeddingGeneratorBuilderServiceCollectionExtensions
 
         var builder = new EmbeddingGeneratorBuilder<TInput, TEmbedding>(innerGeneratorFactory);
         serviceCollection.Add(new ServiceDescriptor(typeof(IEmbeddingGenerator<TInput, TEmbedding>), serviceKey, factory: (services, serviceKey) => builder.Build(services), lifetime));
+        serviceCollection.Add(new ServiceDescriptor(typeof(IEmbeddingGenerator), serviceKey,
+            static (services, serviceKey) => services.GetRequiredKeyedService<IEmbeddingGenerator<TInput, TEmbedding>>(serviceKey), lifetime));
         return builder;
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/LoggingEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/LoggingEmbeddingGenerator.cs
@@ -52,7 +52,7 @@ public partial class LoggingEmbeddingGenerator<TInput, TEmbedding> : DelegatingE
         {
             if (_logger.IsEnabled(LogLevel.Trace))
             {
-                LogInvokedSensitive(AsJson(values), AsJson(options), AsJson(this.GetService<TInput, TEmbedding, EmbeddingGeneratorMetadata>()));
+                LogInvokedSensitive(AsJson(values), AsJson(options), AsJson(this.GetService<EmbeddingGeneratorMetadata>()));
             }
             else
             {

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
@@ -50,7 +50,7 @@ public sealed class OpenTelemetryEmbeddingGenerator<TInput, TEmbedding> : Delega
     {
         Debug.Assert(innerGenerator is not null, "Should have been validated by the base ctor.");
 
-        if (innerGenerator!.GetService<TInput, TEmbedding, EmbeddingGeneratorMetadata>() is EmbeddingGeneratorMetadata metadata)
+        if (innerGenerator!.GetService<EmbeddingGeneratorMetadata>() is EmbeddingGeneratorMetadata metadata)
         {
             _system = metadata.ProviderName;
             _modelId = metadata.ModelId;

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatMessageTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatMessageTests.cs
@@ -141,8 +141,8 @@ public class ChatMessageTests
     {
         ChatMessage message = new(ChatRole.User,
         [
-            new DataContent("http://localhost/audio"),
-            new DataContent("http://localhost/image"),
+            new DataContent("data:text/image;base64,aGVsbG8="),
+            new DataContent("data:text/plain;base64,aGVsbG8="),
             new FunctionCallContent("callId1", "fc1"),
             new TextContent("text-1"),
             new TextContent("text-2"),
@@ -240,7 +240,7 @@ public class ChatMessageTests
             {
                 AdditionalProperties = new() { ["metadata-key-1"] = "metadata-value-1" }
             },
-            new DataContent(new Uri("https://fake-random-test-host:123"), "mime-type/2")
+            new DataContent(new Uri("data:text/plain;base64,aGVsbG8="), "mime-type/2")
             {
                 AdditionalProperties = new() { ["metadata-key-2"] = "metadata-value-2" }
             },
@@ -286,7 +286,7 @@ public class ChatMessageTests
 
         var dataContent = deserializedMessage.Contents[1] as DataContent;
         Assert.NotNull(dataContent);
-        Assert.Equal("https://fake-random-test-host:123/", dataContent.Uri);
+        Assert.Equal("data:mime-type/2;base64,aGVsbG8=", dataContent.Uri);
         Assert.Equal("mime-type/2", dataContent.MediaType);
         Assert.NotNull(dataContent.AdditionalProperties);
         Assert.Single(dataContent.AdditionalProperties);
@@ -294,7 +294,7 @@ public class ChatMessageTests
 
         dataContent = deserializedMessage.Contents[2] as DataContent;
         Assert.NotNull(dataContent);
-        Assert.True(dataContent.Data!.Value.Span.SequenceEqual(new BinaryData(new[] { 1, 2, 3 }, TestJsonSerializerContext.Default.Options)));
+        Assert.True(dataContent.Data.Span.SequenceEqual(new BinaryData(new[] { 1, 2, 3 }, TestJsonSerializerContext.Default.Options)));
         Assert.Equal("mime-type/3", dataContent.MediaType);
         Assert.NotNull(dataContent.AdditionalProperties);
         Assert.Single(dataContent.AdditionalProperties);

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
@@ -124,7 +124,7 @@ public class ChatResponseUpdateExtensionsTests
         {
             for (int i = 0; i < gapLength; i++)
             {
-                updates.Add(new() { Contents = [new DataContent("https://uri", mediaType: "image/png")] });
+                updates.Add(new() { Contents = [new DataContent("data:image/png;base64,aGVsbG8=")] });
             }
         }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateTests.cs
@@ -84,8 +84,8 @@ public class ChatResponseUpdateTests
             Role = ChatRole.User,
             Contents =
             [
-                new DataContent("http://localhost/audio"),
-                new DataContent("http://localhost/image"),
+                new DataContent("data:image/audio;base64,aGVsbG8="),
+                new DataContent("data:image/image;base64,aGVsbG8="),
                 new FunctionCallContent("callId1", "fc1"),
                 new TextContent("text-1"),
                 new TextContent("text-2"),
@@ -114,9 +114,9 @@ public class ChatResponseUpdateTests
             Contents =
             [
                 new TextContent("text-1"),
-                new DataContent("http://localhost/image"),
+                new DataContent("data:image/png;base64,aGVsbG8="),
                 new FunctionCallContent("callId1", "fc1"),
-                new DataContent("data"u8.ToArray()),
+                new DataContent("data"u8.ToArray(), "text/plain"),
                 new TextContent("text-2"),
             ],
             RawRepresentation = new object(),
@@ -137,13 +137,13 @@ public class ChatResponseUpdateTests
         Assert.Equal("text-1", ((TextContent)result.Contents[0]).Text);
 
         Assert.IsType<DataContent>(result.Contents[1]);
-        Assert.Equal("http://localhost/image", ((DataContent)result.Contents[1]).Uri);
+        Assert.Equal("data:image/png;base64,aGVsbG8=", ((DataContent)result.Contents[1]).Uri);
 
         Assert.IsType<FunctionCallContent>(result.Contents[2]);
         Assert.Equal("fc1", ((FunctionCallContent)result.Contents[2]).Name);
 
         Assert.IsType<DataContent>(result.Contents[3]);
-        Assert.Equal("data"u8.ToArray(), ((DataContent)result.Contents[3]).Data?.ToArray());
+        Assert.Equal("data"u8.ToArray(), ((DataContent)result.Contents[3]).Data.ToArray());
 
         Assert.IsType<TextContent>(result.Contents[4]);
         Assert.Equal("text-2", ((TextContent)result.Contents[4]).Text);

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/DataContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/DataContentTests.cs
@@ -200,28 +200,28 @@ public sealed class DataContentTests
     }
 
     [Theory]
-    [InlineData("image/gif", "image/")]
+    [InlineData("image/gif", "image")]
     [InlineData("IMAGE/JPEG", "image")]
-    [InlineData("image/vnd.microsoft.icon", "ima")]
-    [InlineData("image/svg+xml", "IMAGE/")]
+    [InlineData("image/vnd.microsoft.icon", "imAge")]
+    [InlineData("image/svg+xml", "IMAGE")]
     [InlineData("image/nonexistentimagemimetype", "IMAGE")]
-    [InlineData("audio/mpeg", "aUdIo/")]
-    [InlineData("application/json", "")]
-    [InlineData("application/pdf", "application/pdf")]
+    [InlineData("audio/mpeg", "aUdIo")]
     public void HasMediaTypePrefix_ReturnsTrue(string mediaType, string prefix)
     {
         var content = new DataContent("data:application/octet-stream;base64,AQIDBA==", mediaType);
-        Assert.True(content.MediaTypeStartsWith(prefix));
+        Assert.True(content.HasTopLevelMediaType(prefix));
     }
 
     [Theory]
-    [InlineData("audio/mpeg", "image/")]
+    [InlineData("audio/mpeg", "audio/")]
+    [InlineData("audio/mpeg", "image")]
+    [InlineData("audio/mpeg", "audio/mpeg")]
     [InlineData("text/css", "text/csv")]
     [InlineData("text/css", "/csv")]
     [InlineData("application/json", "application/json!")]
     public void HasMediaTypePrefix_ReturnsFalse(string mediaType, string prefix)
     {
         var content = new DataContent("data:application/octet-stream;base64,AQIDBA==", mediaType);
-        Assert.False(content.MediaTypeStartsWith(prefix));
+        Assert.False(content.HasTopLevelMediaType(prefix));
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/UriContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/UriContentTests.cs
@@ -1,0 +1,130 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text.Json;
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public sealed class UriContentTests
+{
+    [Fact]
+    public void Ctor_InvalidUriMediaType_Throws()
+    {
+        Assert.Throws<ArgumentNullException>("uri", () => new UriContent((string)null!, "image/png"));
+        Assert.Throws<ArgumentNullException>("uri", () => new UriContent((Uri)null!, "image/png"));
+        Assert.Throws<UriFormatException>(() => new UriContent("notauri", "image/png"));
+
+        Assert.Throws<ArgumentNullException>("mediaType", () => new UriContent("data:image/png;base64,aGVsbG8=", null!));
+        Assert.Throws<ArgumentException>("mediaType", () => new UriContent("data:image/png;base64,aGVsbG8=", ""));
+        Assert.Throws<ArgumentException>("mediaType", () => new UriContent("data:image/png;base64,aGVsbG8=", "image"));
+
+        Assert.Throws<ArgumentNullException>("mediaType", () => new UriContent(new Uri("data:image/png;base64,aGVsbG8="), null!));
+        Assert.Throws<ArgumentException>("mediaType", () => new UriContent(new Uri("data:image/png;base64,aGVsbG8="), ""));
+        Assert.Throws<ArgumentException>("mediaType", () => new UriContent(new Uri("data:image/png;base64,aGVsbG8="), "audio"));
+
+        UriContent c = new("http://localhost/something", "image/png");
+        Assert.Throws<ArgumentNullException>("value", () => c.Uri = null!);
+    }
+
+    [Theory]
+    [InlineData("type")]
+    [InlineData("type//subtype")]
+    [InlineData("type/subtype/")]
+    [InlineData("type/subtype;key=")]
+    [InlineData("type/subtype;=value")]
+    [InlineData("type/subtype;key=value;another=")]
+    public void Ctor_InvalidMediaType_Throws(string type)
+    {
+        Assert.Throws<ArgumentException>("mediaType", () => new UriContent("http://localhost/something", type));
+
+        UriContent c = new("http://localhost/something", "image/png");
+        Assert.Throws<ArgumentException>("value", () => c.MediaType = type);
+        Assert.Throws<ArgumentNullException>("value", () => c.MediaType = null!);
+    }
+
+    [Theory]
+    [InlineData("type/subtype")]
+    [InlineData("type/subtype;key=value")]
+    [InlineData("type/subtype;key=value;another=value")]
+    [InlineData("type/subtype;key=value;another=value;yet_another=value")]
+    public void Ctor_ValidMediaType_Roundtrips(string mediaType)
+    {
+        var content = new UriContent("http://localhost/something", mediaType);
+        Assert.Equal(mediaType, content.MediaType);
+
+        content.MediaType = "image/png";
+        Assert.Equal("image/png", content.MediaType);
+
+        content.MediaType = mediaType;
+        Assert.Equal(mediaType, content.MediaType);
+    }
+
+    [Fact]
+    public void Serialize_MatchesExpectedJson()
+    {
+        Assert.Equal(
+            """{"uri":"http://localhost/something","mediaType":"image/png"}""",
+            JsonSerializer.Serialize(
+                new UriContent("http://localhost/something", "image/png"),
+                TestJsonSerializerContext.Default.Options));
+    }
+
+    [Theory]
+    [InlineData("application/json")]
+    [InlineData("application/octet-stream")]
+    [InlineData("application/pdf")]
+    [InlineData("application/xml")]
+    [InlineData("audio/mpeg")]
+    [InlineData("audio/ogg")]
+    [InlineData("audio/wav")]
+    [InlineData("image/apng")]
+    [InlineData("image/avif")]
+    [InlineData("image/bmp")]
+    [InlineData("image/gif")]
+    [InlineData("image/jpeg")]
+    [InlineData("image/png")]
+    [InlineData("image/svg+xml")]
+    [InlineData("image/tiff")]
+    [InlineData("image/webp")]
+    [InlineData("text/css")]
+    [InlineData("text/csv")]
+    [InlineData("text/html")]
+    [InlineData("text/javascript")]
+    [InlineData("text/plain")]
+    [InlineData("text/plain;charset=UTF-8")]
+    [InlineData("text/xml")]
+    [InlineData("custom/mediatypethatdoesntexists")]
+    public void MediaType_Roundtrips(string mediaType)
+    {
+        UriContent c = new("http://localhost", mediaType);
+        Assert.Equal(mediaType, c.MediaType);
+    }
+
+    [Theory]
+    [InlineData("image/gif", "image/")]
+    [InlineData("IMAGE/JPEG", "image")]
+    [InlineData("image/vnd.microsoft.icon", "ima")]
+    [InlineData("image/svg+xml", "IMAGE/")]
+    [InlineData("image/nonexistentimagemimetype", "IMAGE")]
+    [InlineData("audio/mpeg", "aUdIo/")]
+    [InlineData("application/json", "")]
+    [InlineData("application/pdf", "application/pdf")]
+    public void HasMediaTypePrefix_ReturnsTrue(string mediaType, string prefix)
+    {
+        UriContent content = new("http://localhost", mediaType);
+        Assert.True(content.MediaTypeStartsWith(prefix));
+    }
+
+    [Theory]
+    [InlineData("audio/mpeg", "image/")]
+    [InlineData("text/css", "text/csv")]
+    [InlineData("text/css", "/csv")]
+    [InlineData("application/json", "application/json!")]
+    public void HasMediaTypePrefix_ReturnsFalse(string mediaType, string prefix)
+    {
+        UriContent content = new("http://localhost", mediaType);
+        Assert.False(content.MediaTypeStartsWith(prefix));
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/UriContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/UriContentTests.cs
@@ -103,28 +103,28 @@ public sealed class UriContentTests
     }
 
     [Theory]
-    [InlineData("image/gif", "image/")]
+    [InlineData("image/gif", "image")]
     [InlineData("IMAGE/JPEG", "image")]
-    [InlineData("image/vnd.microsoft.icon", "ima")]
-    [InlineData("image/svg+xml", "IMAGE/")]
+    [InlineData("image/vnd.microsoft.icon", "imAge")]
+    [InlineData("image/svg+xml", "IMAGE")]
     [InlineData("image/nonexistentimagemimetype", "IMAGE")]
-    [InlineData("audio/mpeg", "aUdIo/")]
-    [InlineData("application/json", "")]
-    [InlineData("application/pdf", "application/pdf")]
+    [InlineData("audio/mpeg", "aUdIo")]
     public void HasMediaTypePrefix_ReturnsTrue(string mediaType, string prefix)
     {
-        UriContent content = new("http://localhost", mediaType);
-        Assert.True(content.MediaTypeStartsWith(prefix));
+        var content = new UriContent("http://localhost", mediaType);
+        Assert.True(content.HasTopLevelMediaType(prefix));
     }
 
     [Theory]
-    [InlineData("audio/mpeg", "image/")]
+    [InlineData("audio/mpeg", "audio/")]
+    [InlineData("audio/mpeg", "image")]
+    [InlineData("audio/mpeg", "audio/mpeg")]
     [InlineData("text/css", "text/csv")]
     [InlineData("text/css", "/csv")]
     [InlineData("application/json", "application/json!")]
     public void HasMediaTypePrefix_ReturnsFalse(string mediaType, string prefix)
     {
-        UriContent content = new("http://localhost", mediaType);
-        Assert.False(content.MediaTypeStartsWith(prefix));
+        var content = new UriContent("http://localhost", mediaType);
+        Assert.False(content.HasTopLevelMediaType(prefix));
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Embeddings/EmbeddingGeneratorExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Embeddings/EmbeddingGeneratorExtensionsTests.cs
@@ -14,15 +14,12 @@ public class EmbeddingGeneratorExtensionsTests
     public void GetService_InvalidArgs_Throws()
     {
         Assert.Throws<ArgumentNullException>("generator", () => EmbeddingGeneratorExtensions.GetService<object>(null!));
-        Assert.Throws<ArgumentNullException>("generator", () => EmbeddingGeneratorExtensions.GetService<string, Embedding<double>, object>(null!));
     }
 
     [Fact]
     public void GetRequiredService_InvalidArgs_Throws()
     {
         Assert.Throws<ArgumentNullException>("generator", () => EmbeddingGeneratorExtensions.GetRequiredService<object>(null!));
-        Assert.Throws<ArgumentNullException>("generator", () => EmbeddingGeneratorExtensions.GetRequiredService<string, Embedding<double>>(null!, typeof(string)));
-        Assert.Throws<ArgumentNullException>("generator", () => EmbeddingGeneratorExtensions.GetRequiredService<string, Embedding<double>, object>(null!));
 
         using var generator = new TestEmbeddingGenerator();
         Assert.Throws<ArgumentNullException>("serviceType", () => generator.GetRequiredService(null!));
@@ -51,41 +48,31 @@ public class EmbeddingGeneratorExtensionsTests
 
         Assert.Equal("null key", generator.GetService(typeof(string)));
         Assert.Equal("null key", generator.GetService<string>());
-        Assert.Equal("null key", generator.GetService<string, Embedding<float>, string>());
 
         Assert.Equal("non-null key", generator.GetService(typeof(string), "key"));
         Assert.Equal("non-null key", generator.GetService<string>("key"));
-        Assert.Equal("non-null key", generator.GetService<string, Embedding<float>, string>("key"));
 
         Assert.Null(generator.GetService(typeof(object)));
         Assert.Null(generator.GetService<object>());
-        Assert.Null(generator.GetService<string, Embedding<float>, object>());
 
         Assert.Null(generator.GetService(typeof(object), "key"));
         Assert.Null(generator.GetService<object>("key"));
-        Assert.Null(generator.GetService<string, Embedding<float>, object>("key"));
 
         Assert.Null(generator.GetService<int?>());
-        Assert.Null(generator.GetService<string, Embedding<float>, int?>());
 
         Assert.Equal("null key", generator.GetRequiredService(typeof(string)));
         Assert.Equal("null key", generator.GetRequiredService<string>());
-        Assert.Equal("null key", generator.GetRequiredService<string, Embedding<float>, string>());
 
         Assert.Equal("non-null key", generator.GetRequiredService(typeof(string), "key"));
         Assert.Equal("non-null key", generator.GetRequiredService<string>("key"));
-        Assert.Equal("non-null key", generator.GetRequiredService<string, Embedding<float>, string>("key"));
 
         Assert.Throws<InvalidOperationException>(() => generator.GetRequiredService(typeof(object)));
         Assert.Throws<InvalidOperationException>(() => generator.GetRequiredService<object>());
-        Assert.Throws<InvalidOperationException>(() => generator.GetRequiredService<string, Embedding<float>, object>());
 
         Assert.Throws<InvalidOperationException>(() => generator.GetRequiredService(typeof(object), "key"));
         Assert.Throws<InvalidOperationException>(() => generator.GetRequiredService<object>("key"));
-        Assert.Throws<InvalidOperationException>(() => generator.GetRequiredService<string, Embedding<float>, object>("key"));
 
         Assert.Throws<InvalidOperationException>(() => generator.GetRequiredService<int?>());
-        Assert.Throws<InvalidOperationException>(() => generator.GetRequiredService<string, Embedding<float>, int?>());
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
@@ -615,7 +615,7 @@ public class AzureAIInferenceChatClientTests
         Assert.NotNull(await client.GetResponseAsync([new(ChatRole.User,
         [
             new TextContent("Describe this picture."),
-            new DataContent("http://dot.net/someimage.png", mediaType: "image/png"),
+            new UriContent("http://dot.net/someimage.png", mediaType: "image/*"),
         ])]));
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientStructuredOutputExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientStructuredOutputExtensionsTests.cs
@@ -149,7 +149,7 @@ public class ChatClientStructuredOutputExtensionsTests
     [Fact]
     public async Task FailureUsage_NoJsonInResponse()
     {
-        var expectedResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, [new DataContent("https://example.com")]));
+        var expectedResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, [new UriContent("https://example.com", "image/*")]));
         using var client = new TestChatClient
         {
             GetResponseAsyncCallback = (messages, options, cancellationToken) => Task.FromResult(expectedResponse),


### PR DESCRIPTION
Necessary, according to @roji:
- Adds a non-generic IEmbeddingGenerator, with GetService then moving down to the non-generic from the generic. This also simplifies the GetService/GetRequiredService extension methods, which no longer need to be generic on TInput/TEmbedding.

Optional (we should discuss which of these we actually want to take):
- Deletes GeneratedEmbeddings and makes GenerateAsync return an `IAsyncEnumerable<TEmbedding>` instead of `GeneratedEmbeddings<TEmbedding>`. The positive aspect of this is it allows for embeddings to be streamed as they're generated (though the main embedding generation services today don't stream), and also enables TEmbedding to be covariant (though it's not clear how much benefit that actually yields). The negative is we lose a place to hang metadata that's about the whole batch, in particular usage data. This moves that usage data to instead be on the Embedding, which is helpful for cases where such information is available per embedding, but isn't ideal for cases where it's about the whole batch. This PR deals with that by just putting such information onto one of the generated embeddings. We'll need to discuss the tradeoff. The alternative is we keep GeneratedEmbeddings but make it an IAsyncEnumerable instead of an IList. That gives a place to hang such batch information, but only if it's all available at the start of the streaming; however, it's also a bit harder to consume, as you need to await the initial call and then await foreach the embeddings.
- Adds a SupportedInputMediaTypes set to EmbeddingGeneratorMetadata, so that a generator can be explicit about what inputs it supports.
- Adds an optional MediaType parameter to TextContent. This would allow, for example, tagging code by language. 
- Makes the DataContent's ReadOnlyMemory constructor require a media type to be supplied. Ideally we'd also require this for non-data urls, but that's a bit trickier, as we can't distinguish between data and non-data urls in the type system. We could check for it dynamically. (This one wasn't actually mentioned by @roji.)

Not addressed:
- Removing IDisposable from IEmbeddingGenerator (and IChatClient), or adding IAsyncDisposable. Not having these implementations makes middleware awkward, as all middleware components need to expose the interface. It also makes it harder to know you might need to dispose the result of a method like AsEmbeddingGenerator. To my knowledge, we don't know of cases where async disposal is necessary.
- Add back a Metadata property. I still think `GetService<EmbeddingGeneratorMetadata>()` is sufficient, but we can discuss it further. We might want to consider an analyzer that would make diagnostic suggestions about supporting it in GetService and filling in as much data as possible.
- Splitting off a UrlContent from DataContent, to differentiate in a strongly typed way cases where data is included or not.

cc: @roji, @SteveSandersonMS 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6058)