### PR TITLE
In chat template, display preformatted/code snippet outputs sensibly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,3 @@
 {
-  "dotnet.automaticallyCreateSolutionInWorkspace": false,
-  "githubPullRequests.ignoredPullRequestBranches": [
-    "main"
-  ]
+  "dotnet.automaticallyCreateSolutionInWorkspace": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "dotnet.automaticallyCreateSolutionInWorkspace": false
+  "dotnet.automaticallyCreateSolutionInWorkspace": false,
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "main"
+  ]
 }

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/ChatMessageItem.razor.css
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/ChatMessageItem.razor.css
@@ -110,3 +110,11 @@
 ::deep th, ::deep tr:nth-child(even) {
     background-color: rgba(0, 0, 0, 0.05);
 }
+
+::deep pre > code {
+    background-color: white;
+    display: block;
+    padding: 0.5rem 1rem;
+    margin: 1rem 0;
+    overflow-x: auto;
+}

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/wwwroot/app.js
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/wwwroot/app.js
@@ -11,6 +11,14 @@ customElements.define('assistant-message', class extends HTMLElement {
             newValue = newValue.replace(/<citation.*?<\/citation>/gs, '');
             const elements = marked.parse(newValue.replace(/</g, '&lt;'));
             this.innerHTML = purify.sanitize(elements, { KEEP_CONTENT: false });
+
+            // Within text nodes, unescape the &lt; entities otherwise it will be displayed
+            // to the user as escaped if the element uses preformatted styling. This is safe
+            // because we're only updating the text content of text nodes.
+            const walker = document.createTreeWalker(this, NodeFilter.SHOW_TEXT);
+            while (walker.nextNode()) {
+                walker.currentNode.textContent = walker.currentNode.textContent.replace(/&lt;/g, '<');
+            }
         }
     }
 });

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/Components/Pages/Chat/ChatMessageItem.razor.css
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/Components/Pages/Chat/ChatMessageItem.razor.css
@@ -110,3 +110,11 @@
 ::deep th, ::deep tr:nth-child(even) {
     background-color: rgba(0, 0, 0, 0.05);
 }
+
+::deep pre > code {
+    background-color: white;
+    display: block;
+    padding: 0.5rem 1rem;
+    margin: 1rem 0;
+    overflow-x: auto;
+}

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/wwwroot/app.js
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/wwwroot/app.js
@@ -11,6 +11,14 @@ customElements.define('assistant-message', class extends HTMLElement {
             newValue = newValue.replace(/<citation.*?<\/citation>/gs, '');
             const elements = marked.parse(newValue.replace(/</g, '&lt;'));
             this.innerHTML = purify.sanitize(elements, { KEEP_CONTENT: false });
+
+            // Within text nodes, unescape the &lt; entities otherwise it will be displayed
+            // to the user as escaped if the element uses preformatted styling. This is safe
+            // because we're only updating the text content of text nodes.
+            const walker = document.createTreeWalker(this, NodeFilter.SHOW_TEXT);
+            while (walker.nextNode()) {
+                walker.currentNode.textContent = walker.currentNode.textContent.replace(/&lt;/g, '<');
+            }
         }
     }
 });


### PR DESCRIPTION
The chatbot is pretty good at producing code snippet outputs, but the formatting is a mess.

This adds a couple of small tweaks that cause code samples or any other Markdown preformatted content to display nicely (albeit without syntax highlighting)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6137)