### PR TITLE
Fix chat template test version scrubbing

### DIFF
--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/AichatwebTemplatesTests.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/AichatwebTemplatesTests.cs
@@ -79,12 +79,11 @@ public class AichatwebTemplatesTests : TestBase
 
                     foreach (var prefix in _packagePrefixesWithJustBuiltVersionNumber)
                     {
-                        // Scrub references to just-built packages and use a fake version name.
+                        // Scrub references to just-built packages and remove the suffix, if it exists.
                         // This allows the snapshots to remain the same regardless of where the repo is built (e.g., locally, public CI, internal CI).
-                        const string VersionReplacement = "REPO_VERSION";
                         var escapedPrefix = Regex.Escape(prefix);
-                        var pattern = $"<PackageReference\\s+Include=\"({escapedPrefix}[^\"]*)\"\\s+Version=\"[^\"]*\"\\s*/>";
-                        var replacement = $"<PackageReference Include=\"$1\" Version=\"{VersionReplacement}\" />";
+                        var pattern = $"<PackageReference\\s+Include=\\\"({escapedPrefix}[^\"]*)\\\"\\s+Version=\\\"([^{{\\\"|\\-}}]*)[^\"]*\\\"\\s*\\/>";
+                        var replacement = "<PackageReference Include=\"$1\" Version=\"$2\" />";
                         content.ScrubByRegex(pattern, replacement);
                     }
                 }

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/AichatwebTemplatesTests.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/AichatwebTemplatesTests.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI.Templates.IntegrationTests;
 using Microsoft.Extensions.AI.Templates.Tests;
@@ -30,10 +29,6 @@ public class AichatwebTemplatesTests : TestBase
         "**/ingestioncache.db",
         "**/NuGet.config",
         "**/Directory.Build.targets",
-    ];
-
-    private static readonly string[] _packagePrefixesWithJustBuiltVersionNumber = [
-        "Microsoft.Extensions.AI",
     ];
 
     private readonly ILogger _log;
@@ -77,15 +72,11 @@ public class AichatwebTemplatesTests : TestBase
                 {
                     content.ScrubByRegex("<UserSecretsId>(.*)<\\/UserSecretsId>", "<UserSecretsId>secret</UserSecretsId>");
 
-                    foreach (var prefix in _packagePrefixesWithJustBuiltVersionNumber)
-                    {
-                        // Scrub references to just-built packages and remove the suffix, if it exists.
-                        // This allows the snapshots to remain the same regardless of where the repo is built (e.g., locally, public CI, internal CI).
-                        var escapedPrefix = Regex.Escape(prefix);
-                        var pattern = $"<PackageReference\\s+Include=\\\"({escapedPrefix}[^\"]*)\\\"\\s+Version=\\\"([^{{\\\"|\\-}}]*)[^\"]*\\\"\\s*\\/>";
-                        var replacement = "<PackageReference Include=\"$1\" Version=\"$2\" />";
-                        content.ScrubByRegex(pattern, replacement);
-                    }
+                    // Scrub references to just-built packages and remove the suffix, if it exists.
+                    // This allows the snapshots to remain the same regardless of where the repo is built (e.g., locally, public CI, internal CI).
+                    var pattern = "<PackageReference\\s+Include=\\\"(Microsoft\\.Extensions\\.AI[^\"]*)\\\"\\s+Version=\\\"([^{{\\\"|\\-}}]*)[^\"]*\\\"\\s*\\/>";
+                    var replacement = "<PackageReference Include=\"$1\" Version=\"$2\" />";
+                    content.ScrubByRegex(pattern, replacement);
                 }
 
                 if (filePath.EndsWith("aichatweb/Properties/launchSettings.json"))

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/AichatwebTemplatesTests.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/AichatwebTemplatesTests.cs
@@ -74,9 +74,8 @@ public class AichatwebTemplatesTests : TestBase
 
                     // Scrub references to just-built packages and remove the suffix, if it exists.
                     // This allows the snapshots to remain the same regardless of where the repo is built (e.g., locally, public CI, internal CI).
-                    var pattern = "<PackageReference\\s+Include=\\\"(Microsoft\\.Extensions\\.AI[^\"]*)\\\"\\s+Version=\\\"([^{{\\\"|\\-}}]*)[^\"]*\\\"\\s*\\/>";
-                    var replacement = "<PackageReference Include=\"$1\" Version=\"$2\" />";
-                    content.ScrubByRegex(pattern, replacement);
+                    var pattern = @"(?<=<PackageReference\s+Include=""Microsoft\.Extensions\..*""\s+Version="")(\d+\.\d+\.\d+)(?:-[^""]*)?(?=""\s*/>)";
+                    content.ScrubByRegex(pattern, replacement: "$1");
                 }
 
                 if (filePath.EndsWith("aichatweb/Properties/launchSettings.json"))

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/aichatweb.csproj
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/aichatweb.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="OpenAI" Version="2.2.0-beta.1" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.4.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="REPO_VERSION" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="9.4.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="REPO_VERSION" />
     <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.37.0" />
     <PackageReference Include="PdfPig" Version="0.1.9" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/aichatweb.csproj
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/aichatweb.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="OpenAI" Version="2.2.0-beta.1" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="REPO_VERSION" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="REPO_VERSION" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="9.4.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.37.0" />
     <PackageReference Include="PdfPig" Version="0.1.9" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />


### PR DESCRIPTION
Fixes an issue where versions in package references to just-built packages were not always being scrubbed correctly.

Prior to this PR, specific version suffixes (`-ci`, `-dev`) were scrubbed, but this new PR takes a more robust approach that looks for `<PackageReference />` items to just-built packages and scrubs the suffix of the `Version` attribute.

There's a static field `_packagePrefixesWithJustBuiltVersionNumber` that can be extended with more package prefixes that are expected to have a just-built version number.

If we're willing to be less conservative, we could even go even further and scrub any references to `Microsoft.Extensions.*` packages.

Fixes https://github.com/dotnet/extensions/issues/6128
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6140)