### PR TITLE
Add netstandard2.0 compatibility to Microsoft.Extensions.Telemetry and dependencies

### DIFF
--- a/src/Libraries/Microsoft.Extensions.DependencyInjection.AutoActivation/Microsoft.Extensions.DependencyInjection.AutoActivation.csproj
+++ b/src/Libraries/Microsoft.Extensions.DependencyInjection.AutoActivation/Microsoft.Extensions.DependencyInjection.AutoActivation.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.Extensions.DependencyInjection</RootNamespace>
+    <TargetFrameworks>$(NetCoreTargetFrameworks);netstandard2.0;</TargetFrameworks>
     <Description>Extensions to auto-activate registered singletons in the dependency injection system.</Description>
     <Workstream>Fundamentals</Workstream>
   </PropertyGroup>

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Microsoft.Extensions.Telemetry.Abstractions.csproj
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Microsoft.Extensions.Telemetry.Abstractions.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.Extensions.Telemetry</RootNamespace>
+    <TargetFrameworks>$(NetCoreTargetFrameworks);netstandard2.0;</TargetFrameworks>
     <Description>Common abstractions for high-level telemetry primitives.</Description>
     <Workstream>Telemetry</Workstream>
   </PropertyGroup>

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.Extensions.Diagnostics</RootNamespace>
+    <TargetFrameworks>$(NetCoreTargetFrameworks);netstandard2.0;</TargetFrameworks>
     <Description>Provides canonical implementations of telemetry abstractions.</Description>
     <Workstream>Telemetry</Workstream>
   </PropertyGroup>

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/RandomProbabilisticSampler.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/RandomProbabilisticSampler.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Linq;
-#if !NETFRAMEWORK
+#if !NETFRAMEWORK && !NETSTANDARD
 using System.Security.Cryptography;
 #endif
 using Microsoft.Extensions.Logging;
@@ -22,7 +22,7 @@ internal sealed class RandomProbabilisticSampler : LoggingSampler, IDisposable
 {
     internal RandomProbabilisticSamplerFilterRule[] LastKnownGoodSamplerRules;
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
     private static readonly System.Threading.ThreadLocal<Random> _randomInstance = new(() => new Random());
 #endif
 
@@ -50,7 +50,7 @@ internal sealed class RandomProbabilisticSampler : LoggingSampler, IDisposable
             return true;
         }
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
         return _randomInstance.Value!.Next(int.MaxValue) < int.MaxValue * probability;
 #else
         return RandomNumberGenerator.GetInt32(int.MaxValue) < int.MaxValue * probability;


### PR DESCRIPTION
Fixes https://github.com/dotnet/extensions/issues/5022

I have based on the format of this project to change the target frameworks:

https://github.com/dotnet/extensions/blob/56df0c4f4933909367536413dcf9c16520a37f82/src/Libraries/Microsoft.Extensions.Compliance.Abstractions/Microsoft.Extensions.Compliance.Abstractions.csproj#L4