### PR TITLE
[AI Evaluation] Add versioning to reporting and caching

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Defaults.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Defaults.cs
@@ -30,4 +30,16 @@ public static class Defaults
     /// in the <see cref="IResponseCacheProvider"/>'s cache before they are considered expired and evicted.
     /// </summary>
     public static TimeSpan DefaultTimeToLiveForCacheEntries { get; } = TimeSpan.FromDays(14);
+
+    /// <summary>
+    /// Defines the version number for the reporting format. If and when the serialized format undergoes breaking changes, this number
+    /// will be incremented to indicate the version a report file was created with compared to the version this library will produce.
+    /// </summary>
+    public const int ReportingFormatVersion = 1;
+
+    /// <summary>
+    /// Defines an version number for the cache format. Changing this value will break the cache key and force requests
+    /// to retrieve fresh data from the source until the version is updated again.
+    /// </summary>
+    public const int CacheVersion = 1;
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Defaults.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Defaults.cs
@@ -32,8 +32,8 @@ public static class Defaults
     public static TimeSpan DefaultTimeToLiveForCacheEntries { get; } = TimeSpan.FromDays(14);
 
     /// <summary>
-    /// Defines the version number for the reporting format. If and when the serialized format undergoes breaking changes, this number
-    /// will be incremented to indicate the version a report file was created with compared to the version this library will produce.
+    /// Defines the version number for the reporting format. If and when the serialized format undergoes
+    /// breaking changes, this number will be incremented.
     /// </summary>
-    public const int ReportingFormatVersion = 1;
+    internal const int ReportingFormatVersion = 1;
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Defaults.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Defaults.cs
@@ -37,9 +37,4 @@ public static class Defaults
     /// </summary>
     public const int ReportingFormatVersion = 1;
 
-    /// <summary>
-    /// Defines an version number for the cache format. Changing this value will break the cache key and force requests
-    /// to retrieve fresh data from the source until the version is updated again.
-    /// </summary>
-    public const int CacheVersion = 1;
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Defaults.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Defaults.cs
@@ -36,5 +36,4 @@ public static class Defaults
     /// will be incremented to indicate the version a report file was created with compared to the version this library will produce.
     /// </summary>
     public const int ReportingFormatVersion = 1;
-
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ResponseCachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ResponseCachingChatClient.cs
@@ -37,6 +37,6 @@ public sealed class ResponseCachingChatClient : DistributedCachingChatClient
 
     /// <inheritdoc/>
     protected override string GetCacheKey(params ReadOnlySpan<object?> values)
-        => base.GetCacheKey([.. values, .. _cachingKeys]);
+        => base.GetCacheKey([Defaults.CacheVersion, .. values, .. _cachingKeys]);
 
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ResponseCachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ResponseCachingChatClient.cs
@@ -37,6 +37,6 @@ public sealed class ResponseCachingChatClient : DistributedCachingChatClient
 
     /// <inheritdoc/>
     protected override string GetCacheKey(params ReadOnlySpan<object?> values)
-        => base.GetCacheKey([Defaults.CacheVersion, .. values, .. _cachingKeys]);
+        => base.GetCacheKey([.. values, .. _cachingKeys]);
 
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
@@ -86,7 +86,7 @@ public sealed class ScenarioRunResult(
     /// <summary>
     /// Gets or sets the Version of the format used to persist this scenario run. You should not modify this value from the default.
     /// </summary>
-    public int FormatVersion { get; init; } = formatVersion;
+    public int FormatVersion { get; set; } = formatVersion;
 
     /// <summary>
     /// Gets or sets the <see cref="ScenarioRun.ScenarioName"/>.

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
@@ -84,9 +84,9 @@ public sealed class ScenarioRunResult(
     }
 
     /// <summary>
-    /// Gets or sets the version of the format used to persist the current <see cref="ScenarioRunResult"/>.
+    /// Gets the version of the format used to persist the current <see cref="ScenarioRunResult"/>.
     /// </summary>
-    public int? FormatVersion { get; set; } = formatVersion ?? Defaults.ReportingFormatVersion;
+    public int? FormatVersion { get; } = formatVersion ?? Defaults.ReportingFormatVersion;
 
     /// <summary>
     /// Gets or sets the <see cref="ScenarioRun.ScenarioName"/>.

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.AI.Evaluation.Reporting;
 /// The <see cref="Evaluation.EvaluationResult"/> for the <see cref="ScenarioRun"/> corresponding to the
 /// <see cref="ScenarioRunResult"/> being constructed.
 /// </param>
-/// <param name="formatVersion">The version of the format used to persist this scenario run.</param>
+/// <param name="formatVersion">The version of the format used to persist the current <see cref="ScenarioRunResult"/>.</param>
 [method: JsonConstructor]
 public sealed class ScenarioRunResult(
     string scenarioName,
@@ -47,7 +47,7 @@ public sealed class ScenarioRunResult(
     IList<ChatMessage> messages,
     ChatResponse modelResponse,
     EvaluationResult evaluationResult,
-    int formatVersion = Defaults.ReportingFormatVersion)
+    int? formatVersion = null)
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ScenarioRunResult"/> class.
@@ -84,9 +84,9 @@ public sealed class ScenarioRunResult(
     }
 
     /// <summary>
-    /// Gets or sets the Version of the format used to persist this scenario run. You should not modify this value from the default.
+    /// Gets or sets the version of the format used to persist the current <see cref="ScenarioRunResult"/>.
     /// </summary>
-    public int FormatVersion { get; set; } = formatVersion;
+    public int? FormatVersion { get; set; } = formatVersion ?? Defaults.ReportingFormatVersion;
 
     /// <summary>
     /// Gets or sets the <see cref="ScenarioRun.ScenarioName"/>.

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
@@ -86,7 +86,7 @@ public sealed class ScenarioRunResult(
     /// <summary>
     /// Gets or sets the Version of the format used to persist this scenario run. You should not modify this value from the default.
     /// </summary>
-    public int FormatVersion { get; set; } = formatVersion;
+    public int FormatVersion { get; init; } = formatVersion;
 
     /// <summary>
     /// Gets or sets the <see cref="ScenarioRun.ScenarioName"/>.

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Extensions.AI.Evaluation.Reporting;
 /// The <see cref="Evaluation.EvaluationResult"/> for the <see cref="ScenarioRun"/> corresponding to the
 /// <see cref="ScenarioRunResult"/> being constructed.
 /// </param>
+/// <param name="formatVersion">The version of the format used to persist this scenario run.</param>
 [method: JsonConstructor]
 public sealed class ScenarioRunResult(
     string scenarioName,
@@ -45,7 +46,8 @@ public sealed class ScenarioRunResult(
     DateTime creationTime,
     IList<ChatMessage> messages,
     ChatResponse modelResponse,
-    EvaluationResult evaluationResult)
+    EvaluationResult evaluationResult,
+    int formatVersion = Defaults.ReportingFormatVersion)
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ScenarioRunResult"/> class.
@@ -80,6 +82,11 @@ public sealed class ScenarioRunResult(
                 evaluationResult)
     {
     }
+
+    /// <summary>
+    /// Gets or sets the Version of the format used to persist this scenario run. You should not modify this value from the default.
+    /// </summary>
+    public int FormatVersion { get; set; } = formatVersion;
 
     /// <summary>
     /// Gets or sets the <see cref="ScenarioRun.ScenarioName"/>.

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
@@ -107,7 +107,7 @@ public class DistributedCachingChatClient : CachingChatClient
     /// The generated cache key is not guaranteed to be stable across releases of the library.
     /// </para>
     /// </remarks>
-    protected override string GetCacheKey(params ReadOnlySpan<object?> values) 
+    protected override string GetCacheKey(params ReadOnlySpan<object?> values)
     {
         // Bump the cache version to invalidate existing caches if the serialization format changes in a breaking way.
         const int CacheVersion = 1;

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
@@ -107,6 +107,11 @@ public class DistributedCachingChatClient : CachingChatClient
     /// The generated cache key is not guaranteed to be stable across releases of the library.
     /// </para>
     /// </remarks>
-    protected override string GetCacheKey(params ReadOnlySpan<object?> values) =>
-        AIJsonUtilities.HashDataToString(values, _jsonSerializerOptions);
+    protected override string GetCacheKey(params ReadOnlySpan<object?> values) 
+    {
+        // Bump the cache version to invalidate existing caches if the serialization format changes in a breaking way.
+        const int CacheVersion = 1;
+
+        return AIJsonUtilities.HashDataToString([CacheVersion, .. values], _jsonSerializerOptions);
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ScenarioRunResultTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ScenarioRunResultTests.cs
@@ -38,6 +38,7 @@ public class ScenarioRunResultTests
             messages: [new ChatMessage(ChatRole.User, "prompt")],
             modelResponse: new ChatResponse(new ChatMessage(ChatRole.Assistant, "response")),
             evaluationResult: new EvaluationResult(booleanMetric, numericMetric, stringMetric, metricWithNoValue));
+        Assert.Equal(Defaults.ReportingFormatVersion, entry.FormatVersion);
 
         string json = JsonSerializer.Serialize(entry, SerializerContext.Default.ScenarioRunResult);
         ScenarioRunResult? deserialized = JsonSerializer.Deserialize<ScenarioRunResult>(json, SerializerContext.Default.ScenarioRunResult);
@@ -49,6 +50,7 @@ public class ScenarioRunResultTests
         Assert.Equal(entry.CreationTime, deserialized.CreationTime);
         Assert.True(entry.Messages.SequenceEqual(deserialized.Messages, ChatMessageComparer.Instance));
         Assert.Equal(entry.ModelResponse, deserialized.ModelResponse, ChatResponseComparer.Instance);
+        Assert.Equal(entry.FormatVersion, deserialized.FormatVersion);
 
         ValidateEquivalence(entry.EvaluationResult, deserialized.EvaluationResult);
     }


### PR DESCRIPTION
These are basically independent escape mechanisms to handle future changes in formats.

`ReportFormatVersion` - Will record which version of the format was used to persist the scenario run, as well as exposing which version the current library will write. This should allow us to convert/adapt to reporting format changes in the future if needed.

`CacheVersion` - Will change all the caching keys causing the existing cache entries to be no longer valid. @stephentoub @SteveSandersonMS 

Hopefully neither of these will ever be needed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6070)