### PR TITLE
Add AIJsonSchemaCreateOptions.IncludeParameter filter

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Reflection;
 using System.Text.Json.Nodes;
+using System.Threading;
 
 #pragma warning disable S1067 // Expressions should not be too complex
 
@@ -22,6 +24,18 @@ public sealed class AIJsonSchemaCreateOptions : IEquatable<AIJsonSchemaCreateOpt
     /// Gets a callback that is invoked for every schema that is generated within the type graph.
     /// </summary>
     public Func<AIJsonSchemaCreateContext, JsonNode, JsonNode>? TransformSchemaNode { get; init; }
+
+    /// <summary>
+    /// Gets a callback that is invoked for every parameter in the <see cref="MethodBase"/> provided to
+    /// <see cref="AIJsonUtilities.CreateFunctionJsonSchema"/> in order to determine whether it should
+    /// be included in the generated schema.
+    /// </summary>
+    /// <remarks>
+    /// By default, when <see cref="IncludeParameter"/> is <see langword="null"/>, all parameters other
+    /// than those of type <see cref="CancellationToken"/> are included in the generated schema.
+    /// The delegate is not invoked for <see cref="CancellationToken"/> parameters.
+    /// </remarks>
+    public Func<ParameterInfo, bool>? IncludeParameter { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether to include the type keyword in inferred schemas for .NET enums.
@@ -44,19 +58,24 @@ public sealed class AIJsonSchemaCreateOptions : IEquatable<AIJsonSchemaCreateOpt
     public bool RequireAllProperties { get; init; } = true;
 
     /// <inheritdoc/>
-    public bool Equals(AIJsonSchemaCreateOptions? other)
-    {
-        return other is not null &&
-            TransformSchemaNode == other.TransformSchemaNode &&
-            IncludeTypeInEnumSchemas == other.IncludeTypeInEnumSchemas &&
-            DisallowAdditionalProperties == other.DisallowAdditionalProperties &&
-            IncludeSchemaKeyword == other.IncludeSchemaKeyword &&
-            RequireAllProperties == other.RequireAllProperties;
-    }
+    public bool Equals(AIJsonSchemaCreateOptions? other) =>
+        other is not null &&
+        TransformSchemaNode == other.TransformSchemaNode &&
+        IncludeParameter == other.IncludeParameter &&
+        IncludeTypeInEnumSchemas == other.IncludeTypeInEnumSchemas &&
+        DisallowAdditionalProperties == other.DisallowAdditionalProperties &&
+        IncludeSchemaKeyword == other.IncludeSchemaKeyword &&
+        RequireAllProperties == other.RequireAllProperties;
 
     /// <inheritdoc />
     public override bool Equals(object? obj) => obj is AIJsonSchemaCreateOptions other && Equals(other);
 
     /// <inheritdoc />
-    public override int GetHashCode() => (TransformSchemaNode, IncludeTypeInEnumSchemas, DisallowAdditionalProperties, IncludeSchemaKeyword, RequireAllProperties).GetHashCode();
+    public override int GetHashCode() =>
+        (TransformSchemaNode,
+         IncludeParameter,
+         IncludeTypeInEnumSchemas,
+         DisallowAdditionalProperties,
+         IncludeSchemaKeyword,
+         RequireAllProperties).GetHashCode();
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
@@ -87,6 +87,14 @@ public static partial class AIJsonUtilities
                 continue;
             }
 
+            if (inferenceOptions.IncludeParameter is { } includeParameter &&
+                !includeParameter(parameter))
+            {
+                // Skip parameters that should not be included in the schema.
+                // By default, all parameters are included.
+                continue;
+            }
+
             JsonNode parameterSchema = CreateJsonSchemaCore(
                 type: parameter.ParameterType,
                 parameterName: parameter.Name,


### PR DESCRIPTION
The CreateFunctionJsonSchema method includes all parameters in the schema. If someone wants to exclude a parameter, e.g. because the LLM shouldn't recognize that parameter and the value for the argument will instead come from somewhere else when the function is invoked, there's no good way to achieve that while still using this helper.

This PR adds an IncludeParameter filter to the create options, such that a developer can supply a delegate invoked for each ParameterInfo to declare whether that parameter should be included or not.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6125)