### PR TITLE
Add custom result marshaling support to AIFunctionFactory

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunction.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunction.cs
@@ -53,7 +53,7 @@ public abstract class AIFunction : AITool
     /// <param name="arguments">The arguments to pass to the function's invocation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The result of the function's execution.</returns>
-    public Task<object?> InvokeAsync(
+    public ValueTask<object?> InvokeAsync(
         AIFunctionArguments? arguments = null,
         CancellationToken cancellationToken = default) =>
         InvokeCoreAsync(arguments ?? [], cancellationToken);
@@ -62,7 +62,7 @@ public abstract class AIFunction : AITool
     /// <param name="arguments">The arguments to pass to the function's invocation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>The result of the function's execution.</returns>
-    protected abstract Task<object?> InvokeCoreAsync(
+    protected abstract ValueTask<object?> InvokeCoreAsync(
         AIFunctionArguments arguments,
         CancellationToken cancellationToken);
 }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMapper.ChatCompletion.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMapper.ChatCompletion.cs
@@ -438,7 +438,7 @@ internal static partial class OpenAIModelMappers
         public override string Description => description;
         public override JsonElement JsonSchema => schema;
         public override IReadOnlyDictionary<string, object?> AdditionalProperties => additionalProps;
-        protected override Task<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken) =>
+        protected override ValueTask<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken) =>
             throw new InvalidOperationException($"The AI function '{Name}' does not support being invoked.");
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactoryOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactoryOptions.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.AI;
 
@@ -71,6 +72,32 @@ public sealed class AIFunctionFactoryOptions
     /// </para>
     /// </remarks>
     public Func<ParameterInfo, ParameterBindingOptions>? ConfigureParameterBinding { get; set; }
+
+    /// <summary>Gets or sets a delegate used to determine the <see cref="object"/> returned by <see cref="AIFunction.InvokeAsync"/>.</summary>
+    /// <remarks>
+    /// <para>
+    /// By default, the return value of invoking the method wrapped into an <see cref="AIFunction"/> by <see cref="AIFunctionFactory"/>
+    /// is then JSON serialized, with the resulting <see cref="JsonElement"/> returned from the <see cref="AIFunction.InvokeAsync"/> method.
+    /// This default behavior is ideal for the common case where the result will be passed back to an AI service. However, if the caller
+    /// requires more control over the result's marshaling, the <see cref="MarshalResult"/> property may be set to a delegate that is
+    /// then provided with complete control over the result's marshaling. The delegate is invoked with the value returned by the method,
+    /// and its return value is then returned from the <see cref="AIFunction.InvokeAsync"/> method.
+    /// </para>
+    /// <para>
+    /// When set, the delegate is invoked even for <see langword="void"/>-returning methods, in which case it is invoked with
+    /// a <see langword="null"/> argument. By default, <see langword="null"/> is returned from the <see cref="AIFunction.InvokeAsync"/>
+    /// method for <see cref="AIFunction"/> instances produced by <see cref="AIFunctionFactory"/> to wrap
+    /// <see langword="void"/>-returning methods).
+    /// </para>
+    /// <para>
+    /// Methods strongly-typed to return types of <see cref="Task"/>, <see cref="Task{TResult}"/>, <see cref="ValueTask"/>,
+    /// and <see cref="ValueTask{TResult}"/> are special-cased. For methods typed to return <see cref="Task"/> or <see cref="ValueTask"/>,
+    /// <see cref="MarshalResult"/> will be invoked with the <see langword="null"/> value after the returned task has successfully completed.
+    /// For methods typed to return <see cref="Task{TResult}"/> or <see cref="ValueTask{TResult}"/>, the delegate will be invoked with the
+    /// task's result value after the task has successfully completed.These behaviors keep synchronous and asynchronous methods consistent.
+    /// </para>
+    /// </remarks>
+    public Func<object?, CancellationToken, ValueTask<object?>>? MarshalResult { get; set; }
 
     /// <summary>Provides configuration options produced by the <see cref="ConfigureParameterBinding"/> delegate.</summary>
     public readonly record struct ParameterBindingOptions

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactoryOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactoryOptions.cs
@@ -96,8 +96,15 @@ public sealed class AIFunctionFactoryOptions
     /// For methods typed to return <see cref="Task{TResult}"/> or <see cref="ValueTask{TResult}"/>, the delegate will be invoked with the
     /// task's result value after the task has successfully completed.These behaviors keep synchronous and asynchronous methods consistent.
     /// </para>
+    /// <para>
+    /// In addition to the returned value, which is provided to the delegate as the first argument, the delegate is also provided with
+    /// a <see cref="Type"/> represented the declared return type of the method. This can be used to determine how to marshal the result.
+    /// This may be different than the actual type of the object (<see cref="object.GetType"/>) if the method returns a derived type
+    /// or <see langword="null"/>. If the method is typed to return <see cref="Task"/>, <see cref="ValueTask"/>, or <see langword="void"/>,
+    /// the <see cref="Type"/> argument will be <see langword="null"/>.
+    /// </para>
     /// </remarks>
-    public Func<object?, CancellationToken, ValueTask<object?>>? MarshalResult { get; set; }
+    public Func<object?, Type?, CancellationToken, ValueTask<object?>>? MarshalResult { get; set; }
 
     /// <summary>Provides configuration options produced by the <see cref="ConfigureParameterBinding"/> delegate.</summary>
     public readonly record struct ParameterBindingOptions

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/FunctionCallContentTests..cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/FunctionCallContentTests..cs
@@ -251,8 +251,8 @@ public class FunctionCallContentTests
 
         public override string Name => "NetTypeless";
         public override string Description => "AIFunction with parameters that lack .NET types";
-        protected override Task<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken) =>
-            Task.FromResult<object?>(arguments);
+        protected override ValueTask<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken) =>
+            new(arguments);
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Functions/AIFunctionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Functions/AIFunctionTests.cs
@@ -21,10 +21,10 @@ public class AIFunctionTests
         public override string Name => "name";
         public override string Description => "";
 
-        protected override Task<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken)
+        protected override ValueTask<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken)
         {
             Assert.NotNull(arguments);
-            return Task.FromResult<object?>((arguments, cancellationToken));
+            return new ValueTask<object?>((arguments, cancellationToken));
         }
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAISerializationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAISerializationTests.cs
@@ -383,7 +383,7 @@ public static partial class OpenAISerializationTests
         Assert.Equal("string", (string)parameterSchema["type"]!);
 
         AIFunctionArguments functionArgs = new() { ["personName"] = "John" };
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => function.InvokeAsync(functionArgs));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => function.InvokeAsync(functionArgs).AsTask());
         Assert.Contains("does not support being invoked.", ex.Message);
     }
 
@@ -731,8 +731,8 @@ public static partial class OpenAISerializationTests
         expected = NormalizeNewLines(expected);
         actual = NormalizeNewLines(actual);
 
-        JsonNode? expectedNode = JsonNode.Parse(expected);
-        JsonNode? actualNode = JsonNode.Parse(actual);
+        var expectedNode = JsonNode.Parse(expected);
+        var actualNode = JsonNode.Parse(actual);
 
         if (!JsonNode.DeepEquals(expectedNode, actualNode))
         {

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 #pragma warning disable S107 // Methods should not have too many parameters
 #pragma warning disable S3358 // Ternary operators should not be nested
+#pragma warning disable S5034 // "ValueTask" should be consumed correctly
 
 namespace Microsoft.Extensions.AI;
 
@@ -64,7 +65,7 @@ public class AIFunctionFactoryTest
 
         foreach (AIFunction f in funcs)
         {
-            Exception e = await Assert.ThrowsAsync<ArgumentException>(() => f.InvokeAsync());
+            Exception e = await Assert.ThrowsAsync<ArgumentException>(() => f.InvokeAsync().AsTask());
             Assert.Contains("'theParam'", e.Message);
         }
     }
@@ -122,7 +123,7 @@ public class AIFunctionFactoryTest
         }
 
         func = AIFunctionFactory.Create(() => (IAsyncEnumerable<int>)new ThrowingAsyncEnumerable());
-        await Assert.ThrowsAsync<NotImplementedException>(() => func.InvokeAsync());
+        await Assert.ThrowsAsync<NotImplementedException>(() => func.InvokeAsync().AsTask());
     }
 
     private sealed class ThrowingAsyncEnumerable : IAsyncEnumerable<int>
@@ -259,7 +260,7 @@ public class AIFunctionFactoryTest
         Assert.DoesNotContain("services", func.JsonSchema.ToString());
         Assert.DoesNotContain("arguments", func.JsonSchema.ToString());
 
-        await Assert.ThrowsAsync<ArgumentException>("arguments", () => func.InvokeAsync(arguments));
+        await Assert.ThrowsAsync<ArgumentException>("arguments", () => func.InvokeAsync(arguments).AsTask());
 
         arguments.Services = sp;
         var result = await func.InvokeAsync(arguments);
@@ -328,7 +329,7 @@ public class AIFunctionFactoryTest
         Assert.Contains("myInteger", f.JsonSchema.ToString());
         Assert.DoesNotContain("service", f.JsonSchema.ToString());
 
-        Exception e = await Assert.ThrowsAsync<ArgumentException>(() => f.InvokeAsync(new() { ["myInteger"] = 1 }));
+        Exception e = await Assert.ThrowsAsync<ArgumentException>(() => f.InvokeAsync(new() { ["myInteger"] = 1 }).AsTask());
         Assert.Contains("Unable to resolve", e.Message);
 
         var result = await f.InvokeAsync(new() { ["myInteger"] = 1, Services = sp });
@@ -365,14 +366,14 @@ public class AIFunctionFactoryTest
         Assert.Contains("myInteger", f.JsonSchema.ToString());
         Assert.DoesNotContain("service", f.JsonSchema.ToString());
 
-        Exception e = await Assert.ThrowsAsync<ArgumentException>(() => f.InvokeAsync(new() { ["myInteger"] = 1 }));
+        Exception e = await Assert.ThrowsAsync<ArgumentException>(() => f.InvokeAsync(new() { ["myInteger"] = 1 }).AsTask());
         Assert.Contains("Unable to resolve", e.Message);
 
         e = await Assert.ThrowsAsync<ArgumentException>(() => f.InvokeAsync(new()
         {
             ["myInteger"] = 1,
             Context = new Dictionary<object, object?>(),
-        }));
+        }).AsTask());
         Assert.Contains("Unable to resolve", e.Message);
 
         var result = await f.InvokeAsync(new()
@@ -418,6 +419,138 @@ public class AIFunctionFactoryTest
 
         var result = await f.InvokeAsync(args1);
         Assert.Contains("43", result?.ToString());
+    }
+
+    [Fact]
+    public async Task MarshalResult_UsedForVoidReturningMethods()
+    {
+        using CancellationTokenSource cts = new();
+
+        AIFunction f = AIFunctionFactory.Create(
+            (int i) => { },
+            new()
+            {
+                MarshalResult = async (result, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    Assert.Null(result);
+                    Assert.Equal(cts.Token, cancellationToken);
+                    return "marshalResultInvoked";
+                },
+            });
+
+        object? result = await f.InvokeAsync(new() { ["i"] = 42 }, cts.Token);
+        Assert.Equal("marshalResultInvoked", result);
+    }
+
+    [Fact]
+    public async Task MarshalResult_UsedForTaskReturningMethods()
+    {
+        using CancellationTokenSource cts = new();
+
+        AIFunction f = AIFunctionFactory.Create(
+            async (int i) => { await Task.Yield(); },
+            new()
+            {
+                MarshalResult = async (result, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    Assert.Null(result);
+                    Assert.Equal(cts.Token, cancellationToken);
+                    return "marshalResultInvoked";
+                },
+            });
+
+        object? result = await f.InvokeAsync(new() { ["i"] = 42 }, cts.Token);
+        Assert.Equal("marshalResultInvoked", result);
+    }
+
+    [Fact]
+    public async Task MarshalResult_UsedForValueTaskReturningMethods()
+    {
+        using CancellationTokenSource cts = new();
+
+        AIFunction f = AIFunctionFactory.Create(
+            async ValueTask (int i) => { await Task.Yield(); },
+            new()
+            {
+                MarshalResult = async (result, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    Assert.Null(result);
+                    Assert.Equal(cts.Token, cancellationToken);
+                    return "marshalResultInvoked";
+                },
+            });
+
+        object? result = await f.InvokeAsync(new() { ["i"] = 42 }, cts.Token);
+        Assert.Equal("marshalResultInvoked", result);
+    }
+
+    [Fact]
+    public async Task MarshalResult_UsedForTReturningMethods()
+    {
+        using CancellationTokenSource cts = new();
+
+        AIFunction f = AIFunctionFactory.Create(
+            (int i) => i,
+            new()
+            {
+                MarshalResult = async (result, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    Assert.Equal(42, result);
+                    Assert.Equal(cts.Token, cancellationToken);
+                    return "marshalResultInvoked";
+                },
+            });
+
+        object? result = await f.InvokeAsync(new() { ["i"] = 42 }, cts.Token);
+        Assert.Equal("marshalResultInvoked", result);
+    }
+
+    [Fact]
+    public async Task MarshalResult_UsedForTaskTReturningMethods()
+    {
+        using CancellationTokenSource cts = new();
+
+        AIFunction f = AIFunctionFactory.Create(
+            async (int i) => { await Task.Yield(); return i; },
+            new()
+            {
+                MarshalResult = async (result, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    Assert.Equal(42, result);
+                    Assert.Equal(cts.Token, cancellationToken);
+                    return "marshalResultInvoked";
+                },
+            });
+
+        object? result = await f.InvokeAsync(new() { ["i"] = 42 }, cts.Token);
+        Assert.Equal("marshalResultInvoked", result);
+    }
+
+    [Fact]
+    public async Task MarshalResult_UsedForValueTaskTReturningMethods()
+    {
+        using CancellationTokenSource cts = new();
+
+        AIFunction f = AIFunctionFactory.Create(
+            async ValueTask<int> (int i) => { await Task.Yield(); return i; },
+            new()
+            {
+                MarshalResult = async (result, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    Assert.Equal(42, result);
+                    Assert.Equal(cts.Token, cancellationToken);
+                    return "marshalResultInvoked";
+                },
+            });
+
+        object? result = await f.InvokeAsync(new() { ["i"] = 42 }, cts.Token);
+        Assert.Equal("marshalResultInvoked", result);
     }
 
     private sealed class MyService(int value)


### PR DESCRIPTION
Higher-level libraries can then specialize how results are handled, rather than them always being JSON serialized. This lets them then special-case certain domain-specific result values/types, or provide a non-null result for void-returning methods, or any other policy.

I also changed the result of AIFunction to be ValueTask instead of Task. This can be on a hot path, and as direct consumption is rare, we needn't be particularly concerned about misuse.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6175)