### PR TITLE
Fix execution order when reporting from Azure

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResultStore.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResultStore.cs
@@ -48,11 +48,10 @@ public sealed class AzureStorageResultStore(DataLakeDirectoryClient client) : IR
             paths.Add(item);
         }
 
-        foreach (PathItem item in paths.OrderBy(item => item.CreatedOn ?? DateTimeOffset.MinValue).Reverse().Take(count ?? 1))
+        foreach (PathItem item in paths.OrderByDescending(item => item.CreatedOn ?? DateTimeOffset.MinValue).Take(count ?? 1))
         {
             yield return GetLastSegmentFromPath(item.Name);
         }
-
     }
 
     /// <inheritdoc/>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResultStore.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResultStore.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
@@ -37,26 +38,21 @@ public sealed class AzureStorageResultStore(DataLakeDirectoryClient client) : IR
         int? count = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        int remaining = count ?? 1;
-
         (string path, _) = GetResultPath();
         DataLakeDirectoryClient subClient = client.GetSubDirectoryClient(path);
 
-#pragma warning disable S3254 // Default parameter value (for 'recursive') should not be passed as argument.
-        await foreach (PathItem item in
-            subClient.GetPathsAsync(recursive: false, cancellationToken: cancellationToken).ConfigureAwait(false))
-#pragma warning restore S3254
+        // We need to fetch the entire list of paths to get the latest execution names.
+        List<PathItem> paths = [];
+        await foreach (PathItem item in subClient.GetPathsAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
         {
-            if (remaining > 0)
-            {
-                yield return GetLastSegmentFromPath(item.Name);
-                remaining--;
-            }
-            else
-            {
-                break;
-            }
+            paths.Add(item);
         }
+
+        foreach (PathItem item in paths.OrderBy(item => item.CreatedOn ?? DateTimeOffset.MinValue).Reverse().Take(count ?? 1))
+        {
+            yield return GetLastSegmentFromPath(item.Name);
+        }
+
     }
 
     /// <inheritdoc/>

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ResultStoreTester.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ResultStoreTester.cs
@@ -119,6 +119,8 @@ public abstract class ResultStoreTester
         ];
         await resultStore.WriteResultsAsync(testResults);
 
+        await Task.Delay(TimeSpan.FromSeconds(1.5));
+
         string secondExecutionName = $"Test Execution {Path.GetRandomFileName()}";
         testResults = [
             CreateTestResult(ScenarioName(0), IterationName(0), secondExecutionName),
@@ -126,6 +128,8 @@ public abstract class ResultStoreTester
             CreateTestResult(ScenarioName(2), IterationName(4), secondExecutionName),
         ];
         await resultStore.WriteResultsAsync(testResults);
+
+        await Task.Delay(TimeSpan.FromSeconds(1.5));
 
         string thirdExecutionName = $"Test Execution {Path.GetRandomFileName()}";
         testResults = [

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ResultStoreTester.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ResultStoreTester.cs
@@ -119,7 +119,7 @@ public abstract class ResultStoreTester
         ];
         await resultStore.WriteResultsAsync(testResults);
 
-        await Task.Delay(TimeSpan.FromSeconds(1.5));
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
 
         string secondExecutionName = $"Test Execution {Path.GetRandomFileName()}";
         testResults = [
@@ -129,7 +129,7 @@ public abstract class ResultStoreTester
         ];
         await resultStore.WriteResultsAsync(testResults);
 
-        await Task.Delay(TimeSpan.FromSeconds(1.5));
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
 
         string thirdExecutionName = $"Test Execution {Path.GetRandomFileName()}";
         testResults = [
@@ -139,7 +139,7 @@ public abstract class ResultStoreTester
         ];
         await resultStore.WriteResultsAsync(testResults);
 
-        (string executionName, string scenarioName, string iterationName)[] results = [.. await LoadResultsAsync(5, resultStore)];
+        (string executionName, string scenarioName, string iterationName)[] results = [.. await LoadResultsAsync(n: 5, resultStore)];
         Assert.Equal(9, results.Length);
 
         Assert.True(results.Take(3).All(r => r.executionName == thirdExecutionName));


### PR DESCRIPTION
Order executions in descending order by creation time (most recent first; matches disk provider). Add tests to verify the order.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6217)