### PR TITLE
Fix handling of empty messages in AzureAIInferenceChatClient

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
@@ -449,9 +449,20 @@ public sealed class AzureAIInferenceChatClient : IChatClient
             }
             else if (input.Role == ChatRole.User)
             {
-                yield return input.Contents.All(c => c is TextContent) ?
-                    new ChatRequestUserMessage(string.Concat(input.Contents)) :
-                    new ChatRequestUserMessage(GetContentParts(input.Contents));
+                if (input.Contents.Count > 0)
+                {
+                    if (input.Contents.All(c => c is TextContent))
+                    {
+                        if (string.Concat(input.Contents) is { Length: > 0 } text)
+                        {
+                            yield return new ChatRequestUserMessage(text);
+                        }
+                    }
+                    else if (GetContentParts(input.Contents) is { Count: > 0 } parts)
+                    {
+                        yield return new ChatRequestUserMessage(parts);
+                    }
+                }
             }
             else if (input.Role == ChatRole.Assistant)
             {

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
@@ -71,6 +71,20 @@ public abstract class ChatClientIntegrationTests : IDisposable
     }
 
     [ConditionalFact]
+    public virtual async Task GetResponseAsync_WithEmptyMessage()
+    {
+        SkipIfNotEnabled();
+
+        var response = await _chatClient.GetResponseAsync(
+        [
+            new(ChatRole.User, []),
+            new(ChatRole.User, "What is 1 + 2? Reply with a single number."),
+        ]);
+
+        Assert.Contains("3", response.Text);
+    }
+
+    [ConditionalFact]
     public virtual async Task GetStreamingResponseAsync()
     {
         SkipIfNotEnabled();


### PR DESCRIPTION
ChatRequestUserMessage's ctor doesn't like it when it's constructed from an empty list.

Closes https://github.com/dotnet/extensions/issues/6055