### PR TITLE
 Enable AIFunctions to be passed an IServiceProvider, Alternate 3

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunction.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunction.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
@@ -53,22 +54,26 @@ public abstract class AIFunction : AITool
 
     /// <summary>Invokes the <see cref="AIFunction"/> and returns its result.</summary>
     /// <param name="arguments">The arguments to pass to the function's invocation.</param>
+    /// <param name="services">The <see cref="IServiceProvider"/> optionally associated with this invocation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The result of the function's execution.</returns>
     public Task<object?> InvokeAsync(
         IEnumerable<KeyValuePair<string, object?>>? arguments = null,
+        IServiceProvider? services = null,
         CancellationToken cancellationToken = default)
     {
         arguments ??= EmptyReadOnlyDictionary<string, object?>.Instance;
 
-        return InvokeCoreAsync(arguments, cancellationToken);
+        return InvokeCoreAsync(arguments, services, cancellationToken);
     }
 
     /// <summary>Invokes the <see cref="AIFunction"/> and returns its result.</summary>
     /// <param name="arguments">The arguments to pass to the function's invocation.</param>
+    /// <param name="services">The <see cref="IServiceProvider"/> optionally associated with this invocation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>The result of the function's execution.</returns>
     protected abstract Task<object?> InvokeCoreAsync(
         IEnumerable<KeyValuePair<string, object?>> arguments,
+        IServiceProvider? services,
         CancellationToken cancellationToken);
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
@@ -79,11 +79,15 @@ public static partial class AIJsonUtilities
                 Throw.ArgumentException(nameof(parameter), "Parameter is missing a name.");
             }
 
-            if (parameter.ParameterType == typeof(CancellationToken))
+            if (parameter.ParameterType == typeof(CancellationToken) ||
+                parameter.ParameterType == typeof(IServiceProvider))
             {
                 // CancellationToken is a special case that, by convention, we don't want to include in the schema.
                 // Invocations of methods that include a CancellationToken argument should also special-case CancellationToken
                 // to pass along what relevant token into the method's invocation.
+
+                // IServiceProvider is a special because it's directly handled by AIFunction.
+
                 continue;
             }
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIRealtimeExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIRealtimeExtensions.cs
@@ -107,7 +107,7 @@ public static class OpenAIRealtimeExtensions
 
             try
             {
-                var result = await aiFunction.InvokeAsync(functionCallContent.Arguments, cancellationToken).ConfigureAwait(false);
+                var result = await aiFunction.InvokeAsync(functionCallContent.Arguments, null, cancellationToken).ConfigureAwait(false);
                 var resultJson = JsonSerializer.Serialize(result, jsonOptions.GetTypeInfo(typeof(object)));
                 return ConversationItem.CreateFunctionCallOutput(update.FunctionCallId, resultJson);
             }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClientBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClientBuilderExtensions.cs
@@ -33,7 +33,7 @@ public static class FunctionInvokingChatClientBuilderExtensions
         {
             loggerFactory ??= services.GetService<ILoggerFactory>();
 
-            var chatClient = new FunctionInvokingChatClient(innerClient, loggerFactory?.CreateLogger(typeof(FunctionInvokingChatClient)));
+            var chatClient = new FunctionInvokingChatClient(innerClient, loggerFactory?.CreateLogger(typeof(FunctionInvokingChatClient)), services);
             configure?.Invoke(chatClient);
             return chatClient;
         });

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/FunctionCallContentTests..cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/FunctionCallContentTests..cs
@@ -251,7 +251,10 @@ public class FunctionCallContentTests
 
         public override string Name => "NetTypeless";
         public override string Description => "AIFunction with parameters that lack .NET types";
-        protected override Task<object?> InvokeCoreAsync(IEnumerable<KeyValuePair<string, object?>>? arguments, CancellationToken cancellationToken) =>
+        protected override Task<object?> InvokeCoreAsync(
+            IEnumerable<KeyValuePair<string, object?>>? arguments,
+            IServiceProvider? services,
+            CancellationToken cancellationToken) =>
             Task.FromResult<object?>(arguments);
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Functions/AIFunctionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Functions/AIFunctionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,13 +17,13 @@ public class AIFunctionTests
         DerivedAIFunction f = new();
 
         using CancellationTokenSource cts = new();
-        var result1 = ((IEnumerable<KeyValuePair<string, object?>>, CancellationToken))(await f.InvokeAsync(null, cts.Token))!;
+        var result1 = ((IEnumerable<KeyValuePair<string, object?>>, CancellationToken))(await f.InvokeAsync(null, null, cts.Token))!;
 
         Assert.NotNull(result1.Item1);
         Assert.Empty(result1.Item1);
         Assert.Equal(cts.Token, result1.Item2);
 
-        var result2 = ((IEnumerable<KeyValuePair<string, object?>>, CancellationToken))(await f.InvokeAsync(null, cts.Token))!;
+        var result2 = ((IEnumerable<KeyValuePair<string, object?>>, CancellationToken))(await f.InvokeAsync(null, null, cts.Token))!;
         Assert.Same(result1.Item1, result2.Item1);
     }
 
@@ -38,7 +39,10 @@ public class AIFunctionTests
         public override string Name => "name";
         public override string Description => "";
 
-        protected override Task<object?> InvokeCoreAsync(IEnumerable<KeyValuePair<string, object?>> arguments, CancellationToken cancellationToken)
+        protected override Task<object?> InvokeCoreAsync(
+            IEnumerable<KeyValuePair<string, object?>> arguments,
+            IServiceProvider? services,
+            CancellationToken cancellationToken)
         {
             Assert.NotNull(arguments);
             return Task.FromResult<object?>((arguments, cancellationToken));

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -606,6 +606,32 @@ public class FunctionInvokingChatClientTests
         Assert.Equal("done!", (await service.GetStreamingResponseAsync("hey", options).ToChatResponseAsync()).ToString());
     }
 
+    [Fact]
+    public async Task FunctionInvocations_PassesServices()
+    {
+        List<ChatMessage> plan =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1", new Dictionary<string, object?> { ["arg1"] = "value1" })]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
+            new ChatMessage(ChatRole.Assistant, "world"),
+        ];
+
+        ServiceCollection c = new();
+        IServiceProvider expected = c.BuildServiceProvider();
+
+        var options = new ChatOptions
+        {
+            Tools = [AIFunctionFactory.Create((IServiceProvider actual) =>
+            {
+                Assert.Same(expected, actual);
+                return "Result 1";
+            }, "Func1")]
+        };
+
+        await InvokeAndAssertAsync(options, plan, services: expected);
+    }
+
     private static async Task<List<ChatMessage>> InvokeAndAssertAsync(
         ChatOptions options,
         List<ChatMessage> plan,


### PR DESCRIPTION
Alternate to https://github.com/dotnet/extensions/pull/6141. Change AIFunction.InvokeAsync to directly take IServiceProvider as an argument, and special-case IServiceProvider for schema generation. Basically IServiceProvider is a first-class citizen in the AIFunction world.