### PR TITLE
Lower M.E.AI dependencies on .NET 8 and lower back to 8.0.x

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/AnonymousDelegatingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/AnonymousDelegatingChatClient.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -158,7 +159,22 @@ internal sealed class AnonymousDelegatingChatClient : DelegatingChatClient
                 }
             });
 
+#if NET9_0_OR_GREATER
             return updates.Reader.ReadAllAsync(cancellationToken);
+#else
+            return ReadAllAsync(updates, cancellationToken);
+            static async IAsyncEnumerable<ChatResponseUpdate> ReadAllAsync(
+                ChannelReader<ChatResponseUpdate> channel, [EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                while (await channel.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    while (channel.TryRead(out var update))
+                    {
+                        yield return update;
+                    }
+                }
+            }
+#endif
         }
         else if (_getStreamingResponseFunc is not null)
         {

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatResponse{T}.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatResponse{T}.cs
@@ -20,7 +20,12 @@ namespace Microsoft.Extensions.AI;
 /// </remarks>
 public class ChatResponse<T> : ChatResponse
 {
-    private static readonly JsonReaderOptions _allowMultipleValuesJsonReaderOptions = new() { AllowMultipleValues = true };
+    private static readonly JsonReaderOptions _allowMultipleValuesJsonReaderOptions = new()
+    {
+#if NET9_0_OR_GREATER
+        AllowMultipleValues = true
+#endif
+    };
     private readonly JsonSerializerOptions _serializerOptions;
 
     private T? _deserializedResult;

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
@@ -18,6 +18,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Shared.Diagnostics;
 
 #pragma warning disable S3358 // Ternary operators should not be nested
+#pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
+#pragma warning disable SA1113 // Comma should be on the same line as previous parameter
 
 namespace Microsoft.Extensions.AI;
 
@@ -70,14 +72,20 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
         _tokenUsageHistogram = _meter.CreateHistogram<int>(
             OpenTelemetryConsts.GenAI.Client.TokenUsage.Name,
             OpenTelemetryConsts.TokensUnit,
-            OpenTelemetryConsts.GenAI.Client.TokenUsage.Description,
-            advice: new() { HistogramBucketBoundaries = OpenTelemetryConsts.GenAI.Client.TokenUsage.ExplicitBucketBoundaries });
+            OpenTelemetryConsts.GenAI.Client.TokenUsage.Description
+#if NET9_0_OR_GREATER
+            , advice: new() { HistogramBucketBoundaries = OpenTelemetryConsts.GenAI.Client.TokenUsage.ExplicitBucketBoundaries }
+#endif
+            );
 
         _operationDurationHistogram = _meter.CreateHistogram<double>(
             OpenTelemetryConsts.GenAI.Client.OperationDuration.Name,
             OpenTelemetryConsts.SecondsUnit,
-            OpenTelemetryConsts.GenAI.Client.OperationDuration.Description,
-            advice: new() { HistogramBucketBoundaries = OpenTelemetryConsts.GenAI.Client.OperationDuration.ExplicitBucketBoundaries });
+            OpenTelemetryConsts.GenAI.Client.OperationDuration.Description
+#if NET9_0_OR_GREATER
+            , advice: new() { HistogramBucketBoundaries = OpenTelemetryConsts.GenAI.Client.OperationDuration.ExplicitBucketBoundaries }
+#endif
+            );
 
         _jsonSerializerOptions = AIJsonUtilities.DefaultOptions;
     }

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
@@ -12,6 +12,9 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Shared.Diagnostics;
 
+#pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
+#pragma warning disable SA1113 // Comma should be on the same line as previous parameter
+
 namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a delegating embedding generator that implements the OpenTelemetry Semantic Conventions for Generative AI systems.</summary>
@@ -67,14 +70,20 @@ public sealed class OpenTelemetryEmbeddingGenerator<TInput, TEmbedding> : Delega
         _tokenUsageHistogram = _meter.CreateHistogram<int>(
             OpenTelemetryConsts.GenAI.Client.TokenUsage.Name,
             OpenTelemetryConsts.TokensUnit,
-            OpenTelemetryConsts.GenAI.Client.TokenUsage.Description,
-            advice: new() { HistogramBucketBoundaries = OpenTelemetryConsts.GenAI.Client.TokenUsage.ExplicitBucketBoundaries });
+            OpenTelemetryConsts.GenAI.Client.TokenUsage.Description
+#if NET9_0_OR_GREATER
+            , advice: new() { HistogramBucketBoundaries = OpenTelemetryConsts.GenAI.Client.TokenUsage.ExplicitBucketBoundaries }
+#endif
+            );
 
         _operationDurationHistogram = _meter.CreateHistogram<double>(
             OpenTelemetryConsts.GenAI.Client.OperationDuration.Name,
             OpenTelemetryConsts.SecondsUnit,
-            OpenTelemetryConsts.GenAI.Client.OperationDuration.Description,
-            advice: new() { HistogramBucketBoundaries = OpenTelemetryConsts.GenAI.Client.OperationDuration.ExplicitBucketBoundaries });
+            OpenTelemetryConsts.GenAI.Client.OperationDuration.Description
+#if NET9_0_OR_GREATER
+            , advice: new() { HistogramBucketBoundaries = OpenTelemetryConsts.GenAI.Client.OperationDuration.ExplicitBucketBoundaries }
+#endif
+            );
     }
 
     /// <inheritdoc/>

--- a/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
@@ -4,8 +4,6 @@
     <RootNamespace>Microsoft.Extensions.AI</RootNamespace>
     <Description>Utilities for working with generative AI components.</Description>
     <Workstream>AI</Workstream>
-    <!-- This package needs to stay referencing .NET 9 versions of its dependencies -->
-    <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/AssertExtensions.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/AssertExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Xunit;
 using Xunit.Sdk;
 
@@ -57,7 +58,9 @@ internal static class AssertExtensions
         options ??= JsonSerializerOptions.Default;
         JsonElement expectedElement = NormalizeToElement(expected, options);
         JsonElement actualElement = NormalizeToElement(actual, options);
-        if (!JsonElement.DeepEquals(expectedElement, actualElement))
+        if (!JsonNode.DeepEquals(
+            JsonSerializer.SerializeToNode(expectedElement),
+            JsonSerializer.SerializeToNode(actualElement)))
         {
             string message = propertyName is null
                 ? $"Function result does not match expected JSON.\r\nExpected: {expectedElement.GetRawText()}\r\nActual:   {actualElement.GetRawText()}"

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Microsoft.Extensions.AI.Abstractions.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Microsoft.Extensions.AI.Abstractions.Tests.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="System.Memory.Data" />
     <PackageReference Include="JsonSchema.Net" />

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
@@ -147,7 +147,7 @@ public static class AIJsonUtilitiesTests
 
         JsonElement actual = AIJsonUtilities.CreateJsonSchema(typeof(MyPoco), serializerOptions: JsonSerializerOptions.Default);
 
-        Assert.True(JsonElement.DeepEquals(expected, actual));
+        Assert.True(DeepEquals(expected, actual));
     }
 
     [Fact]
@@ -192,7 +192,7 @@ public static class AIJsonUtilitiesTests
             serializerOptions: JsonSerializerOptions.Default,
             inferenceOptions: inferenceOptions);
 
-        Assert.True(JsonElement.DeepEquals(expected, actual));
+        Assert.True(DeepEquals(expected, actual));
     }
 
     [Fact]
@@ -237,7 +237,7 @@ public static class AIJsonUtilitiesTests
 
         JsonElement actual = AIJsonUtilities.CreateJsonSchema(typeof(MyPoco), serializerOptions: JsonSerializerOptions.Default, inferenceOptions: inferenceOptions);
 
-        Assert.True(JsonElement.DeepEquals(expected, actual));
+        Assert.True(DeepEquals(expected, actual));
     }
 
     [Fact]
@@ -265,7 +265,7 @@ public static class AIJsonUtilitiesTests
 
         JsonElement actual = AIJsonUtilities.CreateJsonSchema(typeof(PocoWithTypesWithOpenAIUnsupportedKeywords), serializerOptions: JsonSerializerOptions.Default);
 
-        Assert.True(JsonElement.DeepEquals(expected, actual));
+        Assert.True(DeepEquals(expected, actual));
     }
 
     public class PocoWithTypesWithOpenAIUnsupportedKeywords
@@ -289,7 +289,7 @@ public static class AIJsonUtilitiesTests
         Assert.NotNull(func.UnderlyingMethod);
 
         JsonElement resolvedSchema = AIJsonUtilities.CreateFunctionJsonSchema(func.UnderlyingMethod, title: func.Name);
-        Assert.True(JsonElement.DeepEquals(resolvedSchema, func.JsonSchema));
+        Assert.True(DeepEquals(resolvedSchema, func.JsonSchema));
     }
 
     [Fact]
@@ -301,7 +301,9 @@ public static class AIJsonUtilitiesTests
         JsonElement schemaParameters = func.JsonSchema.GetProperty("properties");
         Assert.NotNull(func.UnderlyingMethod);
         ParameterInfo[] parameters = func.UnderlyingMethod.GetParameters();
+#if NET9_0_OR_GREATER
         Assert.Equal(parameters.Length, schemaParameters.GetPropertyCount());
+#endif
 
         int i = 0;
         foreach (JsonProperty property in schemaParameters.EnumerateObject())
@@ -317,7 +319,7 @@ public static class AIJsonUtilitiesTests
                 """).RootElement;
 
             JsonElement actualSchema = property.Value;
-            Assert.True(JsonElement.DeepEquals(expected, actualSchema));
+            Assert.True(DeepEquals(expected, actualSchema));
             i++;
         }
     }
@@ -479,5 +481,16 @@ public static class AIJsonUtilitiesTests
     private class DerivedAIContent : AIContent
     {
         public int DerivedValue { get; set; }
+    }
+
+    private static bool DeepEquals(JsonElement element1, JsonElement element2)
+    {
+#if NET9_0_OR_GREATER
+        return JsonElement.DeepEquals(element1, element2);
+#else
+        return JsonNode.DeepEquals(
+            JsonSerializer.SerializeToNode(element1),
+            JsonSerializer.SerializeToNode(element2));
+#endif
     }
 }

--- a/test/Shared/JsonSchemaExporter/TestData.cs
+++ b/test/Shared/JsonSchemaExporter/TestData.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Schema;
 
 namespace Microsoft.Extensions.AI.JsonSchemaExporter;
 
@@ -14,7 +13,7 @@ internal sealed record TestData<T>(
     T? Value,
     [StringSyntax(StringSyntaxAttribute.Json)] string ExpectedJsonSchema,
     IEnumerable<T?>? AdditionalValues = null,
-    JsonSchemaExporterOptions? ExporterOptions = null,
+    object? ExporterOptions = null,
     JsonSerializerOptions? Options = null,
     bool WritesNumbersAsStrings = false)
     : ITestData
@@ -33,7 +32,9 @@ internal sealed record TestData<T>(
         yield return this;
 
         if (default(T) is null &&
-            ExporterOptions is { TreatNullObliviousAsNonNullable: false } &&
+#if NET9_0_OR_GREATER
+            ExporterOptions is System.Text.Json.Schema.JsonSchemaExporterOptions { TreatNullObliviousAsNonNullable: false } &&
+#endif
             Value is not null)
         {
             yield return this with { Value = default };

--- a/test/Shared/JsonSchemaExporter/TestTypes.cs
+++ b/test/Shared/JsonSchemaExporter/TestTypes.cs
@@ -9,10 +9,14 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+#if NET9_0_OR_GREATER
 using System.Reflection;
+#endif
 using System.Text.Json;
 using System.Text.Json.Nodes;
+#if NET9_0_OR_GREATER
 using System.Text.Json.Schema;
+#endif
 using System.Text.Json.Serialization;
 using System.Xml.Linq;
 
@@ -148,6 +152,7 @@ public static partial class TestTypes
             }
             """);
 
+#if NET9_0_OR_GREATER
         // Same as above but with nullable types set to non-nullable
         yield return new TestData<SimplePoco>(
             Value: new() { String = "string", StringNullable = "string", Int = 42, Double = 3.14, Boolean = true },
@@ -164,7 +169,8 @@ public static partial class TestTypes
                 }
             }
             """,
-            ExporterOptions: new() { TreatNullObliviousAsNonNullable = true });
+            ExporterOptions: new JsonSchemaExporterOptions { TreatNullObliviousAsNonNullable = true });
+#endif
 
         yield return new TestData<SimpleRecord>(
             Value: new(1, "two", true, 3.14),
@@ -305,6 +311,7 @@ public static partial class TestTypes
             }
             """);
 
+#if NET9_0_OR_GREATER
         // Same as above but with non-nullable reference types by default.
         yield return new TestData<PocoWithRecursiveMembers>(
             Value: new() { Value = 1, Next = new() { Value = 2, Next = new() { Value = 3 } } },
@@ -324,9 +331,8 @@ public static partial class TestTypes
                 }
             }
             """,
-            ExporterOptions: new() { TreatNullObliviousAsNonNullable = true });
+            ExporterOptions: new JsonSchemaExporterOptions { TreatNullObliviousAsNonNullable = true });
 
-#if !NET9_0 // Disable until https://github.com/dotnet/runtime/pull/108764 gets backported
         SimpleRecord recordValue = new(42, "str", true, 3.14);
         yield return new TestData<PocoWithNonRecursiveDuplicateOccurrences>(
             Value: new() { Value1 = recordValue, Value2 = recordValue, ArrayValue = [recordValue], ListValue = [recordValue] },
@@ -755,6 +761,7 @@ public static partial class TestTypes
             }
             """);
 
+#if NET9_0_OR_GREATER
         yield return new TestData<ClassWithComponentModelAttributes>(
             Value: new("string", -1),
             ExpectedJsonSchema: """
@@ -767,7 +774,7 @@ public static partial class TestTypes
                 "required": ["StringValue","IntValue"]
             }
             """,
-            ExporterOptions: new()
+            ExporterOptions: new JsonSchemaExporterOptions
             {
                 TransformSchemaNode = static (ctx, schema) =>
                 {
@@ -789,6 +796,7 @@ public static partial class TestTypes
                     return jObj;
                 }
             });
+#endif
 
         // Collection types
         yield return new TestData<int[]>([1, 2, 3], """{"type":["array","null"],"items":{"type":"integer"}}""");
@@ -1292,6 +1300,7 @@ public static partial class TestTypes
     [JsonSerializable(typeof(XElement))]
     public partial class TestTypesContext : JsonSerializerContext;
 
+#if NET9_0_OR_GREATER
     private static TAttribute? ResolveAttribute<TAttribute>(this JsonSchemaExporterContext ctx)
         where TAttribute : Attribute
     {
@@ -1300,16 +1309,12 @@ public static partial class TestTypes
         // 2. Parameter-level attributes and
         // 3. Type-level attributes.
         return
-#if NET9_0_OR_GREATER || !TESTS_JSON_SCHEMA_EXPORTER_POLYFILL
             GetAttrs(ctx.PropertyInfo?.AttributeProvider) ??
             GetAttrs(ctx.PropertyInfo?.AssociatedParameter?.AttributeProvider) ??
-#else
-            GetAttrs(ctx.PropertyAttributeProvider) ??
-            GetAttrs(ctx.ParameterInfo) ??
-#endif
             GetAttrs(ctx.TypeInfo.Type);
 
         static TAttribute? GetAttrs(ICustomAttributeProvider? provider) =>
             (TAttribute?)provider?.GetCustomAttributes(typeof(TAttribute), inherit: false).FirstOrDefault();
     }
+#endif
 }


### PR DESCRIPTION
We had been relying on System.Text.Json 9.0.x. This removes that override to only use 8.x versions of packages until building for .NET 9.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6230)