### PR TITLE
Update AI chat template dependencies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -150,7 +150,7 @@
     <AspireVersion>9.1.0</AspireVersion>
     <AspireAzureAIOpenAIVersion>9.1.0-preview.1.25121.10</AspireAzureAIOpenAIVersion>
     <AzureAIProjectsVersion>1.0.0-beta.3</AzureAIProjectsVersion>
-    <AzureAIOpenAIVersion>2.2.0-beta.3</AzureAIOpenAIVersion>
+    <AzureAIOpenAIVersion>2.2.0-beta.4</AzureAIOpenAIVersion>
     <AzureIdentityVersion>1.13.2</AzureIdentityVersion>
     <AzureSearchDocumentsVersion>11.6.0</AzureSearchDocumentsVersion>
     <CommunityToolkitAspireHostingOllamaVersion>9.2.2-beta.236</CommunityToolkitAspireHostingOllamaVersion>
@@ -162,7 +162,6 @@
     <MicrosoftSemanticKernelConnectorsQdrantVersion>1.41.0-preview</MicrosoftSemanticKernelConnectorsQdrantVersion>
     <MicrosoftSemanticKernelCoreVersion>1.41.0</MicrosoftSemanticKernelCoreVersion>
     <OllamaSharpVersion>5.1.9</OllamaSharpVersion>
-    <OpenAIVersion>2.2.0-beta.3</OpenAIVersion>
     <OpenTelemetryVersion>1.9.0</OpenTelemetryVersion>
     <PdfPigVersion>0.1.9</PdfPigVersion>
     <SystemLinqAsyncVersion>6.0.1</SystemLinqAsyncVersion>

--- a/src/ProjectTemplates/GeneratedContent.targets
+++ b/src/ProjectTemplates/GeneratedContent.targets
@@ -58,7 +58,6 @@
         MicrosoftSemanticKernelConnectorsQdrantVersion=$(MicrosoftSemanticKernelConnectorsQdrantVersion);
         MicrosoftSemanticKernelCoreVersion=$(MicrosoftSemanticKernelCoreVersion);
         OllamaSharpVersion=$(OllamaSharpVersion);
-        OpenAIVersion=$(OpenAIVersion);
         OpenTelemetryVersion=$(OpenTelemetryVersion);
         PdfPigVersion=$(PdfPigVersion);
         SystemLinqAsyncVersion=$(SystemLinqAsyncVersion);

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/ChatWithCustomData-CSharp.Web.csproj.in
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/ChatWithCustomData-CSharp.Web.csproj.in
@@ -14,7 +14,6 @@
 <!--#if (IsOllama)
     <PackageReference Include="OllamaSharp" Version="${OllamaSharpVersion}" />
 #elif (IsGHModels && !IsAspire)
-    <PackageReference Include="OpenAI" Version="${OpenAIVersion}" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="${MicrosoftExtensionsAIVersion}" />
 #elif (IsAzureAiFoundry)
     <PackageReference Include="Azure.AI.Projects" Version="${AzureAIProjectsVersion}" />

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/aichatweb.csproj
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/aichatweb.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenAI" Version="2.2.0-beta.3" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.4.0" />


### PR DESCRIPTION
Makes the following changes to the chat template dependencies:
1. Upgrade `Azure.AI.OpenAI` from `2.2.0-beta.3` to `2.2.0-beta.4`
    * **Justification:** `Azure.AI.OpenAI` version 2.2.0-beta.3 does not exist. This caused version 2.2.0-beta.4 to be resolved automatically, but a warning still got reported when restoring the generated project
2. Remove the explicit dependency on `OpenAI` version `2.2.0-beta.3`
    * **Justification:** `OpenAI` version `2.2.0-beta.4` is already a dependency of `Microsoft.Extensions.AI.OpenAI`, which also gets referenced by the template. This created a restore error because `OpenAI` was being explicitly downgraded in the template's `.csproj`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6220)