### PR TITLE
Use SHA384 and make key more explicit

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.cs
@@ -90,7 +90,7 @@ public static partial class AIJsonUtilities
 
         // For cases where the hash may be used as a cache key, we rely on collision resistance for security purposes.
         // If a collision occurs, we'd serve a cached LLM response for a potentially unrelated prompt, leading to information
-        // disclosure. Use of SHA256 is an implementation detail and can be easily swapped in the future if needed, albeit
+        // disclosure. Use of SHA384 is an implementation detail and can be easily swapped in the future if needed, albeit
         // invalidating any existing cache entries.
 #if NET
         IncrementalHashStream? stream = IncrementalHashStream.ThreadStaticInstance;
@@ -107,7 +107,7 @@ public static partial class AIJsonUtilities
             stream = new();
         }
 
-        Span<byte> hashData = stackalloc byte[SHA256.HashSizeInBytes];
+        Span<byte> hashData = stackalloc byte[SHA384.HashSizeInBytes];
         try
         {
             foreach (object? value in values)
@@ -133,8 +133,8 @@ public static partial class AIJsonUtilities
             JsonSerializer.Serialize(stream, value, jti);
         }
 
-        using var sha256 = SHA256.Create();
-        var hashData = sha256.ComputeHash(stream.GetBuffer(), 0, (int)stream.Length);
+        using var hashAlgorithm = SHA384.Create();
+        var hashData = hashAlgorithm.ComputeHash(stream.GetBuffer(), 0, (int)stream.Length);
 
         return ConvertToHexString(hashData);
 
@@ -185,7 +185,7 @@ public static partial class AIJsonUtilities
         public static IncrementalHashStream? ThreadStaticInstance;
 
         /// <summary>The <see cref="IncrementalHash"/> used by this instance.</summary>
-        private readonly IncrementalHash _hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        private readonly IncrementalHash _hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA384);
 
         /// <summary>Gets the current hash and resets.</summary>
         public void GetHashAndReset(Span<byte> bytes) => _hash.GetHashAndReset(bytes);

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ResponseCachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/ResponseCachingChatClient.cs
@@ -125,6 +125,6 @@ internal sealed class ResponseCachingChatClient : DistributedCachingChatClient
         }
     }
 
-    protected override string GetCacheKey(params ReadOnlySpan<object?> values)
-        => base.GetCacheKey([.. values, .. _cachingKeys]);
+    protected override string GetCacheKey(IEnumerable<ChatMessage> messages, ChatOptions? options, params ReadOnlySpan<object?> additionalValues)
+        => base.GetCacheKey(messages, options, [.. additionalValues, .. _cachingKeys]);
 }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/CachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/CachingChatClient.cs
@@ -53,7 +53,7 @@ public abstract class CachingChatClient : DelegatingChatClient
         // We're only storing the final result, not the in-flight task, so that we can avoid caching failures
         // or having problems when one of the callers cancels but others don't. This has the drawback that
         // concurrent callers might trigger duplicate requests, but that's acceptable.
-        var cacheKey = GetCacheKey(_boxedFalse, messages, options);
+        var cacheKey = GetCacheKey(messages, options, _boxedFalse);
 
         if (await ReadCacheAsync(cacheKey, cancellationToken).ConfigureAwait(false) is not { } result)
         {
@@ -76,7 +76,7 @@ public abstract class CachingChatClient : DelegatingChatClient
             // we make a streaming request, yielding those results, but then convert those into a non-streaming
             // result and cache it. When we get a cache hit, we yield the non-streaming result as a streaming one.
 
-            var cacheKey = GetCacheKey(_boxedTrue, messages, options);
+            var cacheKey = GetCacheKey(messages, options, _boxedTrue);
             if (await ReadCacheAsync(cacheKey, cancellationToken).ConfigureAwait(false) is { } chatResponse)
             {
                 // Yield all of the cached items.
@@ -101,7 +101,7 @@ public abstract class CachingChatClient : DelegatingChatClient
         }
         else
         {
-            var cacheKey = GetCacheKey(_boxedTrue, messages, options);
+            var cacheKey = GetCacheKey(messages, options, _boxedTrue);
             if (await ReadCacheStreamingAsync(cacheKey, cancellationToken).ConfigureAwait(false) is { } existingChunks)
             {
                 // Yield all of the cached items.
@@ -129,9 +129,11 @@ public abstract class CachingChatClient : DelegatingChatClient
     }
 
     /// <summary>Computes a cache key for the specified values.</summary>
-    /// <param name="values">The values to inform the key.</param>
+    /// <param name="messages">The messages to inform the key.</param>
+    /// <param name="options">The <see cref="ChatOptions"/> to inform the key.</param>
+    /// <param name="additionalValues">Any other values to inform the key.</param>
     /// <returns>The computed key.</returns>
-    protected abstract string GetCacheKey(params ReadOnlySpan<object?> values);
+    protected abstract string GetCacheKey(IEnumerable<ChatMessage> messages, ChatOptions? options, params ReadOnlySpan<object?> additionalValues);
 
     /// <summary>
     /// Returns a previously cached <see cref="ChatResponse"/>, if available.

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
@@ -97,21 +97,24 @@ public class DistributedCachingChatClient : CachingChatClient
     }
 
     /// <summary>Computes a cache key for the specified values.</summary>
-    /// <param name="values">The values to inform the key.</param>
+    /// <param name="messages">The messages to inform the key.</param>
+    /// <param name="options">The <see cref="ChatOptions"/> to inform the key.</param>
+    /// <param name="additionalValues">Any other values to inform the key.</param>
     /// <returns>The computed key.</returns>
     /// <remarks>
     /// <para>
-    /// The <paramref name="values"/> are serialized to JSON using <see cref="JsonSerializerOptions"/> in order to compute the key.
+    /// The <paramref name="messages"/>, <paramref name="options"/>, and <paramref name="additionalValues"/> are serialized to JSON using <see cref="JsonSerializerOptions"/>
+    /// in order to compute the key.
     /// </para>
     /// <para>
     /// The generated cache key is not guaranteed to be stable across releases of the library.
     /// </para>
     /// </remarks>
-    protected override string GetCacheKey(params ReadOnlySpan<object?> values)
+    protected override string GetCacheKey(IEnumerable<ChatMessage> messages, ChatOptions? options, params ReadOnlySpan<object?> additionalValues)
     {
         // Bump the cache version to invalidate existing caches if the serialization format changes in a breaking way.
         const int CacheVersion = 1;
 
-        return AIJsonUtilities.HashDataToString([CacheVersion, .. values], _jsonSerializerOptions);
+        return AIJsonUtilities.HashDataToString([CacheVersion, messages, options, .. additionalValues], _jsonSerializerOptions);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
@@ -801,18 +801,10 @@ public class DistributedCachingChatClientTest
     private sealed class CachingChatClientWithCustomKey(IChatClient innerClient, IDistributedCache storage)
         : DistributedCachingChatClient(innerClient, storage)
     {
-        protected override string GetCacheKey(params ReadOnlySpan<object?> values)
+        protected override string GetCacheKey(IEnumerable<ChatMessage> messages, ChatOptions? options, params ReadOnlySpan<object?> additionalValues)
         {
-            var baseKey = base.GetCacheKey(values);
-            foreach (var value in values)
-            {
-                if (value is ChatOptions options)
-                {
-                    return baseKey + options.AdditionalProperties?["someKey"]?.ToString();
-                }
-            }
-
-            return baseKey;
+            var baseKey = base.GetCacheKey(messages, options, additionalValues);
+            return baseKey + options?.AdditionalProperties?["someKey"]?.ToString();
         }
     }
 


### PR DESCRIPTION
This PR includes the changes from https://github.com/dotnet/extensions/pull/6236 and also changes the `GetCacheKey` method signature so that it explicitly takes `messages`/`options` params:

```diff
-    protected abstract string GetCacheKey(params ReadOnlySpan<object?> values);
+    protected abstract string GetCacheKey(IEnumerable<ChatMessage> messages, ChatOptions? options, params ReadOnlySpan<object?> additionalValues);
```

We don't strictly have to do this. However it can be beneficial for people who want to customize the cache key computation to include other data (e.g., from `AdditionalProperties` from within messages or options). Previously they would have to just somehow know that one of the incoming `values` will be the data they need, and would need to do runtime type checking to find the relevant one, and would have to hope that we don't change the incoming data shape in the future (e.g., pre-JSON-serializing the values).

The more explicit signature in this PR would be a guarantee that we will in fact pass in these specific `IEnumerable<ChatMessage>`/`ChatOptions?` types. I don't think there's much drawback to us offering that guarantee, since this is really baked into the `IChatClient` contract anyway - those are exactly the data items that middleware has access to.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6237)

## Hash algorithm

I considered also making the hash algorithm configurable (defaulting to SHA384). However that complicates things because currently we use a thread-static `IncrementalHashStream` that holds the `IncrementalHash` instance. We'd have to create new instances when different hash algorithms are specified.

Since we've been told that in this case, SHA384 is sufficient without being configurable, I'd be happy to leave it at that.