### PR TITLE
Fix grouping of ChatResponseUpdate into ChatMessage

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
@@ -171,7 +171,7 @@ public static class ChatResponseExtensions
         // response ID than the newest update, create a new message.
         ChatMessage message;
         if (response.Messages.Count == 0 ||
-            (update.ResponseId is string updateId && response.ResponseId is string responseId && updateId != responseId))
+            (update.ResponseId is { Length: > 0 } updateId && response.ResponseId is string responseId && updateId != responseId))
         {
             message = new ChatMessage(ChatRole.Assistant, []);
             response.Messages.Add(message);
@@ -213,7 +213,7 @@ public static class ChatResponseExtensions
         // Other members on a ChatResponseUpdate map to members of the ChatResponse.
         // Update the response object with those, preferring the values from later updates.
 
-        if (update.ResponseId is not null)
+        if (update.ResponseId is { Length: > 0 })
         {
             // Note that this must come after the message checks earlier, as they depend
             // on this value for change detection.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseUpdate.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseUpdate.cs
@@ -99,6 +99,12 @@ public class ChatResponseUpdate
     public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
 
     /// <summary>Gets or sets the ID of the response of which this update is a part.</summary>
+    /// <remarks>
+    /// This value is used when <see cref="ChatResponseExtensions.ToChatResponseAsync(IAsyncEnumerable{ChatResponseUpdate}, System.Threading.CancellationToken)"/>
+    /// groups <see cref="ChatResponseUpdate"/> instances into <see cref="ChatMessage"/> instances.
+    /// The value must be unique to each call to the underlying provider, and must be shared by
+    /// all updates that are part of the same response.
+    /// </remarks>
     public string? ResponseId { get; set; }
 
     /// <summary>Gets or sets the chat thread ID associated with the chat response of which this update is a part.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
@@ -132,6 +132,9 @@ public sealed class OllamaChatClient : IChatClient
             await OllamaUtilities.ThrowUnsuccessfulOllamaResponseAsync(httpResponse, cancellationToken).ConfigureAwait(false);
         }
 
+        // Ollama doesn't set a response ID on streamed chunks, so we need to generate one.
+        var responseId = Guid.NewGuid().ToString("N");
+
         using var httpResponseStream = await httpResponse.Content
 #if NET
             .ReadAsStreamAsync(cancellationToken)
@@ -160,7 +163,7 @@ public sealed class OllamaChatClient : IChatClient
                 CreatedAt = DateTimeOffset.TryParse(chunk.CreatedAt, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset createdAt) ? createdAt : null,
                 FinishReason = ToFinishReason(chunk),
                 ModelId = modelId,
-                ResponseId = chunk.CreatedAt,
+                ResponseId = responseId,
                 Role = chunk.Message?.Role is not null ? new ChatRole(chunk.Message.Role) : null,
             };
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
@@ -51,7 +51,7 @@ public class ChatResponseUpdateExtensionsTests
 
         Assert.Equal("123", response.ChatThreadId);
 
-        ChatMessage message = response.Messages.Last();
+        ChatMessage message = response.Messages.Single();
         Assert.Equal(new ChatRole("human"), message.Role);
         Assert.Equal("Someone", message.AuthorName);
         Assert.Null(message.AdditionalProperties);

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
@@ -130,6 +130,25 @@ public abstract class ChatClientIntegrationTests : IDisposable
         Assert.Equal(usage.Details.InputTokenCount + usage.Details.OutputTokenCount, usage.Details.TotalTokenCount);
     }
 
+    [ConditionalFact]
+    public virtual async Task GetStreamingResponseAsync_AppendToHistory()
+    {
+        SkipIfNotEnabled();
+
+        List<ChatMessage> history = [new(ChatRole.User, "Explain in 100 words how AI works")];
+
+        var streamingResponse = _chatClient.GetStreamingResponseAsync(history);
+
+        Assert.Single(history);
+        await history.AddMessagesAsync(streamingResponse);
+        Assert.Equal(2, history.Count);
+        Assert.Equal(ChatRole.Assistant, history[1].Role);
+
+        var singleTextContent = (TextContent)history[1].Contents.Single();
+        Assert.NotEmpty(singleTextContent.Text);
+        Assert.Equal(history[1].Text, singleTextContent.Text);
+    }
+
     protected virtual string? GetModel_MultiModal_DescribeImage() => null;
 
     [ConditionalFact]

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientTests.cs
@@ -171,11 +171,12 @@ public class OllamaChatClientTests
         using IChatClient client = new OllamaChatClient("http://localhost:11434", "llama3.1", httpClient);
 
         List<ChatResponseUpdate> updates = [];
-        await foreach (var update in client.GetStreamingResponseAsync("hello", new()
+        var streamingResponse = client.GetStreamingResponseAsync("hello", new()
         {
             MaxOutputTokens = 20,
             Temperature = 0.5f,
-        }))
+        });
+        await foreach (var update in streamingResponse)
         {
             updates.Add(update);
         }
@@ -201,6 +202,10 @@ public class OllamaChatClientTests
         Assert.Equal(11, usage.Details.InputTokenCount);
         Assert.Equal(20, usage.Details.OutputTokenCount);
         Assert.Equal(31, usage.Details.TotalTokenCount);
+
+        var chatResponse = await streamingResponse.ToChatResponseAsync();
+        Assert.Single(Assert.Single(chatResponse.Messages).Contents);
+        Assert.Equal("Hello! How are you today? Is there something I can help you with or would you like to", chatResponse.Text);
     }
 
     [Fact]


### PR DESCRIPTION
For Ollama, it was broken because it set a new ResponseId for every chunk. It now correctly sets per-response IDs.

For OpenAI, it had a minor issue with handling empty-string ResponseId values. It now treats this case as equivalent to null ResponseId values, and thereby avoids introducing extra blank messages.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6074)