### PR TITLE
Fix evaluation report generation

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/EvalTypes.d.ts
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/EvalTypes.d.ts
@@ -13,9 +13,13 @@ type ScenarioRunResult = {
     executionName: string;
     creationTime?: string;
     messages: ChatMessage[];
-    modelResponse: ChatMessage;
+    modelResponse: ChatResponse;
     evaluationResult: EvaluationResult;
 };
+
+type ChatResponse = {
+    messages: ChatMessage[];
+}
 
 type ChatMessage = {
     authorName?: string;

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/Summary.ts
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/Summary.ts
@@ -145,7 +145,7 @@ const isTextContent = (content: AIContent): content is TextContent => {
     return (content as TextContent).text !== undefined;
 };
 
-export const getPromptDetails = (messages: ChatMessage[], modelResponse?: ChatMessage): {history:string, response: string}=> {
+export const getPromptDetails = (messages: ChatMessage[], modelResponse?: ChatResponse): {history:string, response: string}=> {
     let history: string = "";
     if (messages.length === 1) {
         history = messages[0].contents.map(c => (c as TextContent).text).join("\n");
@@ -163,7 +163,7 @@ export const getPromptDetails = (messages: ChatMessage[], modelResponse?: ChatMe
         history = historyItems.join("\n\n");
     }
 
-    const response: string = modelResponse?.contents.map(c => (c as TextContent).text).join("\n") ?? "";
+    const response: string = modelResponse?.messages.map(m => m.contents.map(c => (c as TextContent).text).join("\n") ?? "").join("\n") ?? "";
 
     return { history, response };
 };


### PR DESCRIPTION
The .NET side code for the `ScenarioRunResult` was recently changed (#5998) to include `ChatResponse` (which can contain multiple `ChatMessage`s) in place of a single `ChatMessage`. Unfortunately, we missed updating the TypeScript reporting code to account for this.

This change fixes the problem by updating the deserialization code in TypeScript to match what .NET code serializes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6061)