### PR TITLE
Add note on extending timeout for Ollama client

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/README.Aspire.md
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/README.Aspire.md
@@ -70,8 +70,7 @@ This project is configured to run Ollama in a Docker container.
 
 To get started, download, install, and run Docker Desktop from the [official website](https://www.docker.com/). Follow the installation instructions specific to your operating system.
 
-The response time from Ollama depends on your GPU. If you find that default resilience timout of 10 seconds used by .NET Aspire is timing out for the HTTP call from the web app to the Ollama service, you can update the web app's `Program.cs` to extend the timeout by adding the following below the line which reads `builder.AddServiceDefaults();`:
-
+The response time from Ollama depends on your GPU. If you find that default resilience timeout of 10 seconds used by .NET Aspire is timing out for the HTTP call from the web app to the Ollama service, you can update the web app's `Program.cs` to extend the timeout by adding the following below the line which reads `builder.AddServiceDefaults();`:
 ```csharp
 // Extend the HTTP Client timeout for Ollama
 builder.Services.ConfigureHttpClientDefaults(http =>

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/README.Aspire.md
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/README.Aspire.md
@@ -70,6 +70,24 @@ This project is configured to run Ollama in a Docker container.
 
 To get started, download, install, and run Docker Desktop from the [official website](https://www.docker.com/). Follow the installation instructions specific to your operating system.
 
+The response time from Ollama depends on your GPU. If you find that default resilience timout of 10 seconds used by .NET Aspire is timing out for the HTTP call from the web app to the Ollama service, you can update the web app's `Program.cs` to extend the timeout by adding the following below the line which reads `builder.AddServiceDefaults();`:
+
+```csharp
+// Extend the HTTP Client timeout for Ollama
+builder.Services.ConfigureHttpClientDefaults(http =>
+{
+    #pragma warning disable EXTEXP0001
+    http.RemoveAllResilienceHandlers();
+    http.AddStandardResilienceHandler(config =>
+    {
+        config.AttemptTimeout.Timeout = TimeSpan.FromMinutes(3);
+        config.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(3) * 3;
+        config.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(3);
+    });
+    #pragma warning restore EXTEXP0001
+});
+```
+
 Note: Ollama and Docker are excellent open source products, but are not maintained by Microsoft.
 #### ---#endif
 #### ---#if (IsAzureOpenAI)

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/README.Aspire.md
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/README.Aspire.md
@@ -80,8 +80,8 @@ builder.Services.ConfigureHttpClientDefaults(http =>
     http.AddStandardResilienceHandler(config =>
     {
         config.AttemptTimeout.Timeout = TimeSpan.FromMinutes(3);
-        config.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(3) * 3;
-        config.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(3);
+        config.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(10); // must be at least double the AttemptTimeout to pass options validation
+        config.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(10);
     });
     #pragma warning restore EXTEXP0001
 });


### PR DESCRIPTION
Standard HttpClient timeout of 10 seconds applied by Service Defaults under .NET Aspire is likely too short for Ollama calls. Add note with code to extend this timeout.

Documentation update:

* [`src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/README.Aspire.md`](diffhunk://#diff-81682bfeeca407b09789261eacf019232f0cf2d003d3fe4293022b3c7f3ebd0eR73-R90): Added instructions for extending the HTTP client timeout for Ollama in `Program.cs` to handle longer response times, including a code snippet for configuring the timeout settings.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6258)