### PR TITLE
Update OllamaSharp to 5.1.5, MEAI to 9.3.0-preview.1.25161.3, and EF.Sqlite to 9.0.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -139,7 +139,7 @@
     <AzureSearchDocumentsVersion>11.6.0</AzureSearchDocumentsVersion>
     <MicrosoftSemanticKernelConnectorsAzureAISearchVersion>1.37.0-preview</MicrosoftSemanticKernelConnectorsAzureAISearchVersion>
     <MicrosoftSemanticKernelCoreVersion>1.37.0</MicrosoftSemanticKernelCoreVersion>
-    <OllamaSharpVersion>5.0.7</OllamaSharpVersion>
+    <OllamaSharpVersion>5.1.5</OllamaSharpVersion>
     <OpenAIVersion>2.2.0-beta.1</OpenAIVersion>
     <PdfPigVersion>0.1.9</PdfPigVersion>
     <SystemLinqAsyncVersion>6.0.1</SystemLinqAsyncVersion>

--- a/src/ProjectTemplates/GeneratedContent.props
+++ b/src/ProjectTemplates/GeneratedContent.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <_MicrosoftExtensionsAIVersion>9.3.0-preview.1.25114.11</_MicrosoftExtensionsAIVersion>
+    <_MicrosoftExtensionsAIVersion>9.3.0-preview.1.25161.3</_MicrosoftExtensionsAIVersion>
 
     <!-- Specify package version variables used in template content. -->
     <GeneratedContentProperties>

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/ChatWithCustomData.Web-CSharp.csproj.in
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/ChatWithCustomData.Web-CSharp.csproj.in
@@ -24,7 +24,7 @@
 <!--#if (UseManagedIdentity) -->
     <PackageReference Include="Azure.Identity" Version="${AzureIdentityVersion}" />
 <!--#endif -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="${MicrosoftExtensionsAIVersion}" />
     <PackageReference Include="Microsoft.SemanticKernel.Core" Version="${MicrosoftSemanticKernelCoreVersion}" />
     <PackageReference Include="PdfPig" Version="${PdfPigVersion}" />

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
@@ -119,9 +119,6 @@
     // an extension method on IList<ChatMessage> for adding messages from a ChatResponseUpdate.
     public static void AddMessages(IList<ChatMessage> list, ChatResponseUpdate update, Func<AIContent, bool>? filter = null)
     {
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(update);
-
         var contentsList = filter is null ? update.Contents : update.Contents.Where(filter).ToList();
         if (contentsList.Count > 0)
         {

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
@@ -75,10 +75,14 @@
         var responseText = new TextContent("");
         currentResponseMessage = new ChatMessage(ChatRole.Assistant, [responseText]);
         currentResponseCancellation = new();
-        await foreach (var chunk in ChatClient.GetStreamingResponseAsync([.. messages], chatOptions, currentResponseCancellation.Token))
+
+        // Pass a copy of the messages then add messages to the list while handling the streaming responses
+        var requestMessages = messages.ToArray();
+
+        await foreach (var update in ChatClient.GetStreamingResponseAsync(requestMessages, chatOptions, currentResponseCancellation.Token))
         {
-            AddNonTextContentToConversation(chunk.Contents);
-            responseText.Text += chunk.Text;
+            AddMessages(messages, update, filter: c => c is not TextContent);
+            responseText.Text += update.Text;
             ChatMessageItem.NotifyChanged(currentResponseMessage);
         }
 
@@ -111,19 +115,22 @@
     }
 
 @*#if (!IsOllama)*@
-    private void AddNonTextContentToConversation(IList<AIContent> contents)
+    // TODO: Needed until https://github.com/dotnet/extensions/issues/6114 is resolved, which will introduce a
+    // an extension method on IList<ChatMessage> for adding messages from a ChatResponseUpdate.
+    public static void AddMessages(IList<ChatMessage> list, ChatResponseUpdate update, Func<AIContent, bool>? filter = null)
     {
-        foreach (var content in contents)
+        ArgumentNullException.ThrowIfNull(list);
+        ArgumentNullException.ThrowIfNull(update);
+
+        var contentsList = filter is null ? update.Contents : update.Contents.Where(filter).ToList();
+        if (contentsList.Count > 0)
         {
-            switch (content)
+            list.Add(new ChatMessage(update.Role ?? ChatRole.Assistant, contentsList)
             {
-                case FunctionCallContent fcc:
-                    messages.Add(new ChatMessage(ChatRole.Assistant, [fcc]));
-                    break;
-                case FunctionResultContent frc:
-                    messages.Add(new ChatMessage(ChatRole.Tool, [frc]));
-                    break;
-            }
+                AuthorName = update.AuthorName,
+                RawRepresentation = update.RawRepresentation,
+                AdditionalProperties = update.AdditionalProperties,
+            });
         }
     }
 

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
@@ -117,12 +117,12 @@
 @*#if (!IsOllama)*@
     // TODO: Needed until https://github.com/dotnet/extensions/issues/6114 is resolved, which will introduce a
     // an extension method on IList<ChatMessage> for adding messages from a ChatResponseUpdate.
-    public static void AddMessages(IList<ChatMessage> list, ChatResponseUpdate update, Func<AIContent, bool>? filter = null)
+    private static void AddMessages(IList<ChatMessage> list, ChatResponseUpdate update, Func<AIContent, bool> filter)
     {
-        var contentsList = filter is null ? update.Contents : update.Contents.Where(filter).ToList();
+        var contentsList = update.Contents.Where(filter).ToList();
         if (contentsList.Count > 0)
         {
-            list.Add(new ChatMessage(update.Role ?? ChatRole.Assistant, contentsList)
+            list.Add(new(update.Role ?? ChatRole.Assistant, contentsList)
             {
                 AuthorName = update.AuthorName,
                 RawRepresentation = update.RawRepresentation,

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
@@ -115,7 +115,7 @@
     }
 
 @*#if (!IsOllama)*@
-    // TODO: Needed until https://github.com/dotnet/extensions/issues/6114 is resolved, which will introduce a
+    // TODO: Needed until https://github.com/dotnet/extensions/issues/6114 is resolved, which will introduce
     // an extension method on IList<ChatMessage> for adding messages from a ChatResponseUpdate.
     private static void AddMessages(IList<ChatMessage> list, ChatResponseUpdate update, Func<AIContent, bool> filter)
     {

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
@@ -67,23 +67,25 @@
         // aren't supported because Ollama will not support both streaming and using Tools
         currentResponseCancellation = new();
         var response = await ChatClient.GetResponseAsync(messages, chatOptions, currentResponseCancellation.Token);
-        currentResponseMessage = response.Message;
-        ChatMessageItem.NotifyChanged(currentResponseMessage);
+
+        // Store responses in the conversation, and begin getting suggestions
+        messages.AddMessages(response);
 #else*@
         // Stream and display a new response from the IChatClient
         var responseText = new TextContent("");
         currentResponseMessage = new ChatMessage(ChatRole.Assistant, [responseText]);
         currentResponseCancellation = new();
-        await foreach (var chunk in ChatClient.GetStreamingResponseAsync(messages, chatOptions, currentResponseCancellation.Token))
+        await foreach (var chunk in ChatClient.GetStreamingResponseAsync([.. messages], chatOptions, currentResponseCancellation.Token))
         {
+            AddNonTextContentToConversation(chunk.Contents);
             responseText.Text += chunk.Text;
             ChatMessageItem.NotifyChanged(currentResponseMessage);
         }
-@*#endif*@
 
         // Store the final response in the conversation, and begin getting suggestions
         messages.Add(currentResponseMessage!);
         currentResponseMessage = null;
+@*#endif*@
         chatSuggestions?.Update(messages);
     }
 
@@ -108,6 +110,24 @@
         await chatInput!.FocusAsync();
     }
 
+@*#if (!IsOllama)*@
+    private void AddNonTextContentToConversation(IList<AIContent> contents)
+    {
+        foreach (var content in contents)
+        {
+            switch (content)
+            {
+                case FunctionCallContent fcc:
+                    messages.Add(new ChatMessage(ChatRole.Assistant, [fcc]));
+                    break;
+                case FunctionResultContent frc:
+                    messages.Add(new ChatMessage(ChatRole.Tool, [frc]));
+                    break;
+            }
+        }
+    }
+
+@*#endif*@
     [Description("Searches for information using a phrase or keyword")]
     private async Task<IEnumerable<string>> SearchAsync(
         [Description("The phrase to search for.")] string searchPhrase,


### PR DESCRIPTION
Changes extracted from [Use just-built packages in the AI chat template by default (dotnet/extensions#6096)](https://github.com/dotnet/extensions/pull/6096), including the compensating changes needed. Adds a temporary helper method for handling the streaming updates to unblock updating the template before [Add AddMessages Extension Method for IList<ChatMessage> (dotnet/extensions#6114)](https://github.com/dotnet/extensions/issues/6114).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6116)