### PR TITLE
Update ordering in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,10 +18,11 @@
 /eng/                                                                       @dotnet/dotnet-extensions-infra
 
 /src/Libraries/Microsoft.Extensions.AI                                      @dotnet/dotnet-extensions-ai
-/src/Libraries/Microsoft.Extensions.AI.Evaluation                           @dotnet/dotnet-extensions-ai-evaluation
 /src/Libraries/Microsoft.Extensions.AI.*                                    @dotnet/dotnet-extensions-ai
-/src/Libraries/Microsoft.Extensions.AI.Evaluation.*                         @dotnet/dotnet-extensions-ai-evaluation
 /test/Libraries/Microsoft.Extensions.AI.*                                   @dotnet/dotnet-extensions-ai
+
+/src/Libraries/Microsoft.Extensions.AI.Evaluation                           @dotnet/dotnet-extensions-ai-evaluation
+/src/Libraries/Microsoft.Extensions.AI.Evaluation.*                         @dotnet/dotnet-extensions-ai-evaluation
 /test/Libraries/Microsoft.Extensions.AI.Evaluation.*                        @dotnet/dotnet-extensions-ai-evaluation
 
 /src/Libraries/Microsoft.Extensions.Caching.Hybrid                          @dotnet/dotnet-extensions-caching-hybrid


### PR DESCRIPTION
Place the rules for MEAI.Evaluation after MEAI since the last matching pattern always takes most precedence. (Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file)

I was seeing that `@dotnet/dotnet-extensions-ai` was being included as a reviewer for changes in the `/src/Libraries/Microsoft.Extensions.AI.Evaluation` folder. I think this was happening because the rule for this folder appeared *before* the rule for `/src/Libraries/Microsoft.Extensions.AI.*` in the CODEOWNERS file, and because the last matching pattern always takes precedence.

The order change should hopefully remedy this and ensure that only `@dotnet/dotnet-extensions-ai-evaluation` is included as a reviewer for changes in the `/src/Libraries/Microsoft.Extensions.AI.Evaluation` folder.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6085)