### PR TITLE
Mirror integration tests for OllamaSharp

### DIFF
--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="$(MicrosoftMLTokenizersVersion)" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="OllamaSharp" Version="5.1.9" />
     <PackageVersion Include="OpenAI" Version="2.2.0-beta.4" />
     <PackageVersion Include="Polly" Version="8.4.2" />
     <PackageVersion Include="Polly.Core" Version="8.4.2" />

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/IntegrationTestHelpers.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/IntegrationTestHelpers.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.AI;
 #pragma warning disable S125 // Sections of code should not be commented out
 
 /// <summary>Shared utility methods for integration tests.</summary>
-internal static class IntegrationTestHelpers
+public static class IntegrationTestHelpers
 {
     /// <summary>Gets a <see cref="Uri"/> to use for testing, or <see langword="null"/> if the associated tests should be disabled.</summary>
     public static Uri? GetOllamaUri()

--- a/test/Libraries/Microsoft.Extensions.AI.OllamaSharp.Integration.Tests/Microsoft.Extensions.AI.OllamaSharp.Integration.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.AI.OllamaSharp.Integration.Tests/Microsoft.Extensions.AI.OllamaSharp.Integration.Tests.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Microsoft.Extensions.AI</RootNamespace>
+    <Description>Integration tests for OllamaSharp</Description>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Extensions.AI.Ollama.Tests\Microsoft.Extensions.AI.Ollama.Tests.csproj" ProjectUnderTest="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OllamaSharp" />
+  </ItemGroup>
+</Project>

--- a/test/Libraries/Microsoft.Extensions.AI.OllamaSharp.Integration.Tests/OllamaSharpChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OllamaSharp.Integration.Tests/OllamaSharpChatClientIntegrationTests.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using OllamaSharp;
+
+namespace Microsoft.Extensions.AI;
+
+public class OllamaSharpChatClientIntegrationTests : OllamaChatClientIntegrationTests
+{
+    protected override IChatClient? CreateChatClient() =>
+        IntegrationTestHelpers.GetOllamaUri() is Uri endpoint ?
+            new OllamaApiClient(endpoint, "llama3.2") :
+            null;
+}

--- a/test/Libraries/Microsoft.Extensions.AI.OllamaSharp.Integration.Tests/OllamaSharpEmbeddingGeneratorIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OllamaSharp.Integration.Tests/OllamaSharpEmbeddingGeneratorIntegrationTests.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using OllamaSharp;
+
+namespace Microsoft.Extensions.AI;
+
+public class OllamaSharpEmbeddingGeneratorIntegrationTests : OllamaEmbeddingGeneratorIntegrationTests
+{
+    protected override IEmbeddingGenerator<string, Embedding<float>>? CreateEmbeddingGenerator() =>
+        IntegrationTestHelpers.GetOllamaUri() is Uri endpoint ?
+            new OllamaApiClient(endpoint, "all-minilm") :
+            null;
+}


### PR DESCRIPTION
- [x] Add OllamaSharp 5.1.9 to [dotnet-public feed](https://github.com/dotnet/arcade/blob/main/Documentation/MirroringPackages.md), the current version there is 2.0.4.
- [ ] Compare results of both integration test runs to discard any bugs in OllamaSharp.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6209)