### PR TITLE
A couple more minor eval report fixes

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/App.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/App.tsx
@@ -24,7 +24,8 @@ const useStyles = makeStyles({
     position: 'sticky',
     top: 0,
     zIndex: 1,
-    paddingBottom: '12px'
+    paddingBottom: '12px',
+    backgroundColor: tokens.colorNeutralBackground1,
   },
   headerTop: {
     display: 'flex',
@@ -124,13 +125,12 @@ function App({ dataset, tree }: AppProperties) {
           </div>
         </div>
         <GlobalTagsDisplay globalTags={globalTags} />
+        <FilterableTagsDisplay
+          filterableTags={filterableTags}
+          onTagClick={handleTagClick}
+          selectedTags={selectedTags}
+        />
       </div>
-
-      <FilterableTagsDisplay
-        filterableTags={filterableTags}
-        onTagClick={handleTagClick}
-        selectedTags={selectedTags}
-      />
 
       <ScenarioGroup
         node={tree}

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/TagsDisplay.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/TagsDisplay.tsx
@@ -8,7 +8,7 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     gap: '8px',
-    marginBottom: '16px',
+    marginBottom: '8px',
     paddingTop: '6px',
   },
   tagsRow: {


### PR DESCRIPTION
* Without the background color on the header, scrolling the report was causing the header portion to become transparent when the report was scrolled.
* Also moved the filterable tags into the header per earlier feedback.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6197)