### PR TITLE
Fix chat template input form submission on Firefox

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/ChatInput.razor.js
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/ChatInput.razor.js
@@ -10,7 +10,7 @@
         if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
             elem.dispatchEvent(new CustomEvent('change', { bubbles: true }));
-            elem.closest('form').dispatchEvent(new CustomEvent('submit', { bubbles: true }));
+            elem.closest('form').dispatchEvent(new CustomEvent('submit', { bubbles: true, cancelable: true }));
         }
     });
 }

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/Components/Pages/Chat/ChatInput.razor.js
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/Components/Pages/Chat/ChatInput.razor.js
@@ -10,7 +10,7 @@
         if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
             elem.dispatchEvent(new CustomEvent('change', { bubbles: true }));
-            elem.closest('form').dispatchEvent(new CustomEvent('submit', { bubbles: true }));
+            elem.closest('form').dispatchEvent(new CustomEvent('submit', { bubbles: true, cancelable: true }));
         }
     });
 }


### PR DESCRIPTION
The JavaScript-dispatched `'submit'` event for the chat input form was uncancellable on Firefox. This meant sending a chat message performed a full POST request that bypasses the interactive form handler, and this fails because the chat template doesn't use prerendering (and even if it did, the behavior would still be wrong).

The solution is to specify the `cancelable` property as `true` on the options object used to construct the custom `'submit'` event.

Fixes https://github.com/dotnet/extensions/issues/6150
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6188)