### PR TITLE
Use only a single TFM for M.E.AI.Eval.Reporting.Console

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Console/Microsoft.Extensions.AI.Evaluation.Console.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Console/Microsoft.Extensions.AI.Evaluation.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>A dotnet tool for managing the evaluation data and generating reports.</Description>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(NetCoreTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(MinimumSupportedTfmForPackaging)</TargetFrameworks>
     <RootNamespace>Microsoft.Extensions.AI.Evaluation.Console</RootNamespace>
     <!-- EA0000: Use source generated logging methods for improved performance. -->
     <NoWarn>$(NoWarn);EA0000</NoWarn>


### PR DESCRIPTION
Restrict MTFM builds of M.E.AI.Eval.Reporting.Console to only the minimum version of .NET Core. This is to prevent build breaks such as [this](https://github.com/dotnet/extensions/pull/6133#issuecomment-2731431023).