### PR TITLE
Fix build failing when running `./build.cmd -vs AI` multiple times

### DIFF
--- a/scripts/Slngen.ps1
+++ b/scripts/Slngen.ps1
@@ -64,7 +64,7 @@ param (
     [Parameter(Mandatory = $false, HelpMessage="Enables use of folders.")]
     [switch]$Folders = $false,
     [Parameter(Mandatory = $false, HelpMessage="Path to exclude from search for project files. Must be repo root folder based.")]
-    [string[]]$ExcludePaths = @('src\Tools\MutationTesting\samples\', 'src\Templates\templates', 'test\**\Snapshots'),
+    [string[]]$ExcludePaths = @('src\Tools\MutationTesting\samples\', 'src\ProjectTemplates\**\src\', 'test\**\Snapshots'),
     [Parameter(Mandatory = $false, HelpMessage="Don't launch Visual Studio.")]
     [switch]$NoLaunch = $false,
     [Parameter(Mandatory = $false, HelpMessage="Minimizes console output.")]


### PR DESCRIPTION
## Overview

When running `./build.cmd -vs AI` multiple times in a row, the build would fail with an error similar to:
```text
    src\ProjectTemplates\Microsoft.Extensions.AI.Templates\src\ChatWithCustomData\ChatWithCustomData.Web-CSharp\ChatWithCustomData.Web-CSharp.csproj : error NU1301: The local source 'artifacts\packages\Debug\Shipping\' doesn't exist.
    src\ProjectTemplates\Microsoft.Extensions.AI.Templates\src\ChatWithCustomData\ChatWithCustomData.Web-CSharp\ChatWithCustomData.Web-CSharp.csproj : error NU1301: The local source 'artifacts\packages\Debug\Shipping\' doesn't exist.

Restore failed with 2 error(s) in 5.4s
```

This is what was happening:
* The first run of `./build.cmd -vs AI` would generate an `SDK.sln` for projects with the `AI` workload. This includes the `Microsoft.Extensions.AI.Templates` project, which as part of its own build generates a `.csproj` file for the chat template (`ChatWithCustomData.Web-CSharp.csproj`).
* The second run of `./build.cmd -vs AI` would pick up the generated `.csproj` from the previous build and add it to `SDK.sln`.
* The build fails because template `.csproj` files require the `artifacts/packages/Debug/Shipping` folder to contain locally-built nuget packages.

The workaround is to run `./build.cmd -build -pack` between the first and second runs of `./build.cmd -vs AI`, but this is a poor developer experience.

## Fix

This PR updates `Slngen.ps1` to correctly exclude generated template project files from `SDK.sln`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6171)