### PR TITLE
Change AIFunction.InvokeAsync to accept AIFunctionArguments

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunction.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunction.cs
@@ -1,12 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Shared.Collections;
 
 namespace Microsoft.Extensions.AI;
 
@@ -56,19 +54,15 @@ public abstract class AIFunction : AITool
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The result of the function's execution.</returns>
     public Task<object?> InvokeAsync(
-        IEnumerable<KeyValuePair<string, object?>>? arguments = null,
-        CancellationToken cancellationToken = default)
-    {
-        arguments ??= EmptyReadOnlyDictionary<string, object?>.Instance;
-
-        return InvokeCoreAsync(arguments, cancellationToken);
-    }
+        AIFunctionArguments? arguments = null,
+        CancellationToken cancellationToken = default) =>
+        InvokeCoreAsync(arguments ?? [], cancellationToken);
 
     /// <summary>Invokes the <see cref="AIFunction"/> and returns its result.</summary>
     /// <param name="arguments">The arguments to pass to the function's invocation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>The result of the function's execution.</returns>
     protected abstract Task<object?> InvokeCoreAsync(
-        IEnumerable<KeyValuePair<string, object?>> arguments,
+        AIFunctionArguments arguments,
         CancellationToken cancellationToken);
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionArguments.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionArguments.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+#pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
+#pragma warning disable SA1112 // Closing parenthesis should be on line of opening parenthesis
+#pragma warning disable SA1114 // Parameter list should follow declaration
+#pragma warning disable CA1710 // Identifiers should have correct suffix
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Represents arguments to be used with <see cref="AIFunction.InvokeAsync"/>.</summary>
+/// <remarks>
+/// <see cref="AIFunctionArguments"/> is a dictionary of name/value pairs that are used
+/// as inputs to an <see cref="AIFunction"/>. However, an instance carries additional non-nominal
+/// information, such as an optional <see cref="IServiceProvider"/> that can be used by
+/// an <see cref="AIFunction"/> if it needs to resolve any services from a dependency injection
+/// container.
+/// </remarks>
+public sealed class AIFunctionArguments : IDictionary<string, object?>, IReadOnlyDictionary<string, object?>
+{
+    /// <summary>The nominal arguments.</summary>
+    private readonly Dictionary<string, object?> _arguments;
+
+    /// <summary>Initializes a new instance of the <see cref="AIFunctionArguments"/> class.</summary>
+    public AIFunctionArguments()
+    {
+        _arguments = [];
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AIFunctionArguments"/> class containing
+    /// the specified <paramref name="arguments"/>.
+    /// </summary>
+    /// <param name="arguments">The arguments represented by this instance.</param>
+    /// <remarks>
+    /// The <paramref name="arguments"/> reference will be stored if the instance is
+    /// already a <see cref="Dictionary{TKey, TValue}"/>, in which case all dictionary
+    /// operations on this instance will be routed directly to that instance. If <paramref name="arguments"/>
+    /// is not a dictionary, a shallow clone of its data will be used to populate this
+    /// instance. A <see langword="null"/> <paramref name="arguments"/> is treated as an
+    /// empty dictionary.
+    /// </remarks>
+    public AIFunctionArguments(IDictionary<string, object?>? arguments)
+    {
+        _arguments =
+            arguments is null ? [] :
+            arguments as Dictionary<string, object?> ??
+            new Dictionary<string, object?>(arguments);
+    }
+
+    /// <summary>Gets or sets services optionally associated with these arguments.</summary>
+    public IServiceProvider? Services { get; set; }
+
+    /// <inheritdoc />
+    public object? this[string key]
+    {
+        get => _arguments[key];
+        set => _arguments[key] = value;
+    }
+
+    /// <inheritdoc />
+    public ICollection<string> Keys => _arguments.Keys;
+
+    /// <inheritdoc />
+    public ICollection<object?> Values => _arguments.Values;
+
+    /// <inheritdoc />
+    public int Count => _arguments.Count;
+
+    /// <inheritdoc />
+    bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => false;
+
+    /// <inheritdoc />
+    IEnumerable<string> IReadOnlyDictionary<string, object?>.Keys => Keys;
+
+    /// <inheritdoc />
+    IEnumerable<object?> IReadOnlyDictionary<string, object?>.Values => Values;
+
+    /// <inheritdoc />
+    public void Add(string key, object? value) => _arguments.Add(key, value);
+
+    /// <inheritdoc />
+    void ICollection<KeyValuePair<string, object?>>.Add(KeyValuePair<string, object?> item) =>
+        ((ICollection<KeyValuePair<string, object?>>)_arguments).Add(item);
+
+    /// <inheritdoc />
+    public void Clear() => _arguments.Clear();
+
+    /// <inheritdoc />
+    bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item) =>
+        ((ICollection<KeyValuePair<string, object?>>)_arguments).Contains(item);
+
+    /// <inheritdoc />
+    public bool ContainsKey(string key) => _arguments.ContainsKey(key);
+
+    /// <inheritdoc />
+    public void CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex) =>
+        ((ICollection<KeyValuePair<string, object?>>)_arguments).CopyTo(array, arrayIndex);
+
+    /// <inheritdoc />
+    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => _arguments.GetEnumerator();
+
+    /// <inheritdoc />
+    public bool Remove(string key) => _arguments.Remove(key);
+
+    /// <inheritdoc />
+    bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item) =>
+        ((ICollection<KeyValuePair<string, object?>>)_arguments).Remove(item);
+
+    /// <inheritdoc />
+    public bool TryGetValue(string key, out object? value) => _arguments.TryGetValue(key, out value);
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.AI;
 /// <summary>
 /// Provides options for configuring the behavior of <see cref="AIJsonUtilities"/> JSON schema creation functionality.
 /// </summary>
-public sealed class AIJsonSchemaCreateOptions : IEquatable<AIJsonSchemaCreateOptions>
+public sealed record class AIJsonSchemaCreateOptions
 {
     /// <summary>
     /// Gets the default options instance.
@@ -56,26 +56,4 @@ public sealed class AIJsonSchemaCreateOptions : IEquatable<AIJsonSchemaCreateOpt
     /// Gets a value indicating whether to mark all properties as required in the schema.
     /// </summary>
     public bool RequireAllProperties { get; init; } = true;
-
-    /// <inheritdoc/>
-    public bool Equals(AIJsonSchemaCreateOptions? other) =>
-        other is not null &&
-        TransformSchemaNode == other.TransformSchemaNode &&
-        IncludeParameter == other.IncludeParameter &&
-        IncludeTypeInEnumSchemas == other.IncludeTypeInEnumSchemas &&
-        DisallowAdditionalProperties == other.DisallowAdditionalProperties &&
-        IncludeSchemaKeyword == other.IncludeSchemaKeyword &&
-        RequireAllProperties == other.RequireAllProperties;
-
-    /// <inheritdoc />
-    public override bool Equals(object? obj) => obj is AIJsonSchemaCreateOptions other && Equals(other);
-
-    /// <inheritdoc />
-    public override int GetHashCode() =>
-        (TransformSchemaNode,
-         IncludeParameter,
-         IncludeTypeInEnumSchemas,
-         DisallowAdditionalProperties,
-         IncludeSchemaKeyword,
-         RequireAllProperties).GetHashCode();
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs
@@ -108,6 +108,7 @@ public static partial class AIJsonUtilities
     [JsonSerializable(typeof(Embedding<float>))]
     [JsonSerializable(typeof(Embedding<double>))]
     [JsonSerializable(typeof(AIContent))]
+    [JsonSerializable(typeof(AIFunctionArguments))]
     [EditorBrowsable(EditorBrowsableState.Never)] // Never use JsonContext directly, use DefaultOptions instead.
     private sealed partial class JsonContext : JsonSerializerContext;
 }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMapper.ChatCompletion.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMapper.ChatCompletion.cs
@@ -437,7 +437,7 @@ internal static partial class OpenAIModelMappers
         public override string Description => description;
         public override JsonElement JsonSchema => schema;
         public override IReadOnlyDictionary<string, object?> AdditionalProperties => additionalProps;
-        protected override Task<object?> InvokeCoreAsync(IEnumerable<KeyValuePair<string, object?>> arguments, CancellationToken cancellationToken) =>
+        protected override Task<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken) =>
             throw new InvalidOperationException($"The AI function '{Name}' does not support being invoked.");
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIRealtimeExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIRealtimeExtensions.cs
@@ -107,7 +107,7 @@ public static class OpenAIRealtimeExtensions
 
             try
             {
-                var result = await aiFunction.InvokeAsync(functionCallContent.Arguments, cancellationToken).ConfigureAwait(false);
+                var result = await aiFunction.InvokeAsync(new(functionCallContent.Arguments), cancellationToken).ConfigureAwait(false);
                 var resultJson = JsonSerializer.Serialize(result, jsonOptions.GetTypeInfo(typeof(object)));
                 return ConversationItem.CreateFunctionCallOutput(update.FunctionCallId, resultJson);
             }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIRealtimeExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIRealtimeExtensions.cs
@@ -52,6 +52,7 @@ public static class OpenAIRealtimeExtensions
     /// <param name="tools">The available tools.</param>
     /// <param name="detailedErrors">An optional flag specifying whether to disclose detailed exception information to the model. The default value is <see langword="false"/>.</param>
     /// <param name="jsonSerializerOptions">An optional <see cref="JsonSerializerOptions"/> that controls JSON handling.</param>
+    /// <param name="functionInvocationServices">An optional <see cref="IServiceProvider"/> to use for resolving services required by <see cref="AIFunction"/> instances being invoked.</param>
     /// <param name="cancellationToken">An optional <see cref="CancellationToken"/>.</param>
     /// <returns>A <see cref="Task"/> that represents the completion of processing, including invoking any asynchronous tools.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
@@ -63,6 +64,7 @@ public static class OpenAIRealtimeExtensions
         IReadOnlyList<AIFunction> tools,
         bool? detailedErrors = false,
         JsonSerializerOptions? jsonSerializerOptions = null,
+        IServiceProvider? functionInvocationServices = null,
         CancellationToken cancellationToken = default)
     {
         _ = Throw.IfNull(session);
@@ -73,7 +75,7 @@ public static class OpenAIRealtimeExtensions
         {
             // If we need to call a tool to update the model, do so
             if (!string.IsNullOrEmpty(itemFinished.FunctionName)
-                && await itemFinished.GetFunctionCallOutputAsync(tools, detailedErrors, jsonSerializerOptions, cancellationToken).ConfigureAwait(false) is { } output)
+                && await itemFinished.GetFunctionCallOutputAsync(tools, detailedErrors, jsonSerializerOptions, functionInvocationServices, cancellationToken).ConfigureAwait(false) is { } output)
             {
                 await session.AddItemAsync(output, cancellationToken).ConfigureAwait(false);
             }
@@ -93,6 +95,7 @@ public static class OpenAIRealtimeExtensions
         IReadOnlyList<AIFunction> tools,
         bool? detailedErrors = false,
         JsonSerializerOptions? jsonSerializerOptions = null,
+        IServiceProvider? functionInvocationServices = null,
         CancellationToken cancellationToken = default)
     {
         if (!string.IsNullOrEmpty(update.FunctionName)
@@ -107,7 +110,7 @@ public static class OpenAIRealtimeExtensions
 
             try
             {
-                var result = await aiFunction.InvokeAsync(new(functionCallContent.Arguments), cancellationToken).ConfigureAwait(false);
+                var result = await aiFunction.InvokeAsync(new(functionCallContent.Arguments) { Services = functionInvocationServices }, cancellationToken).ConfigureAwait(false);
                 var resultJson = JsonSerializer.Serialize(result, jsonOptions.GetTypeInfo(typeof(object)));
                 return ConversationItem.CreateFunctionCallOutput(update.FunctionCallId, resultJson);
             }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvocationContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvocationContext.cs
@@ -24,17 +24,34 @@ public sealed class FunctionInvocationContext
     private AIFunction _function = _nopFunction;
 
     /// <summary>The function call content information associated with this invocation.</summary>
-    private FunctionCallContent _callContent = new(string.Empty, _nopFunction.Name, EmptyReadOnlyDictionary<string, object?>.Instance);
+    private FunctionCallContent? _callContent;
+
+    /// <summary>The arguments used with the function.</summary>
+    private AIFunctionArguments? _arguments;
 
     /// <summary>Initializes a new instance of the <see cref="FunctionInvocationContext"/> class.</summary>
     public FunctionInvocationContext()
     {
     }
 
+    /// <summary>Gets or sets the AI function to be invoked.</summary>
+    public AIFunction Function
+    {
+        get => _function;
+        set => _function = Throw.IfNull(value);
+    }
+
+    /// <summary>Gets or sets the arguments associated with this invocation.</summary>
+    public AIFunctionArguments Arguments
+    {
+        get => _arguments ??= [];
+        set => _arguments = Throw.IfNull(value);
+    }
+
     /// <summary>Gets or sets the function call content information associated with this invocation.</summary>
     public FunctionCallContent CallContent
     {
-        get => _callContent;
+        get => _callContent ??= new(string.Empty, _nopFunction.Name, EmptyReadOnlyDictionary<string, object?>.Instance);
         set => _callContent = Throw.IfNull(value);
     }
 
@@ -47,13 +64,6 @@ public sealed class FunctionInvocationContext
 
     /// <summary>Gets or sets the chat options associated with the operation that initiated this function call request.</summary>
     public ChatOptions? Options { get; set; }
-
-    /// <summary>Gets or sets the AI function to be invoked.</summary>
-    public AIFunction Function
-    {
-        get => _function;
-        set => _function = Throw.IfNull(value);
-    }
 
     /// <summary>Gets or sets the number of this iteration with the underlying client.</summary>
     /// <remarks>

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClientBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClientBuilderExtensions.cs
@@ -33,7 +33,7 @@ public static class FunctionInvokingChatClientBuilderExtensions
         {
             loggerFactory ??= services.GetService<ILoggerFactory>();
 
-            var chatClient = new FunctionInvokingChatClient(innerClient, loggerFactory?.CreateLogger(typeof(FunctionInvokingChatClient)));
+            var chatClient = new FunctionInvokingChatClient(innerClient, loggerFactory, services);
             configure?.Invoke(chatClient);
             return chatClient;
         });

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
@@ -6,7 +6,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+#if !NET
 using System.Linq;
+#endif
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -16,6 +18,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Shared.Collections;
 using Microsoft.Shared.Diagnostics;
+
+#pragma warning disable CA1031 // Do not catch general exception types
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 
 namespace Microsoft.Extensions.AI;
 
@@ -188,25 +193,17 @@ public static partial class AIFunctionFactory
         public override MethodInfo UnderlyingMethod => FunctionDescriptor.Method;
         public override JsonElement JsonSchema => FunctionDescriptor.JsonSchema;
         public override JsonSerializerOptions JsonSerializerOptions => FunctionDescriptor.JsonSerializerOptions;
+
         protected override Task<object?> InvokeCoreAsync(
-            IEnumerable<KeyValuePair<string, object?>>? arguments,
+            AIFunctionArguments arguments,
             CancellationToken cancellationToken)
         {
             var paramMarshallers = FunctionDescriptor.ParameterMarshallers;
             object?[] args = paramMarshallers.Length != 0 ? new object?[paramMarshallers.Length] : [];
 
-            IReadOnlyDictionary<string, object?> argDict =
-                arguments is null || args.Length == 0 ? EmptyReadOnlyDictionary<string, object?>.Instance :
-                arguments as IReadOnlyDictionary<string, object?> ??
-                arguments.
-#if NET8_0_OR_GREATER
-                    ToDictionary();
-#else
-                    ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-#endif
             for (int i = 0; i < args.Length; i++)
             {
-                args[i] = paramMarshallers[i](argDict, cancellationToken);
+                args[i] = paramMarshallers[i](arguments, cancellationToken);
             }
 
             return FunctionDescriptor.ReturnParameterMarshaller(ReflectionInvoke(FunctionDescriptor.Method, Target, args), cancellationToken);
@@ -248,9 +245,36 @@ public static partial class AIFunctionFactory
 
         private ReflectionAIFunctionDescriptor(DescriptorKey key, JsonSerializerOptions serializerOptions)
         {
+            // Augment the schema options to exclude AIFunctionArguments/IServiceProvider from the schema,
+            // as it'll be satisfied from AIFunctionArguments.
+            static bool IncludeNonAIFunctionArgumentParameter(ParameterInfo parameterInfo) =>
+                parameterInfo.ParameterType != typeof(AIFunctionArguments) &&
+                parameterInfo.ParameterType != typeof(IServiceProvider);
+
+            AIJsonSchemaCreateOptions schemaOptions;
+            if (key.SchemaOptions.IncludeParameter is not null)
+            {
+                // There's an existing filter, so delegate to it after filtering out IServiceProvider.
+                var existingIncludeParameter = key.SchemaOptions.IncludeParameter;
+                schemaOptions = key.SchemaOptions with
+                {
+                    IncludeParameter = parameterInfo =>
+                        IncludeNonAIFunctionArgumentParameter(parameterInfo) &&
+                        existingIncludeParameter(parameterInfo),
+                };
+            }
+            else
+            {
+                // There's no existing parameter filter, so only exclude IServiceProvider.
+                schemaOptions = key.SchemaOptions with
+                {
+                    IncludeParameter = IncludeNonAIFunctionArgumentParameter,
+                };
+            }
+
             // Get marshaling delegates for parameters.
             ParameterInfo[] parameters = key.Method.GetParameters();
-            ParameterMarshallers = new Func<IReadOnlyDictionary<string, object?>, CancellationToken, object?>[parameters.Length];
+            ParameterMarshallers = new Func<AIFunctionArguments, CancellationToken, object?>[parameters.Length];
             for (int i = 0; i < parameters.Length; i++)
             {
                 ParameterMarshallers[i] = GetParameterMarshaller(serializerOptions, parameters[i]);
@@ -268,7 +292,7 @@ public static partial class AIFunctionFactory
                 Name,
                 Description,
                 serializerOptions,
-                key.SchemaOptions);
+                schemaOptions);
         }
 
         public string Name { get; }
@@ -276,7 +300,7 @@ public static partial class AIFunctionFactory
         public MethodInfo Method { get; }
         public JsonSerializerOptions JsonSerializerOptions { get; }
         public JsonElement JsonSchema { get; }
-        public Func<IReadOnlyDictionary<string, object?>, CancellationToken, object?>[] ParameterMarshallers { get; }
+        public Func<AIFunctionArguments, CancellationToken, object?>[] ParameterMarshallers { get; }
         public Func<object?, CancellationToken, Task<object?>> ReturnParameterMarshaller { get; }
         public ReflectionAIFunction? CachedDefaultInstance { get; set; }
 
@@ -320,7 +344,7 @@ public static partial class AIFunctionFactory
         /// <summary>
         /// Gets a delegate for handling the marshaling of a parameter.
         /// </summary>
-        private static Func<IReadOnlyDictionary<string, object?>, CancellationToken, object?> GetParameterMarshaller(
+        private static Func<AIFunctionArguments, CancellationToken, object?> GetParameterMarshaller(
             JsonSerializerOptions serializerOptions,
             ParameterInfo parameter)
         {
@@ -341,6 +365,28 @@ public static partial class AIFunctionFactory
                     cancellationToken;
             }
 
+            // For AIFunctionArgument parameters, we always bind to the arguments passed directly to InvokeAsync.
+            if (parameterType == typeof(AIFunctionArguments))
+            {
+                return static (arguments, _) => arguments;
+            }
+
+            // For IServiceProvider parameters, we always bind to the services passed directly to InvokeAsync via AIFunctionArguments.
+            // However, those Services are not required, so we throw if they're not available and are required.
+            if (parameterType == typeof(IServiceProvider))
+            {
+                return (arguments, _) =>
+                {
+                    IServiceProvider? services = arguments.Services;
+                    if (services is null && !parameter.HasDefaultValue)
+                    {
+                        Throw.ArgumentException(nameof(arguments), $"An {nameof(IServiceProvider)} was not provided for the {parameter.Name} parameter.");
+                    }
+
+                    return services;
+                };
+            }
+
             // For all other parameters, create a marshaller that tries to extract the value from the arguments dictionary.
             return (arguments, _) =>
             {
@@ -359,7 +405,6 @@ public static partial class AIFunctionFactory
 
                     object? MarshallViaJsonRoundtrip(object value)
                     {
-#pragma warning disable CA1031 // Do not catch general exception types
                         try
                         {
                             string json = JsonSerializer.Serialize(value, serializerOptions.GetTypeInfo(value.GetType()));
@@ -370,7 +415,6 @@ public static partial class AIFunctionFactory
                             // Eat any exceptions and fall back to the original value to force a cast exception later on.
                             return value;
                         }
-#pragma warning restore CA1031
                     }
                 }
 
@@ -482,9 +526,7 @@ public static partial class AIFunctionFactory
 #if NET
             return (MethodInfo)specializedType.GetMemberWithSameMetadataDefinitionAs(genericMethodDefinition);
 #else
-#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
             const BindingFlags All = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
-#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
             return specializedType.GetMethods(All).First(m => m.MetadataToken == genericMethodDefinition.MetadataToken);
 #endif
         }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/FunctionCallContentTests..cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/FunctionCallContentTests..cs
@@ -96,7 +96,7 @@ public class FunctionCallContentTests
     [Fact]
     public async Task AIFunctionFactory_ObjectValues_Converted()
     {
-        Dictionary<string, object?> arguments = new()
+        AIFunctionArguments arguments = new()
         {
             ["a"] = new DayOfWeek[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday },
             ["b"] = 123.4M,
@@ -116,7 +116,7 @@ public class FunctionCallContentTests
     [Fact]
     public async Task AIFunctionFactory_JsonElementValues_ValuesDeserialized()
     {
-        Dictionary<string, object?> arguments = JsonSerializer.Deserialize<Dictionary<string, object?>>("""
+        AIFunctionArguments arguments = JsonSerializer.Deserialize<AIFunctionArguments>("""
             {
               "a": ["Monday", "Tuesday", "Wednesday"],
               "b": 123.4,
@@ -164,7 +164,7 @@ public class FunctionCallContentTests
             """, TestJsonSerializerContext.Default.Options)!.ToDictionary(k => k.Key, k => (object?)k.Value);
 
         AIFunction function = AIFunctionFactory.Create((DayOfWeek[] a, double b, Guid c, Dictionary<string, string> d) => b, serializerOptions: TestJsonSerializerContext.Default.Options);
-        var result = await function.InvokeAsync(arguments);
+        var result = await function.InvokeAsync(new(arguments));
         AssertExtensions.EqualFunctionCallResults(123.4, result);
     }
 
@@ -185,14 +185,14 @@ public class FunctionCallContentTests
             """, TestJsonSerializerContext.Default.Options)!.ToDictionary(k => k.Key, k => (object?)k.Value);
 
         AIFunction function = AIFunctionFactory.Create((DayOfWeek[] a, double b, Guid c, Dictionary<string, string> d) => b, serializerOptions: TestJsonSerializerContext.Default.Options);
-        var result = await function.InvokeAsync(arguments);
+        var result = await function.InvokeAsync(new(arguments));
         AssertExtensions.EqualFunctionCallResults(123.4, result);
     }
 
     [Fact]
     public async Task TypelessAIFunction_JsonDocumentValues_AcceptsArguments()
     {
-        var arguments = JsonSerializer.Deserialize<Dictionary<string, JsonDocument>>("""
+        AIFunctionArguments arguments = new(JsonSerializer.Deserialize<Dictionary<string, JsonDocument>>("""
             {
               "a": "string",
               "b": 123.4,
@@ -201,7 +201,7 @@ public class FunctionCallContentTests
               "e": ["Monday", "Tuesday", "Wednesday"],
               "f": null
             }
-            """, TestJsonSerializerContext.Default.Options)!.ToDictionary(k => k.Key, k => (object?)k.Value);
+            """, TestJsonSerializerContext.Default.Options)!.ToDictionary(k => k.Key, k => (object?)k.Value));
 
         var result = await NetTypelessAIFunction.Instance.InvokeAsync(arguments);
         Assert.Same(result, arguments);
@@ -210,7 +210,7 @@ public class FunctionCallContentTests
     [Fact]
     public async Task TypelessAIFunction_JsonElementValues_AcceptsArguments()
     {
-        Dictionary<string, object?> arguments = JsonSerializer.Deserialize<Dictionary<string, object?>>("""
+        AIFunctionArguments arguments = new(JsonSerializer.Deserialize<Dictionary<string, object?>>("""
             {
               "a": "string",
               "b": 123.4,
@@ -219,7 +219,7 @@ public class FunctionCallContentTests
               "e": ["Monday", "Tuesday", "Wednesday"],
               "f": null
             }
-            """, TestJsonSerializerContext.Default.Options)!;
+            """, TestJsonSerializerContext.Default.Options)!);
 
         var result = await NetTypelessAIFunction.Instance.InvokeAsync(arguments);
         Assert.Same(result, arguments);
@@ -228,7 +228,7 @@ public class FunctionCallContentTests
     [Fact]
     public async Task TypelessAIFunction_JsonNodeValues_AcceptsArguments()
     {
-        var arguments = JsonSerializer.Deserialize<Dictionary<string, JsonNode>>("""
+        AIFunctionArguments arguments = new(JsonSerializer.Deserialize<Dictionary<string, JsonNode>>("""
             {
               "a": "string",
               "b": 123.4,
@@ -237,7 +237,7 @@ public class FunctionCallContentTests
               "e": ["Monday", "Tuesday", "Wednesday"],
               "f": null
             }
-            """, TestJsonSerializerContext.Default.Options)!.ToDictionary(k => k.Key, k => (object?)k.Value);
+            """, TestJsonSerializerContext.Default.Options)!.ToDictionary(k => k.Key, k => (object?)k.Value));
 
         var result = await NetTypelessAIFunction.Instance.InvokeAsync(arguments);
         Assert.Same(result, arguments);
@@ -251,7 +251,7 @@ public class FunctionCallContentTests
 
         public override string Name => "NetTypeless";
         public override string Description => "AIFunction with parameters that lack .NET types";
-        protected override Task<object?> InvokeCoreAsync(IEnumerable<KeyValuePair<string, object?>>? arguments, CancellationToken cancellationToken) =>
+        protected override Task<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken) =>
             Task.FromResult<object?>(arguments);
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Functions/AIFunctionArgumentsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Functions/AIFunctionArgumentsTests.cs
@@ -1,0 +1,171 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class AIFunctionArgumentsTests
+{
+    [Fact]
+    public void NullArg_RoundtripsAsEmpty()
+    {
+        var args = new AIFunctionArguments();
+        Assert.Null(args.Services);
+        Assert.Empty(args);
+
+        args.Add("key", "value");
+        Assert.Single(args);
+    }
+
+    [Fact]
+    public void EmptyArg_RoundtripsAsEmpty()
+    {
+        var args = new AIFunctionArguments(new Dictionary<string, object?>());
+        Assert.Null(args.Services);
+        Assert.Empty(args);
+
+        args.Add("key", "value");
+        Assert.Single(args);
+    }
+
+    [Fact]
+    public void NonEmptyArg_RoundtripsAsEmpty()
+    {
+        var args = new AIFunctionArguments(new Dictionary<string, object?>
+        {
+            ["key"] = "value"
+        });
+        Assert.Null(args.Services);
+        Assert.Single(args);
+    }
+
+    [Fact]
+    public void Services_Roundtrips()
+    {
+        ServiceCollection sc = new();
+        IServiceProvider sp = sc.BuildServiceProvider();
+
+        var args = new AIFunctionArguments
+        {
+            Services = sp
+        };
+
+        Assert.Same(sp, args.Services);
+        Assert.Empty(args);
+
+        args.Add("key", "value");
+        Assert.Single(args);
+    }
+
+    [Fact]
+    public void IReadOnlyDictionary_ImplementsInterface()
+    {
+        ServiceCollection sc = new();
+        IServiceProvider sp = sc.BuildServiceProvider();
+
+        IReadOnlyDictionary<string, object?> args = new AIFunctionArguments(new Dictionary<string, object?>
+        {
+            ["key1"] = "value1",
+            ["key2"] = "value2",
+        });
+
+        Assert.Equal(2, args.Count);
+
+        Assert.True(args.ContainsKey("key1"));
+        Assert.True(args.ContainsKey("key2"));
+        Assert.False(args.ContainsKey("KEY1"));
+
+        Assert.Equal(["key1", "key2"], args.Keys);
+        Assert.Equal(["value1", "value2"], args.Values);
+
+        Assert.Equal("value1", args["key1"]);
+        Assert.Equal("value2", args["key2"]);
+
+        Assert.Equal(new[] { "key1", "key2" }, args.Keys);
+        Assert.Equal(new[] { "value1", "value2" }, args.Values);
+
+        Assert.True(args.TryGetValue("key1", out var value));
+        Assert.Equal("value1", value);
+        Assert.False(args.TryGetValue("key3", out value));
+        Assert.Null(value);
+
+        Assert.Equal([
+            new KeyValuePair<string, object?>("key1", "value1"),
+            new KeyValuePair<string, object?>("key2", "value2"),
+        ], args.ToArray());
+    }
+
+    [Fact]
+    public void IDictionary_ImplementsInterface()
+    {
+        ServiceCollection sc = new();
+        IServiceProvider sp = sc.BuildServiceProvider();
+
+        IDictionary<string, object?> args = new AIFunctionArguments(new Dictionary<string, object?>
+        {
+            ["key1"] = "value1",
+            ["key2"] = "value2",
+        });
+
+        Assert.Equal(2, args.Count);
+        Assert.False(args.IsReadOnly);
+
+        Assert.True(args.ContainsKey("key1"));
+        Assert.True(args.ContainsKey("key2"));
+        Assert.False(args.ContainsKey("KEY1"));
+
+        Assert.Equal("value1", args["key1"]);
+        Assert.Equal("value2", args["key2"]);
+
+        Assert.Equal(new[] { "key1", "key2" }, args.Keys);
+        Assert.Equal(new[] { "value1", "value2" }, args.Values);
+
+        Assert.True(args.TryGetValue("key1", out var value));
+        Assert.Equal("value1", value);
+        Assert.False(args.TryGetValue("key3", out value));
+        Assert.Null(value);
+
+        Assert.Equal([
+            new KeyValuePair<string, object?>("key1", "value1"),
+            new KeyValuePair<string, object?>("key2", "value2"),
+        ], args.ToArray());
+
+        args.Add("key3", "value3");
+        Assert.Equal(3, args.Count);
+        Assert.True(args.ContainsKey("key3"));
+        Assert.Equal("value3", args["key3"]);
+
+        args["key4"] = "value4";
+        Assert.Equal(4, args.Count);
+        Assert.True(args.ContainsKey("key4"));
+        Assert.Equal("value4", args["key4"]);
+
+        args.Remove("key1");
+        Assert.Equal(3, args.Count);
+        Assert.False(args.ContainsKey("key1"));
+        Assert.Equal("value2", args["key2"]);
+        Assert.Equal("value3", args["key3"]);
+        Assert.Equal("value4", args["key4"]);
+
+        args.Clear();
+        Assert.Empty(args);
+
+        args.Add(new KeyValuePair<string, object?>("key1", "value1"));
+        Assert.Single(args);
+        Assert.True(args.ContainsKey("key1"));
+        Assert.Equal("value1", args["key1"]);
+
+        args.Add(new KeyValuePair<string, object?>("key2", "value2"));
+        Assert.Equal(2, args.Count);
+        Assert.True(args.ContainsKey("key2"));
+        Assert.Equal("value2", args["key2"]);
+
+        Assert.Equal(["key1", "key2"], args.Keys);
+        Assert.Equal(["value1", "value2"], args.Values);
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Functions/AIFunctionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Functions/AIFunctionTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -10,22 +9,6 @@ namespace Microsoft.Extensions.AI;
 
 public class AIFunctionTests
 {
-    [Fact]
-    public async Task InvokeAsync_UsesDefaultEmptyCollectionForNullArgsAsync()
-    {
-        DerivedAIFunction f = new();
-
-        using CancellationTokenSource cts = new();
-        var result1 = ((IEnumerable<KeyValuePair<string, object?>>, CancellationToken))(await f.InvokeAsync(null, cts.Token))!;
-
-        Assert.NotNull(result1.Item1);
-        Assert.Empty(result1.Item1);
-        Assert.Equal(cts.Token, result1.Item2);
-
-        var result2 = ((IEnumerable<KeyValuePair<string, object?>>, CancellationToken))(await f.InvokeAsync(null, cts.Token))!;
-        Assert.Same(result1.Item1, result2.Item1);
-    }
-
     [Fact]
     public void ToString_ReturnsName()
     {
@@ -38,7 +21,7 @@ public class AIFunctionTests
         public override string Name => "name";
         public override string Description => "";
 
-        protected override Task<object?> InvokeCoreAsync(IEnumerable<KeyValuePair<string, object?>> arguments, CancellationToken cancellationToken)
+        protected override Task<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken)
         {
             Assert.NotNull(arguments);
             return Task.FromResult<object?>((arguments, cancellationToken));

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/TestJsonSerializerContext.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/TestJsonSerializerContext.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.AI;
 [JsonSerializable(typeof(ChatOptions))]
 [JsonSerializable(typeof(EmbeddingGenerationOptions))]
 [JsonSerializable(typeof(Dictionary<string, object?>))]
+[JsonSerializable(typeof(AIFunctionArguments))]
 [JsonSerializable(typeof(int[]))] // Used in ChatMessageContentTests
 [JsonSerializable(typeof(Embedding))] // Used in EmbeddingTests
 [JsonSerializable(typeof(Dictionary<string, JsonDocument>))] // Used in Content tests

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAISerializationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAISerializationTests.cs
@@ -382,7 +382,7 @@ public static partial class OpenAISerializationTests
         Assert.Equal("The person whose age is being requested", (string)parameterSchema["description"]!);
         Assert.Equal("string", (string)parameterSchema["type"]!);
 
-        Dictionary<string, object?> functionArgs = new() { ["personName"] = "John" };
+        AIFunctionArguments functionArgs = new() { ["personName"] = "John" };
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => function.InvokeAsync(functionArgs));
         Assert.Contains("does not support being invoked.", ex.Message);
     }


### PR DESCRIPTION
- Adds a new AIFunctionArguments type.
- Changes AIFunction.InvokeAsync to accept an AIFunctionArguments instead of an arbitrary enumerable.
- Changes FunctionInvokingChatClient to accept an IServiceProvider and expose it as a Services property, and to then pass that IServiceProvider into the AIFunction via AIFunctionArguments.Services.
- Augments FunctionInvocationContext with an AIFunctionArguments property.
- Changes AIFunctionFactory to special-case parameters of type IServiceProvider and AIFunctionArguments, sourcing from AIFunctionArguments.
- Makes AIJsonSchemaCreateOptions a record.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6158)