### PR TITLE
Update dev-server data import to reflect runtime import quirks

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/App.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/App.tsx
@@ -55,17 +55,9 @@ function App() {
   const toggleSettings = () => setIsSettingsOpen(!isSettingsOpen);
   const closeSettings = () => setIsSettingsOpen(false);
 
-  const downloadDataset = () => {
-    // check if dataset has a default property that duplicates the content
-    const containsDefault = 'default' in dataset && 
-      typeof dataset.default === 'object' &&
-      dataset.default !== null &&
-      'scenarioRunResults' in (dataset.default as any);
-      
-    const dataToSerialize = containsDefault ? dataset.default : dataset;
-      
+  const downloadDataset = () => {   
     // create a stringified JSON of the dataset
-    const dataStr = JSON.stringify(dataToSerialize, null, 2);
+    const dataStr = JSON.stringify(dataset, null, 2);
 
     // create a link to download the JSON file in the page and click it
     const blob = new Blob([dataStr], { type: 'application/json' });

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/html-report/src/main.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/html-report/src/main.tsx
@@ -13,7 +13,8 @@ let dataset: Dataset = { scenarioRunResults: [] };
 if (!import.meta.env.PROD) {
   // This only runs in development. In production the data is embedded into the dataset variable declaration above.
   // run `node init-devdata.js` to populate the data file from the most recent execution.
-  dataset = await import("../devdata.json") as unknown as Dataset;
+  const imported = await import("../devdata.json");
+  dataset = imported.default as unknown as Dataset;
 }
 
 const scoreSummary = createScoreSummary(dataset);


### PR DESCRIPTION
Update for https://github.com/dotnet/extensions/pull/6252

The previously noted bug only occurs in the local development server. It is caused by the fact that we use runtime `import()` to bring in the data from a json file in the local folder. `import()` assumes we are importing code and treats it as a module, creating a [module namespace object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#module_namespace_object). This causes the data to be duplicated under a `default` key. 

In this PR we update the dev code to reference the data loaded into the default import, which normalizes the data structure.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6257)