### PR TITLE
Simplify function calling error handling

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -60,7 +60,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
     private readonly ActivitySource? _activitySource;
 
     /// <summary>Maximum number of roundtrips allowed to the inner client.</summary>
-    private int? _maximumIterationsPerRequest;
+    private int _maximumIterationsPerRequest = 10;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FunctionInvokingChatClient"/> class.
@@ -138,7 +138,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
     /// </summary>
     /// <value>
     /// The maximum number of iterations per request.
-    /// The default value is <see langword="null"/>.
+    /// The default value is 10.
     /// </value>
     /// <remarks>
     /// <para>
@@ -146,15 +146,14 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
     /// multiple requests to the inner client. Each time the inner client responds with
     /// a function call request, this client might perform that invocation and send the results
     /// back to the inner client in a new request. This property limits the number of times
-    /// such a roundtrip is performed. If null, there is no limit applied. If set, the value
-    /// must be at least one, as it includes the initial request.
+    /// such a roundtrip is performed. The value must be at least one, as it includes the initial request.
     /// </para>
     /// <para>
     /// Changing the value of this property while the client is in use might result in inconsistencies
     /// as to how many iterations are allowed for an in-flight request.
     /// </para>
     /// </remarks>
-    public int? MaximumIterationsPerRequest
+    public int MaximumIterationsPerRequest
     {
         get => _maximumIterationsPerRequest;
         set
@@ -204,7 +203,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
             // Any function call work to do? If yes, ensure we're tracking that work in functionCallContents.
             bool requiresFunctionInvocation =
                 options?.Tools is { Count: > 0 } &&
-                (!MaximumIterationsPerRequest.HasValue || iteration < MaximumIterationsPerRequest.GetValueOrDefault()) &&
+                iteration < MaximumIterationsPerRequest &&
                 CopyFunctionCalls(response.Messages, ref functionCallContents);
 
             // In a common case where we make a request and there's no function calling work required,

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -287,7 +287,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
                 break;
             }
 
-            UpdateOptionsForMode(ref options!, response.ChatThreadId);
+            UpdateOptionsForNextIteration(ref options!, response.ChatThreadId);
         }
 
         Debug.Assert(responseMessages is not null, "Expected to only be here if we have response messages.");
@@ -392,7 +392,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
                 yield break;
             }
 
-            UpdateOptionsForMode(ref options, response.ChatThreadId);
+            UpdateOptionsForNextIteration(ref options, response.ChatThreadId);
         }
     }
 
@@ -490,8 +490,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
         return any;
     }
 
-    /// <summary>Updates <paramref name="options"/> for the response.</summary>
-    private static void UpdateOptionsForMode(ref ChatOptions options, string? chatThreadId)
+    private static void UpdateOptionsForNextIteration(ref ChatOptions options, string? chatThreadId)
     {
         if (options.ToolMode is RequiredChatToolMode)
         {

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -201,15 +201,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
     public int MaximumConsecutiveErrorsPerRequest
     {
         get => _maximumConsecutiveErrorsPerRequest;
-        set
-        {
-            if (value < 0)
-            {
-                Throw.ArgumentOutOfRangeException(nameof(value));
-            }
-
-            _maximumConsecutiveErrorsPerRequest = value;
-        }
+        set => _maximumConsecutiveErrorsPerRequest = Throw.IfLessThan(value, 0);
     }
 
     /// <inheritdoc/>

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -844,7 +844,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
         /// <summary>Gets any exception the function call threw.</summary>
         public Exception? Exception { get; }
 
-        /// <summary>Gets a value indicating whether indication the caller should terminate the processing loop.</summary>
+        /// <summary>Gets a value indicating whether the caller should terminate the processing loop.</summary>
         internal bool ShouldTerminate { get; }
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -592,7 +593,15 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
             consecutiveErrorCount++;
             if (consecutiveErrorCount > _maximumConsecutiveErrorsPerRequest)
             {
-                throw new AggregateException(allExceptions);
+                var allExceptionsArray = allExceptions.ToArray();
+                if (allExceptionsArray.Length == 1)
+                {
+                    ExceptionDispatchInfo.Capture(allExceptionsArray[0]).Throw();
+                }
+                else
+                {
+                    throw new AggregateException(allExceptionsArray);
+                }
             }
         }
         else

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -324,7 +324,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
         List<ChatMessage>? responseMessages = null; // tracked list of messages, across multiple turns, to be used in fallback cases to reconstitute history
         bool lastIterationHadThreadId = false; // whether the last iteration's response had a ChatThreadId set
         List<ChatResponseUpdate> updates = []; // updates from the current response
-        int consecutiveFailureCount = 0;
+        int consecutiveErrorCount = 0;
 
         for (int iteration = 0; ; iteration++)
         {
@@ -362,9 +362,9 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
             FixupHistories(originalMessages, ref messages, ref augmentedHistory, response, responseMessages, ref lastIterationHadThreadId);
 
             // Process all of the functions, adding their results into the history.
-            var modeAndMessages = await ProcessFunctionCallsAsync(augmentedHistory, options, functionCallContents, iteration, consecutiveFailureCount, cancellationToken).ConfigureAwait(false);
+            var modeAndMessages = await ProcessFunctionCallsAsync(augmentedHistory, options, functionCallContents, iteration, consecutiveErrorCount, cancellationToken).ConfigureAwait(false);
             responseMessages.AddRange(modeAndMessages.MessagesAdded);
-            consecutiveFailureCount = modeAndMessages.NewConsecutiveErrorCount;
+            consecutiveErrorCount = modeAndMessages.NewConsecutiveErrorCount;
 
             // This is a synthetic ID since we're generating the tool messages instead of getting them from
             // the underlying provider. When emitting the streamed chunks, it's perfectly valid for us to

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -35,7 +35,7 @@ public class FunctionInvokingChatClientTests
 
         Assert.False(client.AllowConcurrentInvocation);
         Assert.False(client.IncludeDetailedErrors);
-        Assert.Null(client.MaximumIterationsPerRequest);
+        Assert.Equal(10, client.MaximumIterationsPerRequest);
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -271,23 +271,23 @@ public class FunctionInvokingChatClientTests
             new ChatMessage(ChatRole.User, "hello"),
 
             // A single failure isn't enough to stop the cycle
-            ..CreateIterationPlan(ref callIndex, true, false),
+            ..CreateFunctionCallIterationPlan(ref callIndex, true, false),
 
             // Now NumConsecutiveErrors = 1
             // We can reset the number of consecutive errors by having a successful iteration
-            ..CreateIterationPlan(ref callIndex, false, false, false),
+            ..CreateFunctionCallIterationPlan(ref callIndex, false, false, false),
 
             // Now NumConsecutiveErrors = 0
             // Any failure within an iteration causes the whole iteration to be treated as failed
-            ..CreateIterationPlan(ref callIndex, false, true, false),
+            ..CreateFunctionCallIterationPlan(ref callIndex, false, true, false),
 
             // Now NumConsecutiveErrors = 1
             // Even if several calls in the same iteration fail, that only counts as a single iteration having failed, so won't exceed the limit yet
-            ..CreateIterationPlan(ref callIndex, true, true, true),
+            ..CreateFunctionCallIterationPlan(ref callIndex, true, true, true),
 
             // Now NumConsecutiveErrors = 2
             // Any more failures will now exceed the limit
-            ..CreateIterationPlan(ref callIndex, true, true),
+            ..CreateFunctionCallIterationPlan(ref callIndex, true, true),
         ];
 
         var ex = await Assert.ThrowsAsync<AggregateException>(() =>
@@ -301,23 +301,64 @@ public class FunctionInvokingChatClientTests
         Assert.Equal(2, ex.InnerExceptions.Count);
         Assert.Equal("Exception from call 11", Assert.IsType<InvalidTimeZoneException>(ex.InnerExceptions[0]).Message);
         Assert.Equal("Exception from call 12", Assert.IsType<InvalidTimeZoneException>(ex.InnerExceptions[1]).Message);
+    }
 
-        static IEnumerable<ChatMessage> CreateIterationPlan(ref int callIndex, params bool[] shouldThrow)
-        {
-            var assistantMessage = new ChatMessage(ChatRole.Assistant, []);
-            var toolMessage = new ChatMessage(ChatRole.Tool, []);
-
-            foreach (var callShouldThrow in shouldThrow)
+    [Fact]
+    public async Task CanFailOnFirstException()
+    {
+        Func<ChatClientBuilder, ChatClientBuilder> configurePipeline = pipeline => pipeline
+            .UseFunctionInvocation(configure: functionInvokingChatClient =>
             {
-                var thisCallIndex = callIndex++;
-                var callId = $"callId{thisCallIndex}";
-                assistantMessage.Contents.Add(new FunctionCallContent(callId, "Func",
-                    arguments: new Dictionary<string, object?> { { "shouldThrow", callShouldThrow }, { "callIndex", thisCallIndex } }));
-                toolMessage.Contents.Add(new FunctionResultContent(callId, result: callShouldThrow ? "Error: Function failed." : "Success"));
-            }
+                functionInvokingChatClient.MaximumConsecutiveErrorsPerRequest = 0;
+            });
 
-            return [assistantMessage, toolMessage];
+        var callCount = 0;
+        var options = new ChatOptions
+        {
+            Tools =
+            [
+                AIFunctionFactory.Create(() =>
+                {
+                    callCount++;
+                    throw new InvalidTimeZoneException($"It failed");
+                }, "Func"),
+            ]
+        };
+
+        var callIndex = 0;
+        List<ChatMessage> plan =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+            ..CreateFunctionCallIterationPlan(ref callIndex, true),
+        ];
+
+        var ex = await Assert.ThrowsAsync<InvalidTimeZoneException>(() =>
+            InvokeAndAssertAsync(options, plan, configurePipeline: configurePipeline));
+        Assert.Equal("It failed", ex.Message);
+        Assert.Equal(1, callCount);
+        callCount = 0;
+
+        ex = await Assert.ThrowsAsync<InvalidTimeZoneException>(() =>
+            InvokeAndAssertStreamingAsync(options, plan, configurePipeline: configurePipeline));
+        Assert.Equal("It failed", ex.Message);
+        Assert.Equal(1, callCount);
+    }
+
+    private static IEnumerable<ChatMessage> CreateFunctionCallIterationPlan(ref int callIndex, params bool[] shouldThrow)
+    {
+        var assistantMessage = new ChatMessage(ChatRole.Assistant, []);
+        var toolMessage = new ChatMessage(ChatRole.Tool, []);
+
+        foreach (var callShouldThrow in shouldThrow)
+        {
+            var thisCallIndex = callIndex++;
+            var callId = $"callId{thisCallIndex}";
+            assistantMessage.Contents.Add(new FunctionCallContent(callId, "Func",
+                arguments: new Dictionary<string, object?> { { "shouldThrow", callShouldThrow }, { "callIndex", thisCallIndex } }));
+            toolMessage.Contents.Add(new FunctionResultContent(callId, result: callShouldThrow ? "Error: Function failed." : "Success"));
         }
+
+        return [assistantMessage, toolMessage];
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -36,7 +36,6 @@ public class FunctionInvokingChatClientTests
         Assert.False(client.AllowConcurrentInvocation);
         Assert.False(client.IncludeDetailedErrors);
         Assert.Null(client.MaximumIterationsPerRequest);
-        Assert.False(client.RetryOnError);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #6029, following the design described there

 * Remove the `RetryOnError` config option
 * Add a new config option `MaximumConsecutiveErrorsPerRequest` (default: 3)
 * Change `MaximumIterationsPerRequest` to be non-nullable and default to 10

This is sufficient to model various error-handling modes:

 * To rethrow exceptions in all cases, set `MaximumConsecutiveErrorsPerRequest` to 0
 * To retry almost-forever like we had before, set `MaximumConsecutiveErrorsPerRequest` and `MaximumIterationsPerRequest` both to `int.MaxValue` but **this is almost certainly a bad idea**
 * To get the "one last try but without tools" behavior, have `MaximumConsecutiveErrorsPerRequest > 0` and add custom middleware that observes `FunctionResultContent.Exception` being nonnull and uses that as a signal to change `chatOptions.Tools` to `[]`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6169)