### PR TITLE
Support adding tags to scenarios

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageReportingConfiguration.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageReportingConfiguration.cs
@@ -45,10 +45,22 @@ public static class AzureStorageReportingConfiguration
     /// The name of the current execution. See <see cref="ScenarioRun.ExecutionName"/> for more information about this
     /// concept. Uses a fixed default value <c>"Default"</c> if omitted.
     /// </param>
+    /// <param name="evaluationMetricInterpreter">
+    /// An optional function that can be used to override <see cref="EvaluationMetricInterpretation"/>s for
+    /// <see cref="EvaluationMetric"/>s returned from evaluations that use the returned
+    /// <see cref="ReportingConfiguration"/>. The supplied function can either return a new
+    /// <see cref="EvaluationMetricInterpretation"/> for any <see cref="EvaluationMetric"/> that is supplied to it, or
+    /// return <see langword="null"/> if the <see cref="EvaluationMetric.Interpretation"/> should be left unchanged.
+    /// </param>
+    /// <param name="tags">
+    /// A optional set of text tags applicable to all <see cref="ScenarioRun"/>s created using the returned
+    /// <see cref="ReportingConfiguration"/>.
+    /// </param>
     /// <returns>
     /// A <see cref="ReportingConfiguration"/> that persists <see cref="ScenarioRunResult"/>s to Azure Storage
     /// and also uses Azure Storage to cache AI responses.
     /// </returns>
+#pragma warning disable S107 // Methods should not have too many parameters
     public static ReportingConfiguration Create(
         DataLakeDirectoryClient client,
         IEnumerable<IEvaluator> evaluators,
@@ -56,7 +68,10 @@ public static class AzureStorageReportingConfiguration
         ChatConfiguration? chatConfiguration = null,
         bool enableResponseCaching = true,
         IEnumerable<string>? cachingKeys = null,
-        string executionName = Defaults.DefaultExecutionName)
+        string executionName = Defaults.DefaultExecutionName,
+        Func<EvaluationMetric, EvaluationMetricInterpretation?>? evaluationMetricInterpreter = null,
+        IEnumerable<string>? tags = null)
+#pragma warning restore S107
     {
         IResponseCacheProvider? responseCacheProvider =
             chatConfiguration is not null && enableResponseCaching
@@ -71,6 +86,8 @@ public static class AzureStorageReportingConfiguration
             chatConfiguration,
             responseCacheProvider,
             cachingKeys,
-            executionName);
+            executionName,
+            evaluationMetricInterpreter,
+            tags);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResponseCache.CacheEntry.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResponseCache.CacheEntry.cs
@@ -20,7 +20,7 @@ using Microsoft.Extensions.AI.Evaluation.Reporting.JsonSerialization;
 
 namespace Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
 
-public partial class AzureStorageResponseCache
+internal partial class AzureStorageResponseCache
 {
     [method: JsonConstructor]
     internal sealed class CacheEntry(

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResponseCacheProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResponseCacheProvider.cs
@@ -15,7 +15,8 @@ using Microsoft.Extensions.Caching.Distributed;
 namespace Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
 
 /// <summary>
-/// An <see cref="IResponseCacheProvider"/> that returns a <see cref="AzureStorageResponseCache"/>.
+/// An <see cref="IResponseCacheProvider"/> that returns an <see cref="IDistributedCache"/> that can cache AI responses
+/// for a particular <see cref="ScenarioRun"/> under an Azure Storage container.
 /// </summary>
 /// <param name="client">
 /// A <see cref="DataLakeDirectoryClient"/> with access to an Azure Storage container under which the cached AI
@@ -36,8 +37,8 @@ public sealed class AzureStorageResponseCacheProvider(
     /// </remarks>
     internal AzureStorageResponseCacheProvider(
         DataLakeDirectoryClient client,
-        TimeSpan? timeToLiveForCacheEntries,
-        Func<DateTime> provideDateTime)
+        Func<DateTime> provideDateTime,
+        TimeSpan? timeToLiveForCacheEntries = null)
             : this(client, timeToLiveForCacheEntries)
     {
         _provideDateTime = provideDateTime;
@@ -54,8 +55,8 @@ public sealed class AzureStorageResponseCacheProvider(
                 client,
                 scenarioName,
                 iterationName,
-                timeToLiveForCacheEntries,
-                _provideDateTime);
+                _provideDateTime,
+                timeToLiveForCacheEntries);
 
         return new ValueTask<IDistributedCache>(cache);
     }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ChatDetails.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ChatDetails.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Extensions.AI.Evaluation.Reporting;
+
+/// <summary>
+/// A class that records details related to all LLM chat conversation turns involved in the execution of a particular
+/// <see cref="ScenarioRun"/>.
+/// </summary>
+public sealed class ChatDetails
+{
+    /// <summary>
+    /// Gets or sets the <see cref="ChatTurnDetails"/> for the LLM chat conversation turns recorded in this
+    /// <see cref="ChatDetails"/> object.
+    /// </summary>
+#pragma warning disable CA2227
+    // CA2227: Collection properties should be read only.
+    // We disable this warning because we want this type to be fully mutable for serialization purposes and for general
+    // convenience.
+    public IList<ChatTurnDetails> TurnDetails { get; set; }
+#pragma warning restore CA2227
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChatDetails"/> class.
+    /// </summary>
+    /// <param name="turnDetails">
+    /// A list of <see cref="ChatTurnDetails"/> objects.
+    /// </param>
+    [JsonConstructor]
+    public ChatDetails(IList<ChatTurnDetails> turnDetails)
+    {
+        TurnDetails = turnDetails;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChatDetails"/> class.
+    /// </summary>
+    /// <param name="turnDetails">
+    /// An enumeration of <see cref="ChatTurnDetails"/> objects.
+    /// </param>
+    public ChatDetails(IEnumerable<ChatTurnDetails> turnDetails)
+        : this(turnDetails.ToList())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChatDetails"/> class.
+    /// </summary>
+    /// <param name="turnDetails">
+    /// An array of <see cref="ChatTurnDetails"/> objects.
+    /// </param>
+    public ChatDetails(params ChatTurnDetails[] turnDetails)
+        : this(turnDetails as IEnumerable<ChatTurnDetails>)
+    {
+    }
+
+    /// <summary>
+    /// Adds <see cref="ChatTurnDetails"/> for a particular LLM chat conversation turn to the <see cref="TurnDetails"/>
+    /// collection.
+    /// </summary>
+    /// <param name="turnDetails">
+    /// The <see cref="ChatTurnDetails"/> for a particular LLM chat conversation turn.
+    /// </param>
+    public void AddTurnDetails(ChatTurnDetails turnDetails)
+        => TurnDetails.Add(turnDetails);
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ChatTurnDetails.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ChatTurnDetails.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable S3604
+// S3604: Member initializer values should not be redundant.
+// We disable this warning because it is a false positive arising from the analyzer's lack of support for C#'s primary
+// constructor syntax.
+
+using System;
+
+namespace Microsoft.Extensions.AI.Evaluation.Reporting;
+
+/// <summary>
+/// A class that records details related to a particular LLM chat conversation turn involved in the execution of a
+/// particular <see cref="ScenarioRun"/>.
+/// </summary>
+/// <param name="latency">
+/// The duration between the time when the request was sent to the LLM and the time when the response was received for
+/// the chat conversation turn.
+/// </param>
+/// <param name="model">
+/// The model that was used in the creation of the response for the chat conversation turn. Can be
+/// <see langword="null"/> if this information was not available via <see cref="ChatResponse.ModelId"/>.
+/// </param>
+/// <param name="usage">
+/// Usage details for the chat conversation turn (including input and output token counts). Can be
+/// <see langword="null"/> if usage details were not available via <see cref="ChatResponse.Usage"/>.
+/// </param>
+/// <param name="cacheKey">
+/// The cache key for the cached model response for the chat conversation turn if response caching was enabled;
+/// <see langword="null"/> otherwise.
+/// </param>
+/// <param name="cacheHit">
+/// <see langword="true"/> if response caching was enabled and the model response for the chat conversation turn was
+/// retrieved from the cache; <see langword="false"/> if response caching was enabled and the model response was not
+/// retrieved from the cache; <see langword="null"/> if response caching was disabled.
+/// </param>
+public sealed class ChatTurnDetails(
+    TimeSpan latency,
+    string? model = null,
+    UsageDetails? usage = null,
+    string? cacheKey = null,
+    bool? cacheHit = null)
+{
+    /// <summary>
+    /// Gets or sets the duration between the time when the request was sent to the LLM and the time when the response
+    /// was received for the chat conversation turn.
+    /// </summary>
+    public TimeSpan Latency { get; set; } = latency;
+
+    /// <summary>
+    /// Gets or sets the model that was used in the creation of the response for the chat conversation turn.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see langword="null"/> if this information was not available via <see cref="ChatResponse.ModelId"/>.
+    /// </remarks>
+    public string? Model { get; set; } = model;
+
+    /// <summary>
+    /// Gets or sets usage details for the chat conversation turn (including input and output token counts).
+    /// </summary>
+    /// <remarks>
+    /// Returns <see langword="null"/> if usage details were not available via <see cref="ChatResponse.Usage"/>.
+    /// </remarks>
+    public UsageDetails? Usage { get; set; } = usage;
+
+    /// <summary>
+    /// Gets or sets the cache key for the cached model response for the chat conversation turn.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see langword="null"/> if response caching was disabled.
+    /// </remarks>
+    public string? CacheKey { get; set; } = cacheKey;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the model response was retrieved from the cache.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see langword="null"/> if response caching was disabled.
+    /// </remarks>
+    public bool? CacheHit { get; set; } = cacheHit;
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Defaults.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Defaults.cs
@@ -21,7 +21,7 @@ public static class Defaults
     /// <summary>
     /// The default iteration name that should be used if one was not specified when creating a
     /// <see cref="ScenarioRun"/> via
-    /// <see cref="ReportingConfiguration.CreateScenarioRunAsync(string, string, IEnumerable{string}?, CancellationToken)"/>.
+    /// <see cref="ReportingConfiguration.CreateScenarioRunAsync(string, string, IEnumerable{string}?, IEnumerable{string}?, CancellationToken)"/>.
     /// </summary>
     public const string DefaultIterationName = "1";
 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ResponseCachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ResponseCachingChatClient.cs
@@ -2,41 +2,129 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 
 namespace Microsoft.Extensions.AI.Evaluation.Reporting;
 
-/// <summary>
-/// An <see cref="IChatClient"/> that wraps another <see cref="IChatClient"/> and caches all responses generated using
-/// the wrapped <see cref="IChatClient"/> in the supplied <see cref="IDistributedCache"/>.
-/// </summary>
-public sealed class ResponseCachingChatClient : DistributedCachingChatClient
+internal sealed class ResponseCachingChatClient : DistributedCachingChatClient
 {
     private readonly IReadOnlyList<string> _cachingKeys;
+    private readonly ChatDetails _chatDetails;
+    private readonly ConcurrentDictionary<string, Stopwatch> _stopWatches;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ResponseCachingChatClient"/> class that wraps the supplied
-    /// <paramref name="originalChatClient"/> and caches all responses generated using
-    /// <paramref name="originalChatClient"/> in the supplied <paramref name="cache"/>.
-    /// </summary>
-    /// <param name="originalChatClient">The <see cref="IChatClient"/> that is wrapped.</param>
-    /// <param name="cache">The <see cref="IDistributedCache"/> where the cached responses are stored.</param>
-    /// <param name="cachingKeys">
-    /// A collection of unique strings that should be hashed when generating the cache keys for cached AI responses.
-    /// See <see cref="ReportingConfiguration.CachingKeys"/> for more information about this concept.
-    /// </param>
-    public ResponseCachingChatClient(
+    internal ResponseCachingChatClient(
         IChatClient originalChatClient,
         IDistributedCache cache,
-        IEnumerable<string> cachingKeys)
+        IEnumerable<string> cachingKeys,
+        ChatDetails chatDetails)
             : base(originalChatClient, cache)
     {
         _cachingKeys = [.. cachingKeys];
+        _chatDetails = chatDetails;
+        _stopWatches = new ConcurrentDictionary<string, Stopwatch>();
     }
 
-    /// <inheritdoc/>
+    protected override async Task<ChatResponse?> ReadCacheAsync(string key, CancellationToken cancellationToken)
+    {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        ChatResponse? response = await base.ReadCacheAsync(key, cancellationToken).ConfigureAwait(false);
+
+        if (response is null)
+        {
+            _ = _stopWatches.AddOrUpdate(key, addValue: stopwatch, updateValueFactory: (_, _) => stopwatch);
+        }
+        else
+        {
+            stopwatch.Stop();
+
+            _chatDetails.AddTurnDetails(
+                new ChatTurnDetails(
+                    latency: stopwatch.Elapsed,
+                    model: response.ModelId,
+                    usage: response.Usage,
+                    cacheKey: key,
+                    cacheHit: true));
+        }
+
+        return response;
+    }
+
+    protected override async Task<IReadOnlyList<ChatResponseUpdate>?> ReadCacheStreamingAsync(
+        string key,
+        CancellationToken cancellationToken)
+    {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        IReadOnlyList<ChatResponseUpdate>? updates =
+            await base.ReadCacheStreamingAsync(key, cancellationToken).ConfigureAwait(false);
+
+        if (updates is null)
+        {
+            _ = _stopWatches.AddOrUpdate(key, addValue: stopwatch, updateValueFactory: (_, _) => stopwatch);
+        }
+        else
+        {
+            stopwatch.Stop();
+
+            ChatResponse response = updates.ToChatResponse();
+            _chatDetails.AddTurnDetails(
+                new ChatTurnDetails(
+                    latency: stopwatch.Elapsed,
+                    model: response.ModelId,
+                    usage: response.Usage,
+                    cacheKey: key,
+                    cacheHit: true));
+        }
+
+        return updates;
+    }
+
+    protected override async Task WriteCacheAsync(string key, ChatResponse value, CancellationToken cancellationToken)
+    {
+        await base.WriteCacheAsync(key, value, cancellationToken).ConfigureAwait(false);
+
+        if (_stopWatches.TryRemove(key, out Stopwatch? stopwatch))
+        {
+            stopwatch.Stop();
+
+            _chatDetails.AddTurnDetails(
+                new ChatTurnDetails(
+                    latency: stopwatch.Elapsed,
+                    model: value.ModelId,
+                    usage: value.Usage,
+                    cacheKey: key,
+                    cacheHit: false));
+        }
+    }
+
+    protected override async Task WriteCacheStreamingAsync(
+        string key,
+        IReadOnlyList<ChatResponseUpdate> value,
+        CancellationToken cancellationToken)
+    {
+        await base.WriteCacheStreamingAsync(key, value, cancellationToken).ConfigureAwait(false);
+
+        if (_stopWatches.TryRemove(key, out Stopwatch? stopwatch))
+        {
+            stopwatch.Stop();
+
+            ChatResponse response = value.ToChatResponse();
+            _chatDetails.AddTurnDetails(
+                new ChatTurnDetails(
+                    latency: stopwatch.Elapsed,
+                    model: response.ModelId,
+                    usage: response.Usage,
+                    cacheKey: key,
+                    cacheHit: false));
+        }
+    }
+
     protected override string GetCacheKey(params ReadOnlySpan<object?> values)
         => base.GetCacheKey([.. values, .. _cachingKeys]);
-
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRun.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRun.cs
@@ -88,9 +88,12 @@ public sealed class ScenarioRun : IAsyncDisposable
     private readonly CompositeEvaluator _compositeEvaluator;
     private readonly IResultStore _resultStore;
     private readonly Func<EvaluationMetric, EvaluationMetricInterpretation?>? _evaluationMetricInterpreter;
+    private readonly ChatDetails? _chatDetails;
+    private readonly IEnumerable<string>? _tags;
 
     private ScenarioRunResult? _result;
 
+#pragma warning disable S107 // Methods should not have too many parameters
     internal ScenarioRun(
         string scenarioName,
         string iterationName,
@@ -98,7 +101,10 @@ public sealed class ScenarioRun : IAsyncDisposable
         IEnumerable<IEvaluator> evaluators,
         IResultStore resultStore,
         ChatConfiguration? chatConfiguration = null,
-        Func<EvaluationMetric, EvaluationMetricInterpretation?>? evaluationMetricInterpreter = null)
+        Func<EvaluationMetric, EvaluationMetricInterpretation?>? evaluationMetricInterpreter = null,
+        ChatDetails? chatDetails = null,
+        IEnumerable<string>? tags = null)
+#pragma warning restore
     {
         ScenarioName = scenarioName;
         IterationName = iterationName;
@@ -108,6 +114,8 @@ public sealed class ScenarioRun : IAsyncDisposable
         _compositeEvaluator = new CompositeEvaluator(evaluators);
         _resultStore = resultStore;
         _evaluationMetricInterpreter = evaluationMetricInterpreter;
+        _chatDetails = chatDetails;
+        _tags = tags;
     }
 
     /// <summary>
@@ -162,7 +170,9 @@ public sealed class ScenarioRun : IAsyncDisposable
                 creationTime: DateTime.UtcNow,
                 messages,
                 modelResponse,
-                evaluationResult);
+                evaluationResult,
+                _chatDetails,
+                _tags);
 
         return evaluationResult;
     }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ScenarioRunResult.cs
@@ -37,7 +37,16 @@ namespace Microsoft.Extensions.AI.Evaluation.Reporting;
 /// The <see cref="Evaluation.EvaluationResult"/> for the <see cref="ScenarioRun"/> corresponding to the
 /// <see cref="ScenarioRunResult"/> being constructed.
 /// </param>
-/// <param name="formatVersion">The version of the format used to persist the current <see cref="ScenarioRunResult"/>.</param>
+/// <param name="chatDetails">
+/// An optional <see cref="Reporting.ChatDetails"/> object that contains details related to all LLM chat conversation
+/// turns involved in the execution of the the <see cref="ScenarioRun"/> corresponding to the
+/// <see cref="ScenarioRunResult"/> being constructed. Can be <see langword="null"/> if none of the
+/// <see cref="IEvaluator"/>s invoked during the execution of the <see cref="ScenarioRun"/> use an LLM.
+/// </param>
+/// <param name="tags">An optional set of text tags applicable to this <see cref="ScenarioRunResult"/>.</param>
+/// <param name="formatVersion">
+/// The version of the format used to persist the current <see cref="ScenarioRunResult"/>.
+/// </param>
 [method: JsonConstructor]
 public sealed class ScenarioRunResult(
     string scenarioName,
@@ -47,6 +56,8 @@ public sealed class ScenarioRunResult(
     IList<ChatMessage> messages,
     ChatResponse modelResponse,
     EvaluationResult evaluationResult,
+    ChatDetails? chatDetails = null,
+    IList<string>? tags = null,
     int? formatVersion = null)
 {
     /// <summary>
@@ -57,13 +68,21 @@ public sealed class ScenarioRunResult(
     /// <param name="executionName">The <see cref="ScenarioRun.ExecutionName"/>.</param>
     /// <param name="creationTime">The time at which this <see cref="ScenarioRunResult"/> was created.</param>
     /// <param name="messages">
-    /// The conversation history including the request that produced the <paramref name="modelResponse"/> being evaluated.
+    /// The conversation history including the request that produced the <paramref name="modelResponse"/> being
+    /// evaluated.
     /// </param>
     /// <param name="modelResponse">The response being evaluated.</param>
     /// <param name="evaluationResult">
     /// The <see cref="Evaluation.EvaluationResult"/> for the <see cref="ScenarioRun"/> corresponding to the
     /// <see cref="ScenarioRunResult"/> being constructed.
     /// </param>
+    /// <param name="chatDetails">
+    /// An optional <see cref="Reporting.ChatDetails"/> object that contains details related to all LLM chat
+    /// conversation turns involved in the execution of the the <see cref="ScenarioRun"/> corresponding to the
+    /// <see cref="ScenarioRunResult"/> being constructed. Can be <see langword="null"/> if none of the
+    /// <see cref="IEvaluator"/>s invoked during the execution of the <see cref="ScenarioRun"/> use an LLM.
+    /// </param>
+    /// <param name="tags">An optional set of text tags applicable to this <see cref="ScenarioRunResult"/>.</param>
     public ScenarioRunResult(
         string scenarioName,
         string iterationName,
@@ -71,7 +90,9 @@ public sealed class ScenarioRunResult(
         DateTime creationTime,
         IEnumerable<ChatMessage> messages,
         ChatResponse modelResponse,
-        EvaluationResult evaluationResult)
+        EvaluationResult evaluationResult,
+        ChatDetails? chatDetails = null,
+        IEnumerable<string>? tags = null)
             : this(
                 scenarioName,
                 iterationName,
@@ -79,14 +100,11 @@ public sealed class ScenarioRunResult(
                 creationTime,
                 [.. messages],
                 modelResponse,
-                evaluationResult)
+                evaluationResult,
+                chatDetails,
+                tags is null ? null : [.. tags])
     {
     }
-
-    /// <summary>
-    /// Gets the version of the format used to persist the current <see cref="ScenarioRunResult"/>.
-    /// </summary>
-    public int? FormatVersion { get; } = formatVersion ?? Defaults.ReportingFormatVersion;
 
     /// <summary>
     /// Gets or sets the <see cref="ScenarioRun.ScenarioName"/>.
@@ -134,4 +152,30 @@ public sealed class ScenarioRunResult(
     /// is invoked.
     /// </remarks>
     public EvaluationResult EvaluationResult { get; set; } = evaluationResult;
+
+    /// <summary>
+    /// Gets or sets an optional <see cref="Reporting.ChatDetails"/> object that contains details related to all LLM
+    /// chat conversation turns involved in the execution of the <see cref="ScenarioRun"/> corresponding to this
+    /// <see cref="ScenarioRunResult"/>.
+    /// </summary>
+    /// <remarks>
+    /// Can be <see langword="null"/> if none of the <see cref="IEvaluator"/>s invoked during the execution of the
+    /// <see cref="ScenarioRun"/> use an LLM.
+    /// </remarks>
+    public ChatDetails? ChatDetails { get; set; } = chatDetails;
+
+    /// <summary>
+    /// Gets or sets a set of text tags applicable to this <see cref="ScenarioRunResult"/>.
+    /// </summary>
+#pragma warning disable CA2227
+    // CA2227: Collection properties should be read only.
+    // We disable this warning because we want this type to be fully mutable for serialization purposes and for general
+    // convenience.
+    public IList<string>? Tags { get; set; } = tags;
+#pragma warning restore CA2227
+
+    /// <summary>
+    /// Gets or sets the version of the format used to persist the current <see cref="ScenarioRunResult"/>.
+    /// </summary>
+    public int? FormatVersion { get; set; } = formatVersion ?? Defaults.ReportingFormatVersion;
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/SimpleChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/SimpleChatClient.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.AI.Evaluation.Reporting;
+
+internal sealed class SimpleChatClient : DelegatingChatClient
+{
+    private readonly ChatDetails _chatDetails;
+
+    internal SimpleChatClient(IChatClient originalChatClient, ChatDetails chatDetails)
+        : base(originalChatClient)
+    {
+        _chatDetails = chatDetails;
+    }
+
+    public async override Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ChatResponse? response = null;
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            response = await base.GetResponseAsync(messages, options, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            stopwatch.Stop();
+
+            if (response is not null)
+            {
+                _chatDetails.AddTurnDetails(
+                    new ChatTurnDetails(
+                        latency: stopwatch.Elapsed,
+                        model: response.ModelId,
+                        usage: response.Usage));
+            }
+        }
+
+        return response;
+    }
+
+    public override async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        List<ChatResponseUpdate>? updates = null;
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            await foreach (ChatResponseUpdate update in
+                base.GetStreamingResponseAsync(messages, options, cancellationToken).ConfigureAwait(false))
+            {
+                updates ??= [];
+                updates.Add(update);
+
+                yield return update;
+            }
+        }
+        finally
+        {
+            stopwatch.Stop();
+
+            if (updates is not null)
+            {
+                ChatResponse response = updates.ToChatResponse();
+                _chatDetails.AddTurnDetails(
+                    new ChatTurnDetails(
+                        latency: stopwatch.Elapsed,
+                        model: response.ModelId,
+                        usage: response.Usage));
+            }
+        }
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedReportingConfiguration.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedReportingConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -40,17 +41,32 @@ public static class DiskBasedReportingConfiguration
     /// The name of the current execution. See <see cref="ScenarioRun.ExecutionName"/> for more information about this
     /// concept. Uses a fixed default value <c>"Default"</c> if omitted.
     /// </param>
+    /// <param name="evaluationMetricInterpreter">
+    /// An optional function that can be used to override <see cref="EvaluationMetricInterpretation"/>s for
+    /// <see cref="EvaluationMetric"/>s returned from evaluations that use the returned
+    /// <see cref="ReportingConfiguration"/>. The supplied function can either return a new
+    /// <see cref="EvaluationMetricInterpretation"/> for any <see cref="EvaluationMetric"/> that is supplied to it, or
+    /// return <see langword="null"/> if the <see cref="EvaluationMetric.Interpretation"/> should be left unchanged.
+    /// </param>
+    /// <param name="tags">
+    /// A optional set of text tags applicable to all <see cref="ScenarioRun"/>s created using the returned
+    /// <see cref="ReportingConfiguration"/>.
+    /// </param>
     /// <returns>
     /// A <see cref="ReportingConfiguration"/> that persists <see cref="ScenarioRunResult"/>s to disk and also uses the
     /// disk to cache AI responses.
     /// </returns>
+#pragma warning disable S107 // Methods should not have too many parameters
     public static ReportingConfiguration Create(
         string storageRootPath,
         IEnumerable<IEvaluator> evaluators,
         ChatConfiguration? chatConfiguration = null,
         bool enableResponseCaching = true,
         IEnumerable<string>? cachingKeys = null,
-        string executionName = Defaults.DefaultExecutionName)
+        string executionName = Defaults.DefaultExecutionName,
+        Func<EvaluationMetric, EvaluationMetricInterpretation?>? evaluationMetricInterpreter = null,
+        IEnumerable<string>? tags = null)
+#pragma warning restore S107
     {
         storageRootPath = Path.GetFullPath(storageRootPath);
 
@@ -67,6 +83,8 @@ public static class DiskBasedReportingConfiguration
             chatConfiguration,
             responseCacheProvider,
             cachingKeys,
-            executionName);
+            executionName,
+            evaluationMetricInterpreter,
+            tags);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedResponseCache.CacheEntry.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedResponseCache.CacheEntry.cs
@@ -17,7 +17,7 @@ using Microsoft.Extensions.AI.Evaluation.Reporting.JsonSerialization;
 
 namespace Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
 
-public partial class DiskBasedResponseCache
+internal partial class DiskBasedResponseCache
 {
     [method: JsonConstructor]
     internal sealed class CacheEntry(

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedResponseCache.CacheMode.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedResponseCache.CacheMode.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
 
-public partial class DiskBasedResponseCache
+internal partial class DiskBasedResponseCache
 {
     /// <summary>
     /// An enum representing the mode in which the cache is operating.

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedResponseCache.CacheOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedResponseCache.CacheOptions.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.AI.Evaluation.Reporting.JsonSerialization;
 
 namespace Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
 
-public partial class DiskBasedResponseCache
+internal partial class DiskBasedResponseCache
 {
     internal sealed class CacheOptions
     {
@@ -59,7 +59,7 @@ public partial class DiskBasedResponseCache
             using FileStream cacheOptionsFile = File.OpenRead(cacheOptionsFilePath);
 
             CacheOptions cacheOptions =
-                await JsonSerializer.DeserializeAsync<CacheOptions>(
+                await JsonSerializer.DeserializeAsync(
                     cacheOptionsFile,
                     JsonUtilities.Default.CacheOptionsTypeInfo,
                     cancellationToken).ConfigureAwait(false) ??

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedResponseCacheProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedResponseCacheProvider.cs
@@ -14,7 +14,8 @@ using Microsoft.Extensions.Caching.Distributed;
 namespace Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
 
 /// <summary>
-/// An <see cref="IResponseCacheProvider"/> that returns a <see cref="DiskBasedResponseCache"/>.
+/// An <see cref="IResponseCacheProvider"/> that returns an <see cref="IDistributedCache"/> that can cache AI responses
+/// for a particular <see cref="ScenarioRun"/> under the specified <paramref name="storageRootPath"/> on disk.
 /// </summary>
 /// <param name="storageRootPath">
 /// The path to a directory on disk under which the cached AI responses should be stored.

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedResultStore.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Storage/DiskBasedResultStore.cs
@@ -66,7 +66,7 @@ public sealed class DiskBasedResultStore : IResultStore
             using FileStream stream = resultFile.OpenRead();
 
             ScenarioRunResult? result =
-                await JsonSerializer.DeserializeAsync<ScenarioRunResult>(
+                await JsonSerializer.DeserializeAsync(
                     stream,
                     JsonUtilities.Default.ScenarioRunResultTypeInfo,
                     cancellationToken).ConfigureAwait(false);

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/App.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/App.tsx
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { useState } from 'react';
-import { Settings28Regular } from '@fluentui/react-icons';
-import { Drawer, DrawerBody, DrawerHeader, DrawerHeaderTitle, Switch } from '@fluentui/react-components';
+import { Settings28Regular, FilterDismissRegular, Dismiss20Regular } from '@fluentui/react-icons';
+import { Drawer, DrawerBody, DrawerHeader, DrawerHeaderTitle, Switch, Tooltip } from '@fluentui/react-components';
 import { makeStyles } from '@fluentui/react-components';
 import './App.css';
 import { ScoreNode } from './Summary';
 import { ScenarioGroup } from './ScenarioTree';
+import { GlobalTagsDisplay, FilterableTagsDisplay, categorizeAndSortTags } from './TagsDisplay';
+import { tokens } from '@fluentui/react-components';
 
 type AppProperties = {
   dataset: Dataset,
@@ -15,9 +17,66 @@ type AppProperties = {
 };
 
 const useStyles = makeStyles({
-  header: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', position: 'sticky', top: 0, backgroundColor: 'white', zIndex: 1 },
+  header: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    position: 'sticky',
+    top: 0,
+    zIndex: 1,
+    paddingBottom: '12px'
+  },
+  headerTop: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  headerActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+  },
+  iconButton: {
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '40px',
+    height: '40px',
+    borderRadius: '6px',
+    transition: 'all 0.2s ease-in-out',
+    '&:hover': {
+      backgroundColor: tokens.colorNeutralBackground4,
+    },
+  },
+  filterButton: {
+    backgroundColor: tokens.colorBrandBackground2,
+    border: `1px solid ${tokens.colorBrandStroke1}`,
+    fontSize: '20px',
+    width: '40px',
+    height: '40px',
+    borderRadius: '6px',
+    '&:hover': {
+      backgroundColor: tokens.colorNeutralBackground4,
+    },
+  },
   footerText: { fontSize: '0.8rem', marginTop: '2rem' },
-  closeButton: { position: 'absolute', top: '1.5rem', right: '1rem', cursor: 'pointer', fontSize: '2rem' },
+  closeButton: {
+    position: 'absolute',
+    top: '1.5rem',
+    right: '1rem',
+    cursor: 'pointer',
+    fontSize: '2rem',
+    width: '28px',
+    height: '28px',
+    borderRadius: '6px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    '&:hover': {
+      backgroundColor: tokens.colorNeutralBackground4,
+    },
+  },
   switchLabel: { fontSize: '1rem', paddingTop: '1rem' },
   drawerBody: { paddingTop: '1rem' },
 });
@@ -26,29 +85,74 @@ function App({ dataset, tree }: AppProperties) {
   const classes = useStyles();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [renderMarkdown, setRenderMarkdown] = useState(true);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+  const { globalTags, filterableTags } = categorizeAndSortTags(dataset);
 
   const toggleSettings = () => setIsSettingsOpen(!isSettingsOpen);
   const toggleRenderMarkdown = () => setRenderMarkdown(!renderMarkdown);
   const closeSettings = () => setIsSettingsOpen(false);
 
+  const handleTagClick = (tag: string) => {
+    setSelectedTags((prevTags) =>
+      prevTags.includes(tag) ? prevTags.filter((t) => t !== tag) : [...prevTags, tag]
+    );
+  };
+
+  const clearFilters = () => {
+    setSelectedTags([]);
+  };
+
   return (
     <>
       <div className={classes.header}>
-        <h1>AI Evaluation Report</h1>
-        <Settings28Regular onClick={toggleSettings} style={{ cursor: 'pointer' }} />
+        <div className={classes.headerTop}>
+          <h1>AI Evaluation Report</h1>
+          <div className={classes.headerActions}>
+            {selectedTags.length > 0 && (
+              <Tooltip content="Clear Filters" relationship="description">
+                <div className={`${classes.iconButton} ${classes.filterButton}`} onClick={clearFilters}>
+                  <FilterDismissRegular />
+                </div>
+              </Tooltip>
+            )}
+            <Tooltip content="Settings" relationship="description">
+              <div className={classes.iconButton} onClick={toggleSettings}>
+                <Settings28Regular />
+              </div>
+            </Tooltip>
+          </div>
+        </div>
+        <GlobalTagsDisplay globalTags={globalTags} />
       </div>
 
-      <ScenarioGroup node={tree} renderMarkdown={renderMarkdown} />
+      <FilterableTagsDisplay
+        filterableTags={filterableTags}
+        onTagClick={handleTagClick}
+        selectedTags={selectedTags}
+      />
 
-      <p className={classes.footerText}>Generated at {dataset.createdAt} by Microsoft.Extensions.AI.Evaluation.Reporting version {dataset.generatorVersion}</p>
+      <ScenarioGroup
+        node={tree}
+        renderMarkdown={renderMarkdown}
+        selectedTags={selectedTags}
+      />
 
-      <Drawer open={isSettingsOpen} onOpenChange={toggleSettings} position='end'>
+      <p className={classes.footerText}>
+        Generated at {dataset.createdAt} by Microsoft.Extensions.AI.Evaluation.Reporting version {dataset.generatorVersion}
+      </p>
+
+      <Drawer open={isSettingsOpen} onOpenChange={toggleSettings} position="end">
         <DrawerHeader>
           <DrawerHeaderTitle>Settings</DrawerHeaderTitle>
-          <span className={classes.closeButton} onClick={closeSettings}>&times;</span>
+          <span className={classes.closeButton} onClick={closeSettings}><Dismiss20Regular /></span>
         </DrawerHeader>
         <DrawerBody className={classes.drawerBody}>
-          <Switch checked={renderMarkdown} onChange={toggleRenderMarkdown} label={<span className={classes.switchLabel}>Render markdown for conversations</span>} />
+          <Switch
+            checked={renderMarkdown}
+            onChange={toggleRenderMarkdown}
+            label={<span className={classes.switchLabel}>Render markdown for conversations</span>}
+          />
         </DrawerBody>
       </Drawer>
     </>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/EvalTypes.d.ts
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/EvalTypes.d.ts
@@ -11,20 +11,43 @@ type ScenarioRunResult = {
     scenarioName: string;
     iterationName: string;
     executionName: string;
-    creationTime?: string;
+    creationTime: string;
     messages: ChatMessage[];
     modelResponse: ChatResponse;
     evaluationResult: EvaluationResult;
+    chatDetails?: ChatDetails;
+    tags?: string[];
+    formatVersion: int;
 };
 
 type ChatResponse = {
     messages: ChatMessage[];
+    modelId?: string;
+    usage?: UsageDetails;
 }
 
 type ChatMessage = {
     authorName?: string;
     role: string;
-    contents: AIContent[]
+    contents: AIContent[];
+};
+
+type ChatDetails = {
+    turnDetails: ChatTurnDetails[];
+}
+
+type ChatTurnDetails = {
+    latency: number;
+    model?: string;
+    usage?: UsageDetails;
+    cacheKey?: string;
+    cacheHit?: boolean;
+}
+
+type UsageDetails = {
+    inputTokenCount?: number;
+    outputTokenCount?: number;
+    totalTokenCount?: number;
 };
 
 type AIContent = {

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/MetricCard.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/MetricCard.tsx
@@ -5,7 +5,13 @@ import { makeStyles, mergeClasses, tokens, Tooltip } from "@fluentui/react-compo
 import { DismissCircle16Regular, Info16Regular, Warning16Regular } from "@fluentui/react-icons";
 
 const useCardListStyles = makeStyles({
-    metricCardList: { display: 'flex', gap: '1rem', flexWrap: 'wrap' },
+    metricCardList: {
+        display: 'flex',
+        gap: '1rem',
+        flexWrap: 'wrap',
+        maxWidth: '75rem',
+        margin: '0 auto',
+    },
 });
 
 export const MetricCardList = ({ scenario, onMetricSelect, selectedMetric }: { 
@@ -35,7 +41,7 @@ const useCardStyles = makeStyles({
         alignItems: 'center', 
         gap: '0.5rem',
         padding: '.75rem', 
-        border: '1px solid #e0e0e0', 
+        border: `1px solid ${tokens.colorNeutralStroke2}`,
         borderRadius: '4px',
         width: '12rem',
         cursor: 'pointer',
@@ -43,12 +49,12 @@ const useCardStyles = makeStyles({
         position: 'relative',
         '&:hover': {
             opacity: 0.9,
-            boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
+            boxShadow: tokens.shadow4,
         }
     },
     selectedCard: {
         zIndex: 1,
-        boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
+        boxShadow: tokens.shadow8,
         outline: `2px solid ${tokens.colorNeutralForeground3}`,
         outlineOffset: '0px',
         border: 'none'

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/ScenarioTree.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/ScenarioTree.tsx
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import React, { useState, useCallback } from "react";
-import { makeStyles, tokens, Tree, TreeItem, TreeItemLayout, TreeItemValue, TreeOpenChangeData, TreeOpenChangeEvent, mergeClasses } from "@fluentui/react-components";
-import { ScoreNode, ScoreNodeType, getPromptDetails, ChatMessageDisplay } from "./Summary";
+import { makeStyles, tokens, Tree, TreeItem, TreeItemLayout, TreeItemValue, TreeOpenChangeData, TreeOpenChangeEvent, mergeClasses, Table, TableHeader, TableRow, TableHeaderCell, TableBody, TableCell } from "@fluentui/react-components";
+import { ScoreNode, ScoreNodeType, getConversationDisplay, ChatMessageDisplay } from "./Summary";
 import { PassFailBar } from "./PassFailBar";
 import { MetricCardList, type MetricType } from "./MetricCard";
 import ReactMarkdown from "react-markdown";
-import { DismissCircle16Regular, Info16Regular, Warning16Regular } from "@fluentui/react-icons";
+import { DismissCircle16Regular, Info16Regular, Warning16Regular, CheckmarkCircle16Regular, Copy16Regular } from "@fluentui/react-icons";
 import { ChevronDown12Regular, ChevronRight12Regular } from '@fluentui/react-icons';
 
-const ScenarioLevel = ({ node, parentPath, isOpen, renderMarkdown }: { 
-  node: ScoreNode, 
-  parentPath: string, 
-  isOpen: (path: string) => boolean, 
+const ScenarioLevel = ({ node, parentPath, isOpen, renderMarkdown }: {
+  node: ScoreNode,
+  parentPath: string,
+  isOpen: (path: string) => boolean,
   renderMarkdown: boolean,
 }) => {
     const path = `${parentPath}.${node.name}`;
@@ -44,23 +44,57 @@ const ScenarioLevel = ({ node, parentPath, isOpen, renderMarkdown }: {
     }
 };
 
-export const ScenarioGroup = ({ node, renderMarkdown }: { node: ScoreNode, renderMarkdown: boolean }) => {
-    const [openItems, setOpenItems] = useState<Set<TreeItemValue>>(() => new Set());
-    const handleOpenChange = useCallback((_: TreeOpenChangeEvent, data: TreeOpenChangeData) => {
-        setOpenItems(data.openItems);
-    }, []);
-    const isOpen = (name: string) => openItems.has(name);
+export const ScenarioGroup = ({ node, renderMarkdown, selectedTags }: {
+  node: ScoreNode,
+  renderMarkdown: boolean,
+  selectedTags: string[]
+}) => {
+  const [openItems, setOpenItems] = useState<Set<TreeItemValue>>(() => new Set());
+  const handleOpenChange = useCallback((_: TreeOpenChangeEvent, data: TreeOpenChangeData) => {
+    setOpenItems(data.openItems);
+  }, []);
+  const isOpen = (name: string) => openItems.has(name);
 
-    return (
-        <Tree aria-label="Default" appearance="transparent" onOpenChange={handleOpenChange} defaultOpenItems={["." + node.name]}>
-            <ScenarioLevel node={node} parentPath={""} isOpen={isOpen} renderMarkdown={renderMarkdown} />
-        </Tree>);        
+  const filterTree = (node: ScoreNode): ScoreNode | null => {
+    if (selectedTags.length === 0) {
+      return node;
+    }
+
+    if (node.isLeafNode) {
+      return node.scenario?.tags?.some(tag => selectedTags.includes(tag)) ? node : null;
+    }
+
+    const filteredChildren = node.childNodes
+      .map(filterTree)
+      .filter((child): child is ScoreNode => child !== null);
+
+    if (filteredChildren.length > 0) {
+      const newNode = new ScoreNode(node.name, node.nodeType);
+      newNode.setChildren(new Map(filteredChildren.map(child => [child.name, child])));
+      newNode.aggregate(selectedTags);
+      return newNode;
+    }
+
+    return null;
+  };
+
+  const filteredNode = filterTree(node);
+
+  if (!filteredNode) {
+    return <div>No results match the selected tags.</div>;
+  }
+
+  return (
+    <Tree aria-label="Default" appearance="transparent" onOpenChange={handleOpenChange} defaultOpenItems={["." + filteredNode.name]}>
+      <ScenarioLevel node={filteredNode} parentPath={""} isOpen={isOpen} renderMarkdown={renderMarkdown} />
+    </Tree>
+  );        
 };
 
 export const ScoreDetail = ({ scenario, renderMarkdown }: { scenario: ScenarioRunResult, renderMarkdown: boolean }) => {
     const classes = useStyles();
     const [selectedMetric, setSelectedMetric] = useState<MetricType | null>(null);
-    const { messages } = getPromptDetails(scenario.messages, scenario.modelResponse);
+    const { messages, model, usage } = getConversationDisplay(scenario.messages, scenario.modelResponse);
 
     return (<div className={classes.iterationArea}>
         <MetricCardList
@@ -69,7 +103,8 @@ export const ScoreDetail = ({ scenario, renderMarkdown }: { scenario: ScenarioRu
           selectedMetric={selectedMetric}
         />
         {selectedMetric && <MetricDetailsSection metric={selectedMetric} />}
-        <PromptDetails messages={messages} renderMarkdown={renderMarkdown} />
+        <ConversationDetails messages={messages} model={model} usage={usage} renderMarkdown={renderMarkdown} />
+        {scenario.chatDetails && <ChatDetailsSection chatDetails={scenario.chatDetails} />}
     </div>);
 };
 
@@ -161,7 +196,17 @@ const DiagnosticsContent = ({ diagnostics }: { diagnostics: EvaluationDiagnostic
 
 const useStyles = makeStyles({
     headerContainer: { display: 'flex', alignItems: 'center', flexDirection: 'row', gap: '0.5rem' },
-    promptHint: { fontFamily: tokens.fontFamilyMonospace, opacity: 0.6, fontSize: '0.7rem', paddingLeft: '1rem', whiteSpace: 'nowrap' },
+    hint: {
+        fontFamily: tokens.fontFamilyMonospace,
+        opacity: 0.6,
+        fontSize: '0.7rem',
+        paddingTop: '0.25rem',
+        paddingLeft: '1rem',
+        whiteSpace: 'nowrap',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.25rem',
+    },
     score: { fontSize: tokens.fontSizeBase200 },
     passFailBadge: {
         display: 'flex',
@@ -225,12 +270,6 @@ const useStyles = makeStyles({
         color: tokens.colorNeutralForeground1,
         marginBottom: '0.25rem',
     },
-    failContainer: {
-        padding: '1rem',
-        border: '1px solid #e0e0e0',
-        backgroundColor: tokens.colorNeutralBackground2,
-        cursor: 'text',
-    },
     sectionContainer: {
         display: 'flex',
         flexDirection: 'column',
@@ -268,6 +307,70 @@ const useStyles = makeStyles({
         wordBreak: 'break-word',
         width: '100%',
         backgroundColor: tokens.colorNeutralBackground3,
+    },
+    cacheHitIcon: {
+        color: tokens.colorPaletteGreenForeground1,
+    },
+    cacheMissIcon: {
+        color: tokens.colorPaletteRedForeground1,
+    },
+    cacheHit: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.25rem',
+        color: tokens.colorPaletteGreenForeground1,
+    },
+    cacheMiss: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.25rem',
+        color: tokens.colorPaletteRedForeground1,
+    },
+    cacheKeyCell: {
+        maxWidth: '240px',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    },
+    cacheKey: {
+        fontFamily: tokens.fontFamilyMonospace,
+        fontSize: '0.7rem',
+        padding: '0.1rem 0.3rem',
+        backgroundColor: tokens.colorNeutralBackground3,
+        borderRadius: '4px',
+        display: 'block',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    },
+    noCacheKey: {
+        color: tokens.colorNeutralForeground3,
+        fontStyle: 'italic',
+    },
+    tableContainer: {
+        overflowX: 'auto',
+        maxWidth: '75rem',
+    },
+    cacheKeyContainer: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.25rem',
+    },
+    copyButton: {
+        background: 'none',
+        border: 'none',
+        cursor: 'pointer',
+        padding: '2px',
+        color: tokens.colorNeutralForeground3,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: '3px',
+        '&:hover': {
+            backgroundColor: tokens.colorNeutralBackground4,
+            color: tokens.colorNeutralForeground1,
+        }
+    },
+    preWrap: {
+        whiteSpace: 'pre-wrap',
     },
 });
 
@@ -309,24 +412,34 @@ const ScoreNodeHeader = ({ item, showPrompt }: { item: ScoreNode, showPrompt?: b
             ))}
         </div>
         <PassFailBadge pass={ctPass} total={ctPass + ctFail} />
-        {showPrompt && item.shortenedPrompt && <div className={classes.promptHint}>{item.shortenedPrompt}</div>}
+        {showPrompt && item.shortenedPrompt && <div className={classes.hint}>{item.shortenedPrompt}</div>}
     </div>);
 };
 
-export const PromptDetails = ({ messages, renderMarkdown }: { 
+export const ConversationDetails = ({ messages, model, usage, renderMarkdown }: { 
     messages: ChatMessageDisplay[], 
-    renderMarkdown: boolean 
+    model?: string,
+    usage?: UsageDetails,
+    renderMarkdown: boolean,
 }) => {
     const classes = useStyles();
     const [isExpanded, setIsExpanded] = useState(true);
 
     const isUserSide = (role: string) => role.toLowerCase() === 'user' || role.toLowerCase() === 'system';
 
+    const infoText = [
+        model && `Model: ${model}`,
+        usage?.inputTokenCount && `Input Tokens: ${usage.inputTokenCount}`,
+        usage?.outputTokenCount && `Output Tokens: ${usage.outputTokenCount}`,
+        usage?.totalTokenCount && `Total Tokens: ${usage.totalTokenCount}`,
+    ].filter(Boolean).join(' • ');
+
     return (
         <div className={classes.section}>
             <div className={classes.sectionHeader} onClick={() => setIsExpanded(!isExpanded)}>
                 {isExpanded ? <ChevronDown12Regular /> : <ChevronRight12Regular />}
                 <h3 className={classes.sectionHeaderText}>Conversation</h3>
+                {infoText && <div className={classes.hint}>{infoText}</div>}
             </div>
 
             {isExpanded && (
@@ -344,12 +457,115 @@ export const PromptDetails = ({ messages, renderMarkdown }: {
                                 <div className={classes.messageBubble}>
                                     {renderMarkdown ? 
                                         <ReactMarkdown>{message.content}</ReactMarkdown> : 
-                                        <pre style={{ whiteSpace: 'pre-wrap' }}>{message.content}</pre>
+                                        <pre className={classes.preWrap}>{message.content}</pre>
                                     }
                                 </div>
                             </div>
                         );
                     })}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export const ChatDetailsSection = ({ chatDetails }: { chatDetails: ChatDetails }) => {
+    const classes = useStyles();
+    const [isExpanded, setIsExpanded] = useState(false);
+    
+    const totalTurns = chatDetails.turnDetails.length;
+    const cachedTurns = chatDetails.turnDetails.filter(turn => turn.cacheHit === true).length;
+    
+    const hasCacheKey = chatDetails.turnDetails.some(turn => turn.cacheKey !== undefined);
+    const hasCacheStatus = chatDetails.turnDetails.some(turn => turn.cacheHit !== undefined);
+    const hasModelInfo = chatDetails.turnDetails.some(turn => turn.model !== undefined);
+    const hasInputTokens = chatDetails.turnDetails.some(turn => turn.usage?.inputTokenCount !== undefined);
+    const hasOutputTokens = chatDetails.turnDetails.some(turn => turn.usage?.outputTokenCount !== undefined);
+    const hasTotalTokens = chatDetails.turnDetails.some(turn => turn.usage?.totalTokenCount !== undefined);
+
+    const copyToClipboard = (text: string) => {
+        navigator.clipboard.writeText(text);
+    };
+    
+    return (
+        <div className={classes.section}>
+            <div className={classes.sectionHeader} onClick={() => setIsExpanded(!isExpanded)}>
+                {isExpanded ? <ChevronDown12Regular /> : <ChevronRight12Regular />}
+                <h3 className={classes.sectionHeaderText}>LLM Chat Diagnostic Details</h3>
+                {hasCacheStatus && (
+                    <div className={classes.hint}>
+                        {cachedTurns != totalTurns ?
+                            <Warning16Regular className={classes.cacheMissIcon}/> : 
+                            <CheckmarkCircle16Regular className={classes.cacheHitIcon} />
+                        }
+                        {cachedTurns}/{totalTurns} chat responses for this evaluation were fulfiled from cache
+                    </div>
+                )}
+            </div>
+
+            {isExpanded && (
+                <div className={classes.sectionContainer}>
+                    <div className={classes.tableContainer}>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    {hasCacheKey && <TableHeaderCell>Cache Key</TableHeaderCell>}
+                                    {hasCacheStatus && <TableHeaderCell>Cache Status</TableHeaderCell>}
+                                    <TableHeaderCell>Latency (s)</TableHeaderCell>
+                                    {hasModelInfo && <TableHeaderCell>Model Used</TableHeaderCell>}
+                                    {hasInputTokens && <TableHeaderCell>Input Tokens</TableHeaderCell>}
+                                    {hasOutputTokens && <TableHeaderCell>Output Tokens</TableHeaderCell>}
+                                    {hasTotalTokens && <TableHeaderCell>Total Tokens</TableHeaderCell>}
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {chatDetails.turnDetails.map((turn, index) => (
+                                    <TableRow key={index}>
+                                        {hasCacheKey && (
+                                            <TableCell className={classes.cacheKeyCell}>
+                                                {turn.cacheKey ? (
+                                                    <div className={classes.cacheKeyContainer} title={turn.cacheKey}>
+                                                        <span className={classes.cacheKey}>
+                                                            {turn.cacheKey.substring(0, 8)}...
+                                                        </span>
+                                                        <button 
+                                                            className={classes.copyButton} 
+                                                            onClick={(e) => {
+                                                                e.stopPropagation();
+                                                                copyToClipboard(turn.cacheKey || "");
+                                                            }}
+                                                            title="Copy Cache Key"
+                                                        >
+                                                            <Copy16Regular />
+                                                        </button>
+                                                    </div>
+                                                ) : (
+                                                    <span className={classes.noCacheKey}>N/A</span>
+                                                )}
+                                            </TableCell>
+                                        )}
+                                        {hasCacheStatus && (
+                                            <TableCell>
+                                                {turn.cacheHit === true ? 
+                                                    <span className={classes.cacheHit}>
+                                                        <CheckmarkCircle16Regular className={classes.cacheHitIcon} /> Hit
+                                                    </span> : 
+                                                    <span className={classes.cacheMiss}>
+                                                        <Warning16Regular className={classes.cacheMissIcon} /> Miss
+                                                    </span>
+                                                }
+                                            </TableCell>
+                                        )}
+                                        <TableCell>{turn.latency.toFixed(2)}</TableCell>
+                                        {hasModelInfo && <TableCell>{turn.model || '-'}</TableCell>}
+                                        {hasInputTokens && <TableCell>{turn.usage?.inputTokenCount || '-'}</TableCell>}
+                                        {hasOutputTokens && <TableCell>{turn.usage?.outputTokenCount || '-'}</TableCell>}
+                                        {hasTotalTokens && <TableCell>{turn.usage?.totalTokenCount || '-'}</TableCell>}
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </div>
                 </div>
             )}
         </div>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/TagsDisplay.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/TagsDisplay.tsx
@@ -1,0 +1,144 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import { makeStyles, tokens } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  tagsContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    marginBottom: '16px',
+    paddingTop: '6px',
+  },
+  tagsRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '6px',
+  },
+  tagBubble: {
+    padding: '2px 10px',
+    borderRadius: '12px',
+    backgroundColor: tokens.colorNeutralBackground3,
+    fontSize: '0.75rem',
+    cursor: 'pointer',
+    transition: 'all 0.2s ease-in-out',
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    lineHeight: '1.2',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    ':hover': {
+      opacity: 0.9,
+      boxShadow: tokens.shadow4,
+    },
+    '&.selected': {
+      boxShadow: tokens.shadow8,
+      outline: `2px solid ${tokens.colorNeutralForeground3}`,
+      outlineOffset: '0px',
+      border: 'none'
+    }
+  },
+  globalTagBubble: {
+    backgroundColor: tokens.colorBrandBackground2,
+    border: `1px solid ${tokens.colorBrandStroke1}`,
+    cursor: 'default',
+    ':hover': {
+      backgroundColor: tokens.colorBrandBackground2,
+      boxShadow: 'none'
+    },
+    '&.selected': {
+      backgroundColor: tokens.colorBrandBackground2
+    }
+  },
+});
+
+export type TagInfo = { tag: string; count: number };
+
+export function categorizeAndSortTags(dataset: Dataset): { 
+  globalTags: TagInfo[];
+  filterableTags: TagInfo[];
+} {
+  const tagCounts = new Map<string, number>();
+  const totalResults = dataset.scenarioRunResults.length;
+  
+  dataset.scenarioRunResults.forEach(result => {
+    if (result.tags) {
+      result.tags.forEach(tag => {
+        const currentCount = tagCounts.get(tag) || 0;
+        tagCounts.set(tag, currentCount + 1);
+      });
+    }
+  });
+  
+  const globalTags: Array<{ tag: string, count: number }> = [];
+  const filterableTags: Array<{ tag: string, count: number }> = [];
+  
+  tagCounts.forEach((count, tag) => {
+    const tagInfo = { tag, count };
+    if (count === totalResults) {
+      globalTags.push(tagInfo);
+    } else {
+      filterableTags.push(tagInfo);
+    }
+  });
+  
+  filterableTags.sort((a, b) => b.count - a.count);
+  
+  return { globalTags, filterableTags };
+}
+
+export function GlobalTagsDisplay({ globalTags }: { globalTags: TagInfo[] }) {
+  const classes = useStyles();
+
+  if (globalTags.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={classes.tagsRow}>
+      {globalTags.map(({ tag, count }) => (
+        <div 
+          key={tag} 
+          className={`${classes.tagBubble} ${classes.globalTagBubble}`}
+          title={`${tag} (appears on all ${count} results)`}
+        >
+          {tag}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export interface FilterableTagsDisplayProps {
+  filterableTags: TagInfo[];
+  onTagClick: (tag: string) => void;
+  selectedTags: string[];
+}
+
+export function FilterableTagsDisplay({ filterableTags, onTagClick, selectedTags }: FilterableTagsDisplayProps) {
+  const classes = useStyles();
+
+  if (filterableTags.length === 0) {
+    return null;
+  }
+
+  const isSelected = (tag: string) => selectedTags.includes(tag);
+
+  return (
+    <div className={classes.tagsContainer}>
+      <div className={classes.tagsRow}>
+        {filterableTags.map(({ tag, count }) => (
+          <div 
+            key={tag} 
+            className={`${classes.tagBubble} ${isSelected(tag) ? 'selected' : ''}`}
+            title={`${tag} (appears on ${count} results) - Click to filter by this tag`}
+            onClick={() => onTagClick(tag)}
+          >
+            {tag}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/ResultsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/ResultsTests.cs
@@ -19,14 +19,22 @@ public class ResultsTests
 {
     private static readonly ChatMessage _testResponse = "Test response".ToAssistantMessage();
 
-    public static ReportingConfiguration CreateReportingConfiguration(IEvaluator evaluator) =>
-        DiskBasedReportingConfiguration.Create(
+    public static ReportingConfiguration CreateReportingConfiguration(IEvaluator evaluator)
+    {
+        string version = $"Product Version: {Constants.Version}";
+        string date = $"Date: {DateTime.UtcNow:dddd, dd MMMM yyyy}";
+        string projectName = $"Project: Integration Tests";
+        string testClass = $"Test Class: {nameof(ResultsTests)}";
+
+        return DiskBasedReportingConfiguration.Create(
             storageRootPath: Settings.Current.Configured ?
                 Settings.Current.StorageRootPath :
                 Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()),
             evaluators: [evaluator],
             chatConfiguration: null, // Not needed for this test
-            executionName: Constants.Version);
+            executionName: Constants.Version,
+            tags: [version, date, projectName, testClass]);
+    }
 
     #region Interpretations
     private static EvaluationMetricInterpretation? FailIfValueIsTrue(EvaluationMetric m)
@@ -156,7 +164,8 @@ public class ResultsTests
 
         await using ScenarioRun scenarioRun =
             await reportingConfiguration.CreateScenarioRunAsync(
-                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithBooleanMetric)}");
+                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithBooleanMetric)}",
+                additionalTags: ["Feature: BooleanMetric"]);
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(_testResponse);
 
@@ -183,7 +192,8 @@ public class ResultsTests
 
         await using ScenarioRun scenarioRun =
             await reportingConfiguration.CreateScenarioRunAsync(
-                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithBooleanMetricAndInterpretation)}");
+                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithBooleanMetricAndInterpretation)}",
+                additionalTags: ["Feature: BooleanMetric", "Feature: Interpretation"]);
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(_testResponse);
         result.Interpret(FailIfValueIsTrue);
@@ -235,7 +245,8 @@ public class ResultsTests
 
         await using ScenarioRun scenarioRun =
             await reportingConfiguration.CreateScenarioRunAsync(
-                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithStringMetric)}");
+                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithStringMetric)}",
+                additionalTags: ["Feature: StringMetric"]);
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(_testResponse);
 
@@ -290,7 +301,8 @@ public class ResultsTests
 
         await using ScenarioRun scenarioRun =
             await reportingConfiguration.CreateScenarioRunAsync(
-                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithStringMetricAndInterpretation)}");
+                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithStringMetricAndInterpretation)}",
+                additionalTags: ["Feature: StringMetric", "Feature: Interpretation"]);
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(_testResponse);
         result.Interpret(FailIfNotImperialOrUSCustomary);
@@ -339,7 +351,8 @@ public class ResultsTests
 
         await using ScenarioRun scenarioRun =
             await reportingConfiguration.CreateScenarioRunAsync(
-                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithNumericMetrics)}");
+                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithNumericMetrics)}",
+                additionalTags: ["Feature: NumericMetric"]);
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(_testResponse);
 
@@ -374,7 +387,8 @@ public class ResultsTests
 
         await using ScenarioRun scenarioRun =
             await reportingConfiguration.CreateScenarioRunAsync(
-                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithNumericMetricsAndInterpretation)}");
+                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithNumericMetricsAndInterpretation)}",
+                additionalTags: ["Feature: NumericMetric", "Feature: Interpretation"]);
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(_testResponse);
         result.Interpret(FailIfValueIsLessThan4);
@@ -437,7 +451,8 @@ public class ResultsTests
 
         await using ScenarioRun scenarioRun =
             await reportingConfiguration.CreateScenarioRunAsync(
-                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithDiagnosticsOnUninterpretedMetrics)}");
+                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithDiagnosticsOnUninterpretedMetrics)}",
+                additionalTags: ["Feature: Diagnostics", "Feature: Interpretation"]);
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(_testResponse);
 
@@ -489,7 +504,8 @@ public class ResultsTests
 
         await using ScenarioRun scenarioRun =
             await reportingConfiguration.CreateScenarioRunAsync(
-                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithDiagnosticsOnFailingMetrics)}");
+                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithDiagnosticsOnFailingMetrics)}",
+                additionalTags: ["Feature: Diagnostics", "Feature: Interpretation"]);
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(_testResponse);
         result.Interpret(FailIfValueIsMissing);
@@ -547,7 +563,8 @@ public class ResultsTests
 
         await using ScenarioRun scenarioRun =
             await reportingConfiguration.CreateScenarioRunAsync(
-                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithDiagnosticsOnPassingMetrics)}");
+                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithDiagnosticsOnPassingMetrics)}",
+                additionalTags: ["Feature: Diagnostics", "Feature: Interpretation"]);
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(_testResponse);
         result.Interpret(FailIfValueIsMissing);
@@ -579,7 +596,8 @@ public class ResultsTests
 
         await using ScenarioRun scenarioRun =
             await reportingConfiguration.CreateScenarioRunAsync(
-                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithException)}");
+                $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(ResultsTests)}.{nameof(ResultWithException)}",
+                additionalTags: ["Feature: Diagnostics"]);
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(_testResponse);
 

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/Settings.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/Settings.cs
@@ -17,7 +17,7 @@ public class Settings
     public Settings(IConfiguration config)
     {
 #pragma warning disable CA2208 // Pass correct parameter name for ArgumentNullException.
-        Configured = config.GetValue<bool>("Configured", false);
+        Configured = config.GetValue("Configured", false);
 
         DeploymentName =
             config.GetValue<string>("DeploymentName") ??

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/AzureStorage/AzureResponseCacheTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/AzureStorage/AzureResponseCacheTests.cs
@@ -50,5 +50,5 @@ public class AzureResponseCacheTests : ResponseCacheTester, IAsyncLifetime
         => new AzureStorageResponseCacheProvider(_dirClient!);
 
     internal override IResponseCacheProvider CreateResponseCacheProvider(Func<DateTime> provideDateTime)
-        => new AzureStorageResponseCacheProvider(_dirClient!, timeToLiveForCacheEntries: null, provideDateTime);
+        => new AzureStorageResponseCacheProvider(_dirClient!, provideDateTime);
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/CacheEntryTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/CacheEntryTests.cs
@@ -24,7 +24,7 @@ public class CacheEntryTests
                 expiration: DateTime.UtcNow.Add(TimeSpan.FromMinutes(5)));
 
         string json = JsonSerializer.Serialize(entry, JsonUtilities.Default.CacheEntryTypeInfo);
-        CacheEntry? deserialized = JsonSerializer.Deserialize<CacheEntry>(json, JsonUtilities.Default.CacheEntryTypeInfo);
+        CacheEntry? deserialized = JsonSerializer.Deserialize(json, JsonUtilities.Default.CacheEntryTypeInfo);
 
         Assert.NotNull(deserialized);
         Assert.Equal(entry.ScenarioName, deserialized!.ScenarioName);
@@ -44,7 +44,7 @@ public class CacheEntryTests
                 expiration: DateTime.UtcNow.Add(TimeSpan.FromMinutes(5)));
 
         string json = JsonSerializer.Serialize(entry, JsonUtilities.Compact.CacheEntryTypeInfo);
-        CacheEntry? deserialized = JsonSerializer.Deserialize<CacheEntry>(json, JsonUtilities.Default.CacheEntryTypeInfo);
+        CacheEntry? deserialized = JsonSerializer.Deserialize(json, JsonUtilities.Default.CacheEntryTypeInfo);
 
         Assert.NotNull(deserialized);
         Assert.Equal(entry.ScenarioName, deserialized!.ScenarioName);

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/CacheOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/CacheOptionsTests.cs
@@ -20,7 +20,7 @@ public class CacheOptionsTests
         var options = new CacheOptions(CacheMode.Disabled, TimeSpan.FromDays(300));
 
         string json = JsonSerializer.Serialize(options, JsonUtilities.Default.CacheOptionsTypeInfo);
-        CacheOptions? deserialized = JsonSerializer.Deserialize<CacheOptions>(json, JsonUtilities.Default.CacheOptionsTypeInfo);
+        CacheOptions? deserialized = JsonSerializer.Deserialize(json, JsonUtilities.Default.CacheOptionsTypeInfo);
 
         Assert.NotNull(deserialized);
         Assert.Equal(options.Mode, deserialized!.Mode);
@@ -34,7 +34,7 @@ public class CacheOptionsTests
         var options = new CacheOptions(CacheMode.Disabled, TimeSpan.FromDays(300));
 
         string json = JsonSerializer.Serialize(options, JsonUtilities.Compact.CacheOptionsTypeInfo);
-        CacheOptions? deserialized = JsonSerializer.Deserialize<CacheOptions>(json, JsonUtilities.Default.CacheOptionsTypeInfo);
+        CacheOptions? deserialized = JsonSerializer.Deserialize(json, JsonUtilities.Default.CacheOptionsTypeInfo);
 
         Assert.NotNull(deserialized);
         Assert.Equal(options.Mode, deserialized!.Mode);

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ScenarioRunResultTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ScenarioRunResultTests.cs
@@ -17,18 +17,36 @@ public class ScenarioRunResultTests
     [Fact]
     public void SerializeScenarioRunResult()
     {
-        BooleanMetric booleanMetric = new BooleanMetric("boolean", value: true);
+        var booleanMetric = new BooleanMetric("boolean", value: true);
         booleanMetric.AddDiagnostic(EvaluationDiagnostic.Error("error"));
         booleanMetric.AddDiagnostic(EvaluationDiagnostic.Warning("warning"));
 
-        NumericMetric numericMetric = new NumericMetric("numeric", value: 3);
+        var numericMetric = new NumericMetric("numeric", value: 3);
         numericMetric.AddDiagnostic(EvaluationDiagnostic.Informational("info"));
 
-        StringMetric stringMetric = new StringMetric("string", value: "A");
+        var stringMetric = new StringMetric("string", value: "A");
 
-        EvaluationMetric metricWithNoValue = new EvaluationMetric("none");
+        var metricWithNoValue = new EvaluationMetric("none");
         metricWithNoValue.AddDiagnostic(EvaluationDiagnostic.Error("error"));
         metricWithNoValue.AddDiagnostic(EvaluationDiagnostic.Informational("info"));
+
+        var turn1 =
+            new ChatTurnDetails(
+                latency: TimeSpan.FromSeconds(1),
+                model: "gpt-4o",
+                usage: new UsageDetails { InputTokenCount = 10, OutputTokenCount = 20, TotalTokenCount = 30 },
+                cacheKey: Guid.NewGuid().ToString(),
+                cacheHit: true);
+
+        var turn2 =
+            new ChatTurnDetails(
+                latency: TimeSpan.FromSeconds(2),
+                model: "gpt-4o",
+                usage: new UsageDetails { InputTokenCount = 20, OutputTokenCount = 30, TotalTokenCount = 50 },
+                cacheKey: Guid.NewGuid().ToString(),
+                cacheHit: false);
+
+        var chatDetails = new ChatDetails(turn1, turn2);
 
         var entry = new ScenarioRunResult(
             scenarioName: "Test Scenario",
@@ -37,11 +55,14 @@ public class ScenarioRunResultTests
             creationTime: DateTime.UtcNow,
             messages: [new ChatMessage(ChatRole.User, "prompt")],
             modelResponse: new ChatResponse(new ChatMessage(ChatRole.Assistant, "response")),
-            evaluationResult: new EvaluationResult(booleanMetric, numericMetric, stringMetric, metricWithNoValue));
+            evaluationResult: new EvaluationResult(booleanMetric, numericMetric, stringMetric, metricWithNoValue),
+            chatDetails: chatDetails,
+            tags: ["first", "second"]);
+
         Assert.Equal(Defaults.ReportingFormatVersion, entry.FormatVersion);
 
         string json = JsonSerializer.Serialize(entry, JsonUtilities.Default.ScenarioRunResultTypeInfo);
-        ScenarioRunResult? deserialized = JsonSerializer.Deserialize<ScenarioRunResult>(json, JsonUtilities.Default.ScenarioRunResultTypeInfo);
+        ScenarioRunResult? deserialized = JsonSerializer.Deserialize(json, JsonUtilities.Default.ScenarioRunResultTypeInfo);
 
         Assert.NotNull(deserialized);
         Assert.Equal(entry.ScenarioName, deserialized!.ScenarioName);
@@ -50,6 +71,8 @@ public class ScenarioRunResultTests
         Assert.Equal(entry.CreationTime, deserialized.CreationTime);
         Assert.True(entry.Messages.SequenceEqual(deserialized.Messages, ChatMessageComparer.Instance));
         Assert.Equal(entry.ModelResponse, deserialized.ModelResponse, ChatResponseComparer.Instance);
+        Assert.True(entry.ChatDetails!.TurnDetails.SequenceEqual(deserialized.ChatDetails!.TurnDetails!, ChatTurnDetailsComparer.Instance));
+        Assert.True(entry.Tags!.SequenceEqual(deserialized.Tags!));
         Assert.Equal(entry.FormatVersion, deserialized.FormatVersion);
 
         ValidateEquivalence(entry.EvaluationResult, deserialized.EvaluationResult);
@@ -58,18 +81,36 @@ public class ScenarioRunResultTests
     [Fact]
     public void SerializeDatasetCompact()
     {
-        BooleanMetric booleanMetric = new BooleanMetric("boolean", value: true);
+        var booleanMetric = new BooleanMetric("boolean", value: true);
         booleanMetric.AddDiagnostic(EvaluationDiagnostic.Error("error"));
         booleanMetric.AddDiagnostic(EvaluationDiagnostic.Warning("warning"));
 
-        NumericMetric numericMetric = new NumericMetric("numeric", value: 3);
+        var numericMetric = new NumericMetric("numeric", value: 3);
         numericMetric.AddDiagnostic(EvaluationDiagnostic.Informational("info"));
 
-        StringMetric stringMetric = new StringMetric("string", value: "A");
+        var stringMetric = new StringMetric("string", value: "A");
 
-        EvaluationMetric metricWithNoValue = new EvaluationMetric("none");
+        var metricWithNoValue = new EvaluationMetric("none");
         metricWithNoValue.AddDiagnostic(EvaluationDiagnostic.Error("error"));
         metricWithNoValue.AddDiagnostic(EvaluationDiagnostic.Informational("info"));
+
+        var turn1 =
+            new ChatTurnDetails(
+                latency: TimeSpan.FromSeconds(1),
+                model: "gpt-4o",
+                usage: new UsageDetails { InputTokenCount = 10, OutputTokenCount = 20, TotalTokenCount = 30 },
+                cacheKey: Guid.NewGuid().ToString(),
+                cacheHit: true);
+
+        var turn2 =
+            new ChatTurnDetails(
+                latency: TimeSpan.FromSeconds(2),
+                model: "gpt-4o",
+                usage: new UsageDetails { InputTokenCount = 20, OutputTokenCount = 30, TotalTokenCount = 50 },
+                cacheKey: Guid.NewGuid().ToString(),
+                cacheHit: false);
+
+        var chatDetails = new ChatDetails(turn1, turn2);
 
         var entry = new ScenarioRunResult(
             scenarioName: "Test Scenario",
@@ -78,7 +119,11 @@ public class ScenarioRunResultTests
             creationTime: DateTime.UtcNow,
             messages: [new ChatMessage(ChatRole.User, "prompt")],
             modelResponse: new ChatResponse(new ChatMessage(ChatRole.Assistant, "response")),
-            evaluationResult: new EvaluationResult(booleanMetric, numericMetric, stringMetric, metricWithNoValue));
+            evaluationResult: new EvaluationResult(booleanMetric, numericMetric, stringMetric, metricWithNoValue),
+            chatDetails,
+            tags: ["first", "second"]);
+
+        Assert.Equal(Defaults.ReportingFormatVersion, entry.FormatVersion);
 
         var dataset = new Dataset([entry], createdAt: DateTime.UtcNow, generatorVersion: "1.2.3.4");
 
@@ -92,6 +137,9 @@ public class ScenarioRunResultTests
         Assert.Equal(entry.CreationTime, deserialized.ScenarioRunResults[0].CreationTime);
         Assert.True(entry.Messages.SequenceEqual(deserialized.ScenarioRunResults[0].Messages, ChatMessageComparer.Instance));
         Assert.Equal(entry.ModelResponse, deserialized.ScenarioRunResults[0].ModelResponse, ChatResponseComparer.Instance);
+        Assert.True(entry.ChatDetails!.TurnDetails.SequenceEqual(deserialized.ScenarioRunResults[0].ChatDetails!.TurnDetails!, ChatTurnDetailsComparer.Instance));
+        Assert.True(entry.Tags!.SequenceEqual(deserialized.ScenarioRunResults[0].Tags!));
+        Assert.Equal(entry.FormatVersion, deserialized.ScenarioRunResults[0].FormatVersion);
 
         Assert.Single(deserialized.ScenarioRunResults);
         Assert.Equal(dataset.CreatedAt, deserialized.CreatedAt);
@@ -181,6 +229,24 @@ public class ScenarioRunResultTests
             => x?.Severity == y?.Severity && x?.Message == y?.Message;
 
         public int GetHashCode(EvaluationDiagnostic obj)
+            => obj.GetHashCode();
+    }
+
+    private class ChatTurnDetailsComparer : IEqualityComparer<ChatTurnDetails>
+    {
+        public static ChatTurnDetailsComparer Instance { get; } = new ChatTurnDetailsComparer();
+
+#pragma warning disable S1067 // Expressions should not be too complex
+        public bool Equals(ChatTurnDetails? x, ChatTurnDetails? y) =>
+            x?.Latency == y?.Latency &&
+            x?.Usage?.InputTokenCount == y?.Usage?.InputTokenCount &&
+            x?.Usage?.OutputTokenCount == y?.Usage?.OutputTokenCount &&
+            x?.Usage?.TotalTokenCount == y?.Usage?.TotalTokenCount &&
+            x?.CacheKey == y?.CacheKey &&
+            x?.CacheHit == y?.CacheHit;
+#pragma warning restore S1067
+
+        public int GetHashCode(ChatTurnDetails obj)
             => obj.GetHashCode();
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/Settings.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/Settings.cs
@@ -15,7 +15,7 @@ public class Settings
     public Settings(IConfiguration config)
     {
 #pragma warning disable CA2208 // Pass correct parameter name for ArgumentNullException.
-        Configured = config.GetValue<bool>("Configured", false);
+        Configured = config.GetValue("Configured", false);
 
         StorageAccountEndpoint =
             config.GetValue<string>("StorageAccountEndpoint")


### PR DESCRIPTION
Also includes
- Support for measuring and logging diagnostic data related to caching, latency and token usage for all LLM turns involved in each evaluation.
- Report generation changes to view and filter scenarios by the tags above, and to display the above usage statistics under each scenario in the tree.
- Changes to make some previously public types internal to avoid public API bloat.
- Other miscellaneous bug fixes and improvements in the report generation and display.

Fixes #6034 and #5970
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6189)