### PR TITLE
add CommTagAttribute for metric code generator

### DIFF
--- a/src/Generators/Microsoft.Gen.Metrics/Emitter.cs
+++ b/src/Generators/Microsoft.Gen.Metrics/Emitter.cs
@@ -94,7 +94,7 @@ internal sealed class Emitter : EmitterBase
                 OutLn();
             }
 
-            GenInstrumentClass(metricMethod);
+            GenInstrumentClass(metricMethod, metricType.CommonTags);
         }
     }
 
@@ -145,7 +145,8 @@ internal sealed class Emitter : EmitterBase
         }
     }
 
-    private void GenInstrumentClass(MetricMethod metricMethod)
+    private void GenInstrumentClass(MetricMethod metricMethod, List<KeyValuePair<string, string>>? commonTags)
+
     {
         const string CounterObjectName = "counter";
         const string HistogramObjectName = "histogram";
@@ -180,7 +181,9 @@ internal sealed class Emitter : EmitterBase
         }
 
         var tagListInit = metricMethod.TagKeys.Count != 0 ||
-                          metricMethod.StrongTypeConfigs.Count != 0;
+                          metricMethod.StrongTypeConfigs.Count != 0 ||
+                          (commonTags != null && commonTags.Count != 0);
+
 
         var accessModifier = metricMethod.MetricTypeModifiers.Contains("public")
             ? "public"
@@ -231,7 +234,7 @@ internal sealed class Emitter : EmitterBase
             Indent();
             OutLn("var tagList = new global::System.Diagnostics.TagList");
             OutOpenBrace();
-            GenTagList(metricMethod);
+            GenTagList(metricMethod, commonTags);
             Unindent();
             OutLn("};");
             Unindent();
@@ -290,7 +293,7 @@ internal sealed class Emitter : EmitterBase
         OutLn();
     }
 
-    private void GenTagList(MetricMethod metricMethod)
+    private void GenTagList(MetricMethod metricMethod, List<KeyValuePair<string, string>>? commonTags)
     {
         if (string.IsNullOrEmpty(metricMethod.StrongTypeObjectName))
         {
@@ -320,6 +323,14 @@ internal sealed class Emitter : EmitterBase
                     : "o." + config.Path + "." + paramInvoke;
 
                 OutLn($"new global::System.Collections.Generic.KeyValuePair<string, object?>(\"{config.TagName}\", {access}),");
+            }
+        }
+
+        if (commonTags != null)
+        {
+            foreach (var tag in commonTags)
+            {
+                OutLn($"new global::System.Collections.Generic.KeyValuePair<string, object?>(\"{tag.Key}\", \"{tag.Value}\"),");
             }
         }
     }

--- a/src/Generators/Microsoft.Gen.Metrics/Model/MetricType.cs
+++ b/src/Generators/Microsoft.Gen.Metrics/Model/MetricType.cs
@@ -14,4 +14,5 @@ internal sealed class MetricType
     public string Modifiers = string.Empty;
     public string Keyword = string.Empty;
     public MetricType? Parent;
+    public List<KeyValuePair<string, string>>? CommonTags;
 }

--- a/src/Generators/Microsoft.Gen.Metrics/Parser.cs
+++ b/src/Generators/Microsoft.Gen.Metrics/Parser.cs
@@ -75,6 +75,8 @@ internal sealed class Parser
 
                 MetricType? metricType = null;
                 string nspace = string.Empty;
+                semanticModel ??= _compilation.GetSemanticModel(typeDeclaration.SyntaxTree);
+                var commonTags = GetCommonTags(typeDeclaration, symbols, semanticModel, _cancellationToken);
 
                 metricNames.Clear();
 
@@ -135,6 +137,7 @@ internal sealed class Parser
                             {
                                 Namespace = nspace,
                                 Name = typeDeclaration.Identifier.ToString() + typeDeclaration.TypeParameterList,
+                                CommonTags = commonTags,
                                 Constraints = typeDeclaration.ConstraintClauses.ToString(),
                                 Keyword = typeDeclaration.Keyword.ValueText,
                                 Parent = null,
@@ -157,6 +160,7 @@ internal sealed class Parser
                                 {
                                     Namespace = nspace,
                                     Name = parentMetricClass.Identifier.ToString() + parentMetricClass.TypeParameterList,
+                                    CommonTags = commonTags,
                                     Constraints = parentMetricClass.ConstraintClauses.ToString(),
                                     Keyword = parentMetricClass.Keyword.ValueText,
                                     Modifiers = parentMetricClass.Modifiers.ToString(),
@@ -185,6 +189,54 @@ internal sealed class Parser
         }
 
         return results;
+    }
+
+    private static List<KeyValuePair<string, string>> GetCommonTags(TypeDeclarationSyntax classDeclaration, SymbolHolder symbols, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        List<KeyValuePair<string, string>> commonTags = new();
+        var attributes = classDeclaration.AttributeLists.SelectMany(al => al.Attributes);
+
+        foreach (var attribute in attributes)
+        {
+            var attributeTypeInfo = semanticModel.GetTypeInfo(attribute, cancellationToken);
+            if (attributeTypeInfo.Type == null || !attributeTypeInfo.Type.Equals(symbols.CommonTagAttribute, SymbolEqualityComparer.Default))
+            {
+                continue;
+            }
+
+            if (attribute.ArgumentList != null)
+            {
+                KeyValuePair<string, string> tag;
+                string tagKey = string.Empty;
+                string tagValue = string.Empty;
+
+                foreach (var argument in attribute.ArgumentList.Arguments)
+                {
+                    var key = argument.NameColon?.Name.ToString();
+                    var value = argument.Expression.ToString().Trim('"');
+                    if (key != null && !string.IsNullOrWhiteSpace(key))
+                    {
+                        if (key == "tagName")
+                        {
+                            tagKey = value;
+                        }
+                        else if (key == "tagValue")
+                        {
+                            tagValue = value;
+                        }
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(tagKey))
+                {
+                    tag = new KeyValuePair<string, string>(tagKey, tagValue);
+                }
+
+                commonTags.Add(tag);
+            }
+        }
+
+        return commonTags;
     }
 
     private static void UpdateMetricKeywordIfRequired(TypeDeclarationSyntax? typeDeclaration, MetricType metricType)

--- a/src/Generators/Microsoft.Gen.Metrics/SymbolHolder.cs
+++ b/src/Generators/Microsoft.Gen.Metrics/SymbolHolder.cs
@@ -15,4 +15,5 @@ internal sealed record class SymbolHolder(
     INamedTypeSymbol? HistogramOfTAttribute,
     INamedTypeSymbol? GaugeAttribute,
     INamedTypeSymbol LongTypeSymbol,
-    INamedTypeSymbol? TagNameAttribute);
+    INamedTypeSymbol? TagNameAttribute,
+    INamedTypeSymbol? CommonTagAttribute);

--- a/src/Generators/Microsoft.Gen.Metrics/SymbolLoader.cs
+++ b/src/Generators/Microsoft.Gen.Metrics/SymbolLoader.cs
@@ -12,6 +12,7 @@ internal static class SymbolLoader
     internal const string GaugeAttribute = "Microsoft.Extensions.Diagnostics.Metrics.GaugeAttribute";
     internal const string CounterAttribute = "Microsoft.Extensions.Diagnostics.Metrics.CounterAttribute";
     internal const string HistogramAttribute = "Microsoft.Extensions.Diagnostics.Metrics.HistogramAttribute";
+    internal const string CommonTagAttribute = "Microsoft.Extensions.Diagnostics.Metrics.CommonTagAttribute";
     internal const string TagNameAttribute = "Microsoft.Extensions.Diagnostics.Metrics.TagNameAttribute";
     internal const string MeterClass = "System.Diagnostics.Metrics.Meter";
 
@@ -33,6 +34,7 @@ internal static class SymbolLoader
         var histogramTAttribute = compilation.GetTypeByMetadataName(HistogramTAttribute);
         var gaugeAttribute = compilation.GetTypeByMetadataName(GaugeAttribute);
         var tagNameAttribute = compilation.GetTypeByMetadataName(TagNameAttribute);
+        var commonTagAttribute = compilation.GetTypeByMetadataName(CommonTagAttribute);
         var longType = compilation.GetSpecialType(SpecialType.System_Int64);
 
         return new(
@@ -43,6 +45,7 @@ internal static class SymbolLoader
             histogramTAttribute,
             gaugeAttribute,
             longType,
-            tagNameAttribute);
+            tagNameAttribute,
+            commonTagAttribute);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/CommonTagAttribute.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/CommonTagAttribute.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.Telemetry.Metrics;
+
+/// <summary>
+/// Provides a way to add common tags to the all the metrics in this class.
+/// </summary>
+/// <example>
+/// <code language="csharp">
+/// [CommonTag("Category", "Http")]
+/// [CommonTag("MetricVersion", "v1")]
+/// static partial class Metric
+/// {
+///     [Counter("RequestName", "RequestStatusCode")]
+///     static partial RequestCounter CreateRequestCounter(Meter meter);
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+[Conditional("CODE_GENERATION_ATTRIBUTES")]
+public sealed class CommonTagAttribute : Attribute
+{
+    public CommonTagAttribute(string tagName, string tagValue)
+    {
+        if (string.IsNullOrEmpty(tagName))
+        {
+            throw new ArgumentException("tagName name cannot be null or empty.", nameof(tagName));
+        }
+
+        this.TagName = tagName;
+        this.TagValue = tagValue;
+    }
+
+    public string TagName { get; }
+    public string TagValue { get; }
+}


### PR DESCRIPTION
Support common tag and value for the same group of metrics

```
[CommonTag("Category", "Http")]
[CommonTag("MetricVersion", "v1")]
 static partial class Metric
 {
    [Counter("RequestName", "RequestStatusCode")]
    static partial RequestCounter CreateRequestCounter(Meter meter);
}
```