### PR TITLE
HybridCache: richer detection for field-only types (ref STJ)

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultJsonSerializerFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultJsonSerializerFactory.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -35,7 +38,7 @@ internal sealed class DefaultJsonSerializerFactory : IHybridCacheSerializerFacto
 
         // see if there is a per-type options registered (keyed by the **closed** generic type), otherwise use the default
         JsonSerializerOptions options = _serviceProvider.GetKeyedService<JsonSerializerOptions>(typeof(IHybridCacheSerializer<T>)) ?? Options;
-        if (IsValueTuple(typeof(T)) && !options.IncludeFields)
+        if (!options.IncludeFields && IsFieldOnlyType(typeof(T)))
         {
             // value-tuples expose fields, not properties; special-case this as a common scenario
             options = FieldEnabledJsonOptions;
@@ -45,8 +48,90 @@ internal sealed class DefaultJsonSerializerFactory : IHybridCacheSerializerFacto
         return true;
     }
 
-    private static bool IsValueTuple(Type type)
-        => type.IsValueType && (type.FullName ?? string.Empty).StartsWith("System.ValueTuple`", StringComparison.Ordinal);
+    internal static bool IsFieldOnlyType(Type type)
+    {
+        Dictionary<Type, FieldOnlyResult>? state = null; // only needed for complex types
+        return IsFieldOnlyType(type, ref state) == FieldOnlyResult.FieldOnly;
+    }
+
+    [SuppressMessage("Trimming", "IL2070:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.",
+        Justification = "Custom serializers may be needed for AOT with STJ")]
+    [SuppressMessage("Performance", "CA1864:Prefer the 'IDictionary.TryAdd(TKey, TValue)' method", Justification = "Not available in all platforms")]
+    private static FieldOnlyResult IsFieldOnlyType(
+        Type type, ref Dictionary<Type, FieldOnlyResult>? state)
+    {
+        if (type is null || type.IsPrimitive || type == typeof(string))
+        {
+            return FieldOnlyResult.NotFieldOnly;
+        }
+
+        // re-use existing results, and more importantly: prevent infinite recursion
+        if (state is not null && state.TryGetValue(type, out var existingResult))
+        {
+            return existingResult;
+        }
+
+        // check for collection types; start at IEnumerable and then look for IEnumerable<T>
+        // (this is broadly comparable to STJ)
+        if (typeof(IEnumerable).IsAssignableFrom(type))
+        {
+            PrepareStateForDepth(type, ref state);
+            foreach (var iType in type.GetInterfaces())
+            {
+                if (iType.IsGenericType && iType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    if (IsFieldOnlyType(iType.GetGenericArguments()[0], ref state) == FieldOnlyResult.FieldOnly)
+                    {
+                        return SetState(type, state, true);
+                    }
+                }
+            }
+
+            // no problems detected
+            return SetState(type, state, false);
+        }
+
+        // not a collection; check for field-only scenario - look for properties first
+        var props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        if (props.Length != 0)
+        {
+            PrepareStateForDepth(type, ref state);
+            foreach (var prop in props)
+            {
+                if (IsFieldOnlyType(prop.PropertyType, ref state) == FieldOnlyResult.FieldOnly)
+                {
+                    return SetState(type, state, true);
+                }
+            }
+
+            // then we *do* have public instance properties, that aren't themselves problems; we're good
+            return SetState(type, state, false);
+        }
+
+        // no properties; if there are fields, this is the problem scenario we're trying to detect
+        var haveFields = type.GetFields(BindingFlags.Public | BindingFlags.Instance).Length != 0;
+        return SetState(type, state, haveFields);
+
+        static void PrepareStateForDepth(Type type, ref Dictionary<Type, FieldOnlyResult>? state)
+        {
+            state ??= [];
+            if (!state.ContainsKey(type))
+            {
+                state.Add(type, FieldOnlyResult.Incomplete);
+            }
+        }
+
+        static FieldOnlyResult SetState(Type type, Dictionary<Type, FieldOnlyResult>? state, bool result)
+        {
+            var value = result ? FieldOnlyResult.FieldOnly : FieldOnlyResult.NotFieldOnly;
+            if (state is not null)
+            {
+                state[type] = value;
+            }
+
+            return value;
+        }
+    }
 
     internal sealed class DefaultJsonSerializer<T> : IHybridCacheSerializer<T>
     {
@@ -76,4 +161,11 @@ internal sealed class DefaultJsonSerializerFactory : IHybridCacheSerializerFacto
 #pragma warning restore IDE0079
     }
 
+    // used to store intermediate state when calculating IsFieldOnlyType
+    private enum FieldOnlyResult
+    {
+        Incomplete = 0,
+        FieldOnly = 1,
+        NotFieldOnly = 2,
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SerializerTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SerializerTests.cs
@@ -81,9 +81,9 @@ public class SerializerTests
 
     [Theory]
     [InlineData(JsonSerializer.None, JsonSerializer.FieldEnabled)]
-    [InlineData(JsonSerializer.CustomGlobal, JsonSerializer.FieldEnabled)]
-    [InlineData(JsonSerializer.CustomPerType, JsonSerializer.FieldEnabled)]
-    [InlineData(JsonSerializer.CustomPerType | JsonSerializer.CustomGlobal, JsonSerializer.FieldEnabled)]
+    [InlineData(JsonSerializer.CustomGlobal, JsonSerializer.CustomGlobal)]
+    [InlineData(JsonSerializer.CustomPerType, JsonSerializer.CustomPerType)]
+    [InlineData(JsonSerializer.CustomPerType | JsonSerializer.CustomGlobal, JsonSerializer.CustomPerType)]
     public void RoundTripValueTuple(JsonSerializer addSerializers, JsonSerializer expectedSerializer)
     {
         var obj = RoundTrip((42, "abc"), """{"Item1":42,"Item2":"abc"}"""u8, expectedSerializer, addSerializers);
@@ -93,9 +93,9 @@ public class SerializerTests
 
     [Theory]
     [InlineData(JsonSerializer.None, JsonSerializer.FieldEnabled)]
-    [InlineData(JsonSerializer.CustomGlobal, JsonSerializer.FieldEnabled)]
-    [InlineData(JsonSerializer.CustomPerType, JsonSerializer.FieldEnabled)]
-    [InlineData(JsonSerializer.CustomPerType | JsonSerializer.CustomGlobal, JsonSerializer.FieldEnabled)]
+    [InlineData(JsonSerializer.CustomGlobal, JsonSerializer.CustomGlobal)]
+    [InlineData(JsonSerializer.CustomPerType, JsonSerializer.CustomPerType)]
+    [InlineData(JsonSerializer.CustomPerType | JsonSerializer.CustomGlobal, JsonSerializer.CustomPerType)]
     public void RoundTripNamedValueTuple(JsonSerializer addSerializers, JsonSerializer expectedSerializer)
     {
         var obj = RoundTrip((X: 42, Y: "abc"), """{"Item1":42,"Item2":"abc"}"""u8, expectedSerializer, addSerializers);
@@ -224,13 +224,13 @@ public class SerializerTests
 
         if ((addSerializers & JsonSerializer.CustomGlobal) != JsonSerializer.None)
         {
-            globalOptions = new();
+            globalOptions = new() { IncludeFields = true }; // assume any custom options will serialize the whole type
             services.AddKeyedSingleton<JsonSerializerOptions>(typeof(IHybridCacheSerializer<>), globalOptions);
         }
 
         if ((addSerializers & JsonSerializer.CustomPerType) != JsonSerializer.None)
         {
-            perTypeOptions = new();
+            perTypeOptions = new() { IncludeFields = true }; // assume any custom options will serialize the whole type
             services.AddKeyedSingleton<JsonSerializerOptions>(typeof(IHybridCacheSerializer<T>), perTypeOptions);
         }
 

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SerializerTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SerializerTests.cs
@@ -183,6 +183,24 @@ public class SerializerTests
         Assert.Null(clone.Next.Next);
     }
 
+    [Fact]
+    public void RoundTripDictionary()
+    {
+        Dictionary<string, (int id, string who, DateTime when)> source = new()
+        {
+            ["x"] = (42, "Fred", new(2025, 03, 18)),
+            ["y"] = (43, "Barney", new(2025, 03, 22)),
+        };
+        var clone = RoundTrip(source,
+            """{"x":{"Item1":42,"Item2":"Fred","Item3":"2025-03-18T00:00:00"},"y":{"Item1":43,"Item2":"Barney","Item3":"2025-03-22T00:00:00"}}"""u8,
+            JsonSerializer.FieldEnabled);
+        Assert.Equal(2, clone.Count);
+        Assert.True(clone.TryGetValue("x", out var val));
+        Assert.Equal(source["x"], val);
+        Assert.True(clone.TryGetValue("y", out val));
+        Assert.Equal(source["y"], val);
+    }
+
     public class FieldOnlyPoco
     {
         public int X;


### PR DESCRIPTION
HybridCache uses System.Text.Json for the default serializer, which has some opinions on fields; this means that named-tuples (or value-tuples generally), and types that *use* value tuples or otherwise field-only values, can lose data.

We already detect value-tuples specifically as the root type, but real-world usage has highlit wider ranges of scenarios. This PR adds deeper detection for this scenario, applying the same workaround. It duly considers collection types and recursion scenarios.

fix https://github.com/dotnet/aspnetcore/issues/60934
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6118)