### PR TITLE
Remove use of ConfigureAwait from Microsoft.Extensions.AI.dll for AIFunction invocations

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/AnonymousDelegatingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/AnonymousDelegatingChatClient.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+#if !NET9_0_OR_GREATER
 using System.Runtime.CompilerServices;
+#endif
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -100,8 +102,8 @@ internal sealed class AnonymousDelegatingChatClient : DelegatingChatClient
                 ChatResponse? response = null;
                 await _sharedFunc(messages, options, async (messages, options, cancellationToken) =>
                 {
-                    response = await InnerClient.GetResponseAsync(messages, options, cancellationToken).ConfigureAwait(false);
-                }, cancellationToken).ConfigureAwait(false);
+                    response = await InnerClient.GetResponseAsync(messages, options, cancellationToken);
+                }, cancellationToken);
 
                 if (response is null)
                 {
@@ -133,20 +135,19 @@ internal sealed class AnonymousDelegatingChatClient : DelegatingChatClient
         {
             var updates = Channel.CreateBounded<ChatResponseUpdate>(1);
 
-#pragma warning disable CA2016 // explicitly not forwarding the cancellation token, as we need to ensure the channel is always completed
-            _ = Task.Run(async () =>
-#pragma warning restore CA2016
+            _ = ProcessAsync();
+            async Task ProcessAsync()
             {
                 Exception? error = null;
                 try
                 {
                     await _sharedFunc(messages, options, async (messages, options, cancellationToken) =>
                     {
-                        await foreach (var update in InnerClient.GetStreamingResponseAsync(messages, options, cancellationToken).ConfigureAwait(false))
+                        await foreach (var update in InnerClient.GetStreamingResponseAsync(messages, options, cancellationToken))
                         {
-                            await updates.Writer.WriteAsync(update, cancellationToken).ConfigureAwait(false);
+                            await updates.Writer.WriteAsync(update, cancellationToken);
                         }
-                    }, cancellationToken).ConfigureAwait(false);
+                    }, cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -157,7 +158,7 @@ internal sealed class AnonymousDelegatingChatClient : DelegatingChatClient
                 {
                     _ = updates.Writer.TryComplete(error);
                 }
-            });
+            }
 
 #if NET9_0_OR_GREATER
             return updates.Reader.ReadAllAsync(cancellationToken);
@@ -166,7 +167,7 @@ internal sealed class AnonymousDelegatingChatClient : DelegatingChatClient
             static async IAsyncEnumerable<ChatResponseUpdate> ReadAllAsync(
                 ChannelReader<ChatResponseUpdate> channel, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                while (await channel.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+                while (await channel.WaitToReadAsync(cancellationToken))
                 {
                     while (channel.TryRead(out var update))
                     {
@@ -187,7 +188,7 @@ internal sealed class AnonymousDelegatingChatClient : DelegatingChatClient
 
             static async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsyncViaGetResponseAsync(Task<ChatResponse> task)
             {
-                ChatResponse response = await task.ConfigureAwait(false);
+                ChatResponse response = await task;
                 foreach (var update in response.ToChatResponseUpdates())
                 {
                     yield return update;

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/CachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/CachingChatClient.cs
@@ -55,10 +55,10 @@ public abstract class CachingChatClient : DelegatingChatClient
         // concurrent callers might trigger duplicate requests, but that's acceptable.
         var cacheKey = GetCacheKey(messages, options, _boxedFalse);
 
-        if (await ReadCacheAsync(cacheKey, cancellationToken).ConfigureAwait(false) is not { } result)
+        if (await ReadCacheAsync(cacheKey, cancellationToken) is not { } result)
         {
-            result = await base.GetResponseAsync(messages, options, cancellationToken).ConfigureAwait(false);
-            await WriteCacheAsync(cacheKey, result, cancellationToken).ConfigureAwait(false);
+            result = await base.GetResponseAsync(messages, options, cancellationToken);
+            await WriteCacheAsync(cacheKey, result, cancellationToken);
         }
 
         return result;
@@ -77,7 +77,7 @@ public abstract class CachingChatClient : DelegatingChatClient
             // result and cache it. When we get a cache hit, we yield the non-streaming result as a streaming one.
 
             var cacheKey = GetCacheKey(messages, options, _boxedTrue);
-            if (await ReadCacheAsync(cacheKey, cancellationToken).ConfigureAwait(false) is { } chatResponse)
+            if (await ReadCacheAsync(cacheKey, cancellationToken) is { } chatResponse)
             {
                 // Yield all of the cached items.
                 foreach (var chunk in chatResponse.ToChatResponseUpdates())
@@ -89,20 +89,20 @@ public abstract class CachingChatClient : DelegatingChatClient
             {
                 // Yield and store all of the items.
                 List<ChatResponseUpdate> capturedItems = [];
-                await foreach (var chunk in base.GetStreamingResponseAsync(messages, options, cancellationToken).ConfigureAwait(false))
+                await foreach (var chunk in base.GetStreamingResponseAsync(messages, options, cancellationToken))
                 {
                     capturedItems.Add(chunk);
                     yield return chunk;
                 }
 
                 // Write the captured items to the cache as a non-streaming result.
-                await WriteCacheAsync(cacheKey, capturedItems.ToChatResponse(), cancellationToken).ConfigureAwait(false);
+                await WriteCacheAsync(cacheKey, capturedItems.ToChatResponse(), cancellationToken);
             }
         }
         else
         {
             var cacheKey = GetCacheKey(messages, options, _boxedTrue);
-            if (await ReadCacheStreamingAsync(cacheKey, cancellationToken).ConfigureAwait(false) is { } existingChunks)
+            if (await ReadCacheStreamingAsync(cacheKey, cancellationToken) is { } existingChunks)
             {
                 // Yield all of the cached items.
                 string? chatThreadId = null;
@@ -116,14 +116,14 @@ public abstract class CachingChatClient : DelegatingChatClient
             {
                 // Yield and store all of the items.
                 List<ChatResponseUpdate> capturedItems = [];
-                await foreach (var chunk in base.GetStreamingResponseAsync(messages, options, cancellationToken).ConfigureAwait(false))
+                await foreach (var chunk in base.GetStreamingResponseAsync(messages, options, cancellationToken))
                 {
                     capturedItems.Add(chunk);
                     yield return chunk;
                 }
 
                 // Write the captured items to the cache.
-                await WriteCacheStreamingAsync(cacheKey, capturedItems, cancellationToken).ConfigureAwait(false);
+                await WriteCacheStreamingAsync(cacheKey, capturedItems, cancellationToken);
             }
         }
     }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientBuilderChatClientExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientBuilderChatClientExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Microsoft.Extensions.AI;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
@@ -221,7 +221,7 @@ public static class ChatClientStructuredOutputExtensions
             messages = [.. messages, promptAugmentation];
         }
 
-        var result = await chatClient.GetResponseAsync(messages, options, cancellationToken).ConfigureAwait(false);
+        var result = await chatClient.GetResponseAsync(messages, options, cancellationToken);
         return new ChatResponse<T>(result, serializerOptions) { IsWrappedInObject = isWrappedInObject };
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ConfigureOptionsChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ConfigureOptionsChatClient.cs
@@ -36,13 +36,13 @@ public sealed class ConfigureOptionsChatClient : DelegatingChatClient
     /// <inheritdoc/>
     public override async Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default) =>
-        await base.GetResponseAsync(messages, Configure(options), cancellationToken).ConfigureAwait(false);
+        await base.GetResponseAsync(messages, Configure(options), cancellationToken);
 
     /// <inheritdoc/>
     public override async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
         IEnumerable<ChatMessage> messages, ChatOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await foreach (var update in base.GetStreamingResponseAsync(messages, Configure(options), cancellationToken).ConfigureAwait(false))
+        await foreach (var update in base.GetStreamingResponseAsync(messages, Configure(options), cancellationToken))
         {
             yield return update;
         }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
@@ -52,7 +52,7 @@ public class DistributedCachingChatClient : CachingChatClient
         _ = Throw.IfNull(key);
         _jsonSerializerOptions.MakeReadOnly();
 
-        if (await _storage.GetAsync(key, cancellationToken).ConfigureAwait(false) is byte[] existingJson)
+        if (await _storage.GetAsync(key, cancellationToken) is byte[] existingJson)
         {
             return (ChatResponse?)JsonSerializer.Deserialize(existingJson, _jsonSerializerOptions.GetTypeInfo(typeof(ChatResponse)));
         }
@@ -66,7 +66,7 @@ public class DistributedCachingChatClient : CachingChatClient
         _ = Throw.IfNull(key);
         _jsonSerializerOptions.MakeReadOnly();
 
-        if (await _storage.GetAsync(key, cancellationToken).ConfigureAwait(false) is byte[] existingJson)
+        if (await _storage.GetAsync(key, cancellationToken) is byte[] existingJson)
         {
             return (IReadOnlyList<ChatResponseUpdate>?)JsonSerializer.Deserialize(existingJson, _jsonSerializerOptions.GetTypeInfo(typeof(IReadOnlyList<ChatResponseUpdate>)));
         }
@@ -82,7 +82,7 @@ public class DistributedCachingChatClient : CachingChatClient
         _jsonSerializerOptions.MakeReadOnly();
 
         var newJson = JsonSerializer.SerializeToUtf8Bytes(value, _jsonSerializerOptions.GetTypeInfo(typeof(ChatResponse)));
-        await _storage.SetAsync(key, newJson, cancellationToken).ConfigureAwait(false);
+        await _storage.SetAsync(key, newJson, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -93,7 +93,7 @@ public class DistributedCachingChatClient : CachingChatClient
         _jsonSerializerOptions.MakeReadOnly();
 
         var newJson = JsonSerializer.SerializeToUtf8Bytes(value, _jsonSerializerOptions.GetTypeInfo(typeof(IReadOnlyList<ChatResponseUpdate>)));
-        await _storage.SetAsync(key, newJson, cancellationToken).ConfigureAwait(false);
+        await _storage.SetAsync(key, newJson, cancellationToken);
     }
 
     /// <summary>Computes a cache key for the specified values.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/LoggingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/LoggingChatClient.cs
@@ -60,7 +60,7 @@ public partial class LoggingChatClient : DelegatingChatClient
 
         try
         {
-            var response = await base.GetResponseAsync(messages, options, cancellationToken).ConfigureAwait(false);
+            var response = await base.GetResponseAsync(messages, options, cancellationToken);
 
             if (_logger.IsEnabled(LogLevel.Debug))
             {
@@ -127,7 +127,7 @@ public partial class LoggingChatClient : DelegatingChatClient
             {
                 try
                 {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
+                    if (!await e.MoveNextAsync())
                     {
                         break;
                     }
@@ -164,7 +164,7 @@ public partial class LoggingChatClient : DelegatingChatClient
         }
         finally
         {
-            await e.DisposeAsync().ConfigureAwait(false);
+            await e.DisposeAsync();
         }
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
@@ -145,7 +145,7 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
         Exception? error = null;
         try
         {
-            response = await base.GetResponseAsync(messages, options, cancellationToken).ConfigureAwait(false);
+            response = await base.GetResponseAsync(messages, options, cancellationToken);
             return response;
         }
         catch (Exception ex)
@@ -183,7 +183,7 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
             throw;
         }
 
-        var responseEnumerator = updates.ConfigureAwait(false).GetAsyncEnumerator();
+        var responseEnumerator = updates.GetAsyncEnumerator(cancellationToken);
         List<ChatResponseUpdate> trackedUpdates = [];
         Exception? error = null;
         try

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/AnonymousDelegatingEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/AnonymousDelegatingEmbeddingGenerator.cs
@@ -39,6 +39,6 @@ internal sealed class AnonymousDelegatingEmbeddingGenerator<TInput, TEmbedding> 
     {
         _ = Throw.IfNull(values);
 
-        return await _generateFunc(values, options, InnerGenerator, cancellationToken).ConfigureAwait(false);
+        return await _generateFunc(values, options, InnerGenerator, cancellationToken);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/CachingEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/CachingEmbeddingGenerator.cs
@@ -42,19 +42,19 @@ public abstract class CachingEmbeddingGenerator<TInput, TEmbedding> : Delegating
                     // In the expected common case where we can cheaply tell there's only a single value and access it,
                     // we can avoid all the overhead of splitting the list and reassembling it.
                     var cacheKey = GetCacheKey(valuesList[0], options);
-                    if (await ReadCacheAsync(cacheKey, cancellationToken).ConfigureAwait(false) is TEmbedding e)
+                    if (await ReadCacheAsync(cacheKey, cancellationToken) is TEmbedding e)
                     {
                         return [e];
                     }
                     else
                     {
-                        var generated = await base.GenerateAsync(valuesList, options, cancellationToken).ConfigureAwait(false);
+                        var generated = await base.GenerateAsync(valuesList, options, cancellationToken);
                         if (generated.Count != 1)
                         {
                             Throw.InvalidOperationException($"Expected exactly one embedding to be generated, but received {generated.Count}.");
                         }
 
-                        await WriteCacheAsync(cacheKey, generated[0], cancellationToken).ConfigureAwait(false);
+                        await WriteCacheAsync(cacheKey, generated[0], cancellationToken);
                         return generated;
                     }
             }
@@ -72,7 +72,7 @@ public abstract class CachingEmbeddingGenerator<TInput, TEmbedding> : Delegating
             // concurrent callers might trigger duplicate requests, but that's acceptable.
             var cacheKey = GetCacheKey(input, options);
 
-            if (await ReadCacheAsync(cacheKey, cancellationToken).ConfigureAwait(false) is TEmbedding existing)
+            if (await ReadCacheAsync(cacheKey, cancellationToken) is TEmbedding existing)
             {
                 results.Add(existing);
             }
@@ -87,12 +87,12 @@ public abstract class CachingEmbeddingGenerator<TInput, TEmbedding> : Delegating
         if (uncached is not null)
         {
             // Now make a single call to the wrapped generator to generate embeddings for all of the uncached inputs.
-            var uncachedResults = await base.GenerateAsync(uncached.Select(e => e.Input), options, cancellationToken).ConfigureAwait(false);
+            var uncachedResults = await base.GenerateAsync(uncached.Select(e => e.Input), options, cancellationToken);
 
             // Store the resulting embeddings into the cache individually.
             for (int i = 0; i < uncachedResults.Count; i++)
             {
-                await WriteCacheAsync(uncached[i].CacheKey, uncachedResults[i], cancellationToken).ConfigureAwait(false);
+                await WriteCacheAsync(uncached[i].CacheKey, uncachedResults[i], cancellationToken);
             }
 
             // Fill in the gaps with the newly generated results.

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/ConfigureOptionsEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/ConfigureOptionsEmbeddingGenerator.cs
@@ -46,7 +46,7 @@ public sealed class ConfigureOptionsEmbeddingGenerator<TInput, TEmbedding> : Del
         EmbeddingGenerationOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        return await base.GenerateAsync(values, Configure(options), cancellationToken).ConfigureAwait(false);
+        return await base.GenerateAsync(values, Configure(options), cancellationToken);
     }
 
     /// <summary>Creates and configures the <see cref="EmbeddingGenerationOptions"/> to pass along to the inner client.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/DistributedCachingEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/DistributedCachingEmbeddingGenerator.cs
@@ -57,7 +57,7 @@ public class DistributedCachingEmbeddingGenerator<TInput, TEmbedding> : CachingE
         _ = Throw.IfNull(key);
         _jsonSerializerOptions.MakeReadOnly();
 
-        if (await _storage.GetAsync(key, cancellationToken).ConfigureAwait(false) is byte[] existingJson)
+        if (await _storage.GetAsync(key, cancellationToken) is byte[] existingJson)
         {
             return JsonSerializer.Deserialize(existingJson, (JsonTypeInfo<TEmbedding>)_jsonSerializerOptions.GetTypeInfo(typeof(TEmbedding)));
         }
@@ -73,7 +73,7 @@ public class DistributedCachingEmbeddingGenerator<TInput, TEmbedding> : CachingE
         _jsonSerializerOptions.MakeReadOnly();
 
         var newJson = JsonSerializer.SerializeToUtf8Bytes(value, (JsonTypeInfo<TEmbedding>)_jsonSerializerOptions.GetTypeInfo(typeof(TEmbedding)));
-        await _storage.SetAsync(key, newJson, cancellationToken).ConfigureAwait(false);
+        await _storage.SetAsync(key, newJson, cancellationToken);
     }
 
     /// <summary>Computes a cache key for the specified values.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/EmbeddingGeneratorBuilderEmbeddingGeneratorExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/EmbeddingGeneratorBuilderEmbeddingGeneratorExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Microsoft.Extensions.AI;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/LoggingEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/LoggingEmbeddingGenerator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -62,7 +61,7 @@ public partial class LoggingEmbeddingGenerator<TInput, TEmbedding> : DelegatingE
 
         try
         {
-            var embeddings = await base.GenerateAsync(values, options, cancellationToken).ConfigureAwait(false);
+            var embeddings = await base.GenerateAsync(values, options, cancellationToken);
 
             LogCompleted(embeddings.Count);
 

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
@@ -104,7 +104,7 @@ public sealed class OpenTelemetryEmbeddingGenerator<TInput, TEmbedding> : Delega
         Exception? error = null;
         try
         {
-            response = await base.GenerateAsync(values, options, cancellationToken).ConfigureAwait(false);
+            response = await base.GenerateAsync(values, options, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
@@ -303,7 +303,7 @@ public static partial class AIFunctionFactory
                 }
 
                 return await FunctionDescriptor.ReturnParameterMarshaller(
-                    ReflectionInvoke(FunctionDescriptor.Method, target, args), cancellationToken).ConfigureAwait(false);
+                    ReflectionInvoke(FunctionDescriptor.Method, target, args), cancellationToken);
             }
             finally
             {
@@ -311,7 +311,7 @@ public static partial class AIFunctionFactory
                 {
                     if (target is IAsyncDisposable ad)
                     {
-                        await ad.DisposeAsync().ConfigureAwait(false);
+                        await ad.DisposeAsync();
                     }
                     else if (target is IDisposable d)
                     {
@@ -599,14 +599,14 @@ public static partial class AIFunctionFactory
                 {
                     return async (result, cancellationToken) =>
                     {
-                        await ((Task)ThrowIfNullResult(result)).ConfigureAwait(false);
-                        return await marshalResult(null, null, cancellationToken).ConfigureAwait(false);
+                        await ((Task)ThrowIfNullResult(result));
+                        return await marshalResult(null, null, cancellationToken);
                     };
                 }
 
                 return async static (result, _) =>
                 {
-                    await ((Task)ThrowIfNullResult(result)).ConfigureAwait(false);
+                    await ((Task)ThrowIfNullResult(result));
                     return null;
                 };
             }
@@ -618,14 +618,14 @@ public static partial class AIFunctionFactory
                 {
                     return async (result, cancellationToken) =>
                     {
-                        await ((ValueTask)ThrowIfNullResult(result)).ConfigureAwait(false);
-                        return await marshalResult(null, null, cancellationToken).ConfigureAwait(false);
+                        await ((ValueTask)ThrowIfNullResult(result));
+                        return await marshalResult(null, null, cancellationToken);
                     };
                 }
 
                 return async static (result, _) =>
                 {
-                    await ((ValueTask)ThrowIfNullResult(result)).ConfigureAwait(false);
+                    await ((ValueTask)ThrowIfNullResult(result));
                     return null;
                 };
             }
@@ -640,18 +640,18 @@ public static partial class AIFunctionFactory
                     {
                         return async (taskObj, cancellationToken) =>
                         {
-                            await ((Task)ThrowIfNullResult(taskObj)).ConfigureAwait(false);
+                            await ((Task)ThrowIfNullResult(taskObj));
                             object? result = ReflectionInvoke(taskResultGetter, taskObj, null);
-                            return await marshalResult(result, taskResultGetter.ReturnType, cancellationToken).ConfigureAwait(false);
+                            return await marshalResult(result, taskResultGetter.ReturnType, cancellationToken);
                         };
                     }
 
                     returnTypeInfo = serializerOptions.GetTypeInfo(taskResultGetter.ReturnType);
                     return async (taskObj, cancellationToken) =>
                     {
-                        await ((Task)ThrowIfNullResult(taskObj)).ConfigureAwait(false);
+                        await ((Task)ThrowIfNullResult(taskObj));
                         object? result = ReflectionInvoke(taskResultGetter, taskObj, null);
-                        return await SerializeResultAsync(result, returnTypeInfo, cancellationToken).ConfigureAwait(false);
+                        return await SerializeResultAsync(result, returnTypeInfo, cancellationToken);
                     };
                 }
 
@@ -666,9 +666,9 @@ public static partial class AIFunctionFactory
                         return async (taskObj, cancellationToken) =>
                         {
                             var task = (Task)ReflectionInvoke(valueTaskAsTask, ThrowIfNullResult(taskObj), null)!;
-                            await task.ConfigureAwait(false);
+                            await task;
                             object? result = ReflectionInvoke(asTaskResultGetter, task, null);
-                            return await marshalResult(result, asTaskResultGetter.ReturnType, cancellationToken).ConfigureAwait(false);
+                            return await marshalResult(result, asTaskResultGetter.ReturnType, cancellationToken);
                         };
                     }
 
@@ -676,9 +676,9 @@ public static partial class AIFunctionFactory
                     return async (taskObj, cancellationToken) =>
                     {
                         var task = (Task)ReflectionInvoke(valueTaskAsTask, ThrowIfNullResult(taskObj), null)!;
-                        await task.ConfigureAwait(false);
+                        await task;
                         object? result = ReflectionInvoke(asTaskResultGetter, task, null);
-                        return await SerializeResultAsync(result, returnTypeInfo, cancellationToken).ConfigureAwait(false);
+                        return await SerializeResultAsync(result, returnTypeInfo, cancellationToken);
                     };
                 }
             }
@@ -702,7 +702,7 @@ public static partial class AIFunctionFactory
 
                 // Serialize asynchronously to support potential IAsyncEnumerable responses.
                 using PooledMemoryStream stream = new();
-                await JsonSerializer.SerializeAsync(stream, result, returnTypeInfo, cancellationToken).ConfigureAwait(false);
+                await JsonSerializer.SerializeAsync(stream, result, returnTypeInfo, cancellationToken);
                 Utf8JsonReader reader = new(stream.GetBuffer());
                 return JsonElement.ParseValue(ref reader);
             }

--- a/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
@@ -16,6 +16,16 @@
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworks);netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA2227;CA1034;SA1316;S1067;S1121;S1994;S3253</NoWarn>
+
+    <!-- CA2007 requires use of ConfigureAwait. While in general we strive to use ConfigureAwait in all our libraries,
+         the exemption is when user code that might care about SynchronizationContext is invoked as part of operation.
+         FunctionInvokingChatClient may invoke AIFunctions created to run user code that cares about the context, such
+         as an AIFunction that invokes code to update a UI. As such, the Microsoft.Extensions.AI library explicitly avoids
+         using ConfigureAwait(false). It could use ConfigureAwait(true), but it's easier to spot the presence of ConfigureAwait
+         at all then to spot ones that use false rather than true. Alternatively, we could try to avoid using ConfigureAwait(false)
+         only on paths that could lead up to the invocation of an AIFunction, but that is challenging to maintain correctly. -->
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
+    
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DisableNETStandardCompatErrors>true</DisableNETStandardCompatErrors>
   </PropertyGroup>

--- a/src/Libraries/Microsoft.Extensions.AI/SpeechToText/ConfigureOptionsSpeechToTextClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/SpeechToText/ConfigureOptionsSpeechToTextClient.cs
@@ -40,14 +40,14 @@ public sealed class ConfigureOptionsSpeechToTextClient : DelegatingSpeechToTextC
     public override async Task<SpeechToTextResponse> GetTextAsync(
         Stream audioSpeechStream, SpeechToTextOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return await base.GetTextAsync(audioSpeechStream, Configure(options), cancellationToken).ConfigureAwait(false);
+        return await base.GetTextAsync(audioSpeechStream, Configure(options), cancellationToken);
     }
 
     /// <inheritdoc/>
     public override async IAsyncEnumerable<SpeechToTextResponseUpdate> GetStreamingTextAsync(
         Stream audioSpeechStream, SpeechToTextOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await foreach (var update in base.GetStreamingTextAsync(audioSpeechStream, Configure(options), cancellationToken).ConfigureAwait(false))
+        await foreach (var update in base.GetStreamingTextAsync(audioSpeechStream, Configure(options), cancellationToken))
         {
             yield return update;
         }

--- a/src/Libraries/Microsoft.Extensions.AI/SpeechToText/LoggingSpeechToTextClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/SpeechToText/LoggingSpeechToTextClient.cs
@@ -63,7 +63,7 @@ public partial class LoggingSpeechToTextClient : DelegatingSpeechToTextClient
 
         try
         {
-            var response = await base.GetTextAsync(audioSpeechStream, options, cancellationToken).ConfigureAwait(false);
+            var response = await base.GetTextAsync(audioSpeechStream, options, cancellationToken);
 
             if (_logger.IsEnabled(LogLevel.Debug))
             {
@@ -130,7 +130,7 @@ public partial class LoggingSpeechToTextClient : DelegatingSpeechToTextClient
             {
                 try
                 {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
+                    if (!await e.MoveNextAsync())
                     {
                         break;
                     }
@@ -167,7 +167,7 @@ public partial class LoggingSpeechToTextClient : DelegatingSpeechToTextClient
         }
         finally
         {
-            await e.DisposeAsync().ConfigureAwait(false);
+            await e.DisposeAsync();
         }
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI/SpeechToText/SpeechToTextClientBuilderSpeechToTextClientExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/SpeechToText/SpeechToTextClientBuilderSpeechToTextClientExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.AI;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;


### PR DESCRIPTION
We try to use ConfigureAwait(false) throughout our libraries. However, we exempt ourselves from that in cases where user code is expected to be called back from within the async code, and there's a reasonable presumption that such code might care about the synchronization context. AIFunction fits that bill. And FunctionInvokingChatClient needs to invoke such functions, which means that we need to be able to successfully flow the context from where user code calls Get{Streaming}ResponseAsync through into wherever a FunctionInvokingChatClient is in the middleware pipeline. We could try to selectively avoid ConfigureAwait(false) on the path through middleware that could result in calls to FICC.Get{Streaming}ResponseAsync, but that's fairly brittle and hard to maintain. Instead, this PR just removes ConfigureAwait use from the M.E.AI library. It also fixes a few places where tasks were explicitly being created and queued to the thread pool.