### PR TITLE
Avoid duplicate data in downloaded report file

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/App.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/App.tsx
@@ -67,8 +67,16 @@ function App() {
   const closeSettings = () => setIsSettingsOpen(false);
 
   const downloadDataset = () => {
+    // check if dataset has a default property that duplicates the content
+    const containsDefault = 'default' in dataset && 
+      typeof dataset.default === 'object' &&
+      dataset.default !== null &&
+      'scenarioRunResults' in (dataset.default as any);
+      
+    const dataToSerialize = containsDefault ? dataset.default : dataset;
+      
     // create a stringified JSON of the dataset
-    const dataStr = JSON.stringify(dataset, null, 2);
+    const dataStr = JSON.stringify(dataToSerialize, null, 2);
 
     // create a link to download the JSON file in the page and click it
     const blob = new Blob([dataStr], { type: 'application/json' });


### PR DESCRIPTION
When importing default-exported modules, the JavaScript runtime creates an object with both the properties of the exported object and a 'default' property containing the same data. In the case of the download functionality in the report, this results in the evaluation data being duplicated in the downloaded file (once at the root level and then again inside the 'default' property under the root level).

The fix in this commit avoids the problem by serializing the contents of the 'default' property if present and falling back to serializing the outer object otherwise.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6252)