### PR TITLE
Fix tree expansion in evaluation report

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/ScenarioTree.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/ScenarioTree.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState, useCallback } from "react";
 import { makeStyles, tokens, Tree, TreeItem, TreeItemLayout, TreeItemValue, TreeOpenChangeData, TreeOpenChangeEvent, mergeClasses } from "@fluentui/react-components";
-import { DefaultRootNodeName, ScoreNode, ScoreNodeType, getPromptDetails, ChatMessageDisplay } from "./Summary";
+import { ScoreNode, ScoreNodeType, getPromptDetails, ChatMessageDisplay } from "./Summary";
 import { PassFailBar } from "./PassFailBar";
 import { MetricCardList, type MetricType } from "./MetricCard";
 import ReactMarkdown from "react-markdown";
@@ -16,7 +16,6 @@ const ScenarioLevel = ({ node, parentPath, isOpen, renderMarkdown }: {
   isOpen: (path: string) => boolean, 
   renderMarkdown: boolean,
 }) => {
-    node.collapseSingleChildNodes();
     const path = `${parentPath}.${node.name}`;
     if (node.isLeafNode) {
         return <TreeItem itemType="branch" value={path}>
@@ -53,7 +52,7 @@ export const ScenarioGroup = ({ node, renderMarkdown }: { node: ScoreNode, rende
     const isOpen = (name: string) => openItems.has(name);
 
     return (
-        <Tree aria-label="Default" appearance="transparent" onOpenChange={handleOpenChange} defaultOpenItems={["." + DefaultRootNodeName]}>
+        <Tree aria-label="Default" appearance="transparent" onOpenChange={handleOpenChange} defaultOpenItems={["." + node.name]}>
             <ScenarioLevel node={node} parentPath={""} isOpen={isOpen} renderMarkdown={renderMarkdown} />
         </Tree>);        
 };

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/Summary.ts
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/Summary.ts
@@ -150,8 +150,8 @@ const shortenPrompt = (prompt: string | undefined) => {
     return prompt;
 };
 
-function* flattener(node: ScoreNode, parentKey: string): Iterable<{key: string, node: ScoreNode}> {
-    const key= `${parentKey}.${node.name}`;
+const flattener = function* (node: ScoreNode, parentKey: string): Iterable<{key: string, node: ScoreNode}> {
+    const key = `${parentKey}.${node.name}`;
     if (node.isLeafNode) {
         yield {key, node};
     } else {
@@ -160,7 +160,7 @@ function* flattener(node: ScoreNode, parentKey: string): Iterable<{key: string, 
             yield* flattener(child, key);
         }
     }
-}
+};
 
 const isTextContent = (content: AIContent): content is TextContent => {
     return (content as TextContent).text !== undefined;

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/Summary.ts
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/Summary.ts
@@ -129,14 +129,13 @@ export class ScoreNode {
     }
 };
 
-export const DefaultRootNodeName = "All Evaluations";
-
 export const createScoreTree = (dataset: Dataset): ScoreNode => {
-    const root = new ScoreNode(DefaultRootNodeName, ScoreNodeType.Group);
+    const root = new ScoreNode("All Evaluations", ScoreNodeType.Group);
     for (const scenario of dataset.scenarioRunResults) {
         const path = [...scenario.scenarioName.split('.'), scenario.iterationName];
         root.insertNode(path, scenario);
     }
+    root.collapseSingleChildNodes();
     root.aggregate();
     return root;
 };

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/html-report/init-devdata.js
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/html-report/init-devdata.js
@@ -5,10 +5,16 @@ import fs from 'fs/promises';
 import path from 'path';
 import {fileURLToPath} from 'url';
 
+const storagePath = process.argv[2];
+if (!storagePath) {
+    console.error('Usage: node init-devdata.js <storagePath>');
+    process.exit(1);
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const resultsDir = path.join(__dirname, '../../../.storage/results');
+const resultsDir = path.join(storagePath, 'results');
 const scenarioDirents = await fs.readdir(resultsDir, { withFileTypes: true });
 
 let maxBirthtime = 0;


### PR DESCRIPTION
The fix ensures that the root level of the scenario tree is expanded by default when the report is opened.

Also includes a change to ensure that we collapse single child nodes once right after the tree is constructed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6107)