### PR TITLE
Automatically add 'untriaged' label to new issues without milestones

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -215,8 +215,6 @@ configuration:
             action: Closed
       then:
       - removeLabel:
-          label: untriaged
-      - removeLabel:
           label: 'work in progress :construction:'
       - removeLabel:
           label: 'waiting-author-feedback :mailbox_with_no_mail:'

--- a/.github/policies/untriaged.yml
+++ b/.github/policies/untriaged.yml
@@ -1,0 +1,36 @@
+id: untriaged
+name: Automatically apply and remove the untriaged label
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+    - description: Add untriaged label to new/reopened issues without a milestone
+      if:
+      - payloadType: Issues
+      - or:
+        - isAction:
+            action: Opened
+        - isAction:
+            action: Reopened
+      - isOpen
+      - not: isPartOfAnyMilestone
+      - not:
+          hasLabel:
+            label: untriaged
+      then:
+      - addLabel:
+          label: untriaged
+
+    - description: Remove untriaged label from closed issues
+      if:
+      - payloadType: Issues
+      - hasLabel:
+          label: untriaged
+      - or:
+        - isAction:
+            action: Closed
+      then:
+      - removeLabel:
+          label: untriaged


### PR DESCRIPTION
@joperezr This would be helpful for us as we track MEAI issues coming in, but I wasn't sure if you'd want it applied to all issues.

If you would prefer not to enable this across the repo, I could change it so that it reacts to when an issue gets the `area-ai` or `area-ai-templates` label and only apply `untriaged` to those.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6060)