### PR TITLE
Add test for optional parameters being required with RequireAllProperties

### DIFF
--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
@@ -304,10 +304,30 @@ public static partial class AIJsonUtilitiesTests
         Assert.True(DeepEquals(resolvedSchema, func.JsonSchema));
     }
 
-    [Fact]
-    public static void CreateFunctionJsonSchema_OptionalParameters_ShouldNotBeRequired()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public static void CreateFunctionJsonSchema_OptionalParameters(bool requireAllProperties)
     {
-        JsonElement expected = JsonDocument.Parse("""
+        string unitJsonSchema = requireAllProperties ? """
+            {
+                "description": "The unit to calculate the current temperature to (Default value: \u0022celsius\u0022)",
+                "type": "string"
+            }
+            """ :
+            """
+            {
+                "description": "The unit to calculate the current temperature to",
+                "type": "string",
+                "default": "celsius"
+            }
+            """;
+
+        string requiredParamsJsonSchema = requireAllProperties ?
+            """["city", "unit"]""" :
+            """["city"]""";
+
+        JsonElement expected = JsonDocument.Parse($$"""
             {
               "title": "get_weather",
               "description": "Gets the current weather for a current location",
@@ -317,27 +337,31 @@ public static partial class AIJsonUtilitiesTests
                   "description": "The city to get the weather for",
                   "type": "string"
                 },
-                "unit": {
-                  "description": "The unit to calculate the current temperature to (Default value: \u0022celsius\u0022)",
-                  "type": "string"
-                }
+                "unit": {{unitJsonSchema}}
               },
-              "required": [
-                "city"
-              ]
+              "required": {{requiredParamsJsonSchema}}
             }
             """).RootElement;
 
-        JsonSerializerOptions options = new(AIJsonUtilities.DefaultOptions);
         AIFunction func = AIFunctionFactory.Create((
             [Description("The city to get the weather for")] string city,
             [Description("The unit to calculate the current temperature to")] string unit = "celsius") => "sunny",
-            "get_weather", "Gets the current weather for a current location");
+            new AIFunctionFactoryOptions
+            {
+                Name = "get_weather",
+                Description = "Gets the current weather for a current location",
+                JsonSchemaCreateOptions = new AIJsonSchemaCreateOptions { RequireAllProperties = requireAllProperties }
+            });
 
         Assert.NotNull(func.UnderlyingMethod);
+        AssertDeepEquals(expected, func.JsonSchema);
 
-        JsonElement resolvedSchema = AIJsonUtilities.CreateFunctionJsonSchema(func.UnderlyingMethod, title: func.Name, description: func.Description);
-        Assert.True(DeepEquals(expected, resolvedSchema));
+        JsonElement resolvedSchema = AIJsonUtilities.CreateFunctionJsonSchema(
+            func.UnderlyingMethod,
+            title: func.Name,
+            description: func.Description,
+            inferenceOptions: new AIJsonSchemaCreateOptions { RequireAllProperties = requireAllProperties });
+        AssertDeepEquals(expected, resolvedSchema);
     }
 
     [Fact]
@@ -549,5 +573,18 @@ public static partial class AIJsonUtilitiesTests
             JsonSerializer.SerializeToNode(element1, AIJsonUtilities.DefaultOptions),
             JsonSerializer.SerializeToNode(element2, AIJsonUtilities.DefaultOptions));
 #endif
+    }
+
+    private static void AssertDeepEquals(JsonElement element1, JsonElement element2)
+    {
+#pragma warning disable SA1118 // Parameter should not span multiple lines
+        Assert.True(DeepEquals(element1, element2), $"""
+            Elements are not equal.
+            Expected:
+            {element1}
+            Actual:
+            {element2}
+            """);
+#pragma warning restore SA1118 // Parameter should not span multiple lines
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
@@ -159,7 +159,7 @@ public static partial class AIJsonUtilitiesTests
 
         JsonElement actual = AIJsonUtilities.CreateJsonSchema(typeof(MyPoco), serializerOptions: JsonContext.Default.Options);
 
-        Assert.True(DeepEquals(expected, actual));
+        AssertDeepEquals(expected, actual);
     }
 
     [Fact]
@@ -204,7 +204,7 @@ public static partial class AIJsonUtilitiesTests
             serializerOptions: JsonContext.Default.Options,
             inferenceOptions: inferenceOptions);
 
-        Assert.True(DeepEquals(expected, actual));
+        AssertDeepEquals(expected, actual);
     }
 
     [Fact]
@@ -249,7 +249,7 @@ public static partial class AIJsonUtilitiesTests
 
         JsonElement actual = AIJsonUtilities.CreateJsonSchema(typeof(MyPoco), serializerOptions: JsonContext.Default.Options, inferenceOptions: inferenceOptions);
 
-        Assert.True(DeepEquals(expected, actual));
+        AssertDeepEquals(expected, actual);
     }
 
     [Fact]
@@ -277,7 +277,7 @@ public static partial class AIJsonUtilitiesTests
 
         JsonElement actual = AIJsonUtilities.CreateJsonSchema(typeof(PocoWithTypesWithOpenAIUnsupportedKeywords), serializerOptions: JsonContext.Default.Options);
 
-        Assert.True(DeepEquals(expected, actual));
+        AssertDeepEquals(expected, actual);
     }
 
     public class PocoWithTypesWithOpenAIUnsupportedKeywords
@@ -301,7 +301,7 @@ public static partial class AIJsonUtilitiesTests
         Assert.NotNull(func.UnderlyingMethod);
 
         JsonElement resolvedSchema = AIJsonUtilities.CreateFunctionJsonSchema(func.UnderlyingMethod, title: func.Name);
-        Assert.True(DeepEquals(resolvedSchema, func.JsonSchema));
+        AssertDeepEquals(resolvedSchema, func.JsonSchema);
     }
 
     [Theory]
@@ -391,7 +391,7 @@ public static partial class AIJsonUtilitiesTests
                 """).RootElement;
 
             JsonElement actualSchema = property.Value;
-            Assert.True(DeepEquals(expected, actualSchema));
+            AssertDeepEquals(expected, actualSchema);
             i++;
         }
     }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
@@ -305,6 +305,42 @@ public static partial class AIJsonUtilitiesTests
     }
 
     [Fact]
+    public static void CreateFunctionJsonSchema_OptionalParameters_ShouldNotBeRequired()
+    {
+        JsonElement expected = JsonDocument.Parse("""
+            {
+              "title": "get_weather",
+              "description": "Gets the current weather for a current location",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "description": "The city to get the weather for",
+                  "type": "string"
+                },
+                "unit": {
+                  "description": "The unit to calculate the current temperature to (Default value: \u0022celsius\u0022)",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "city"
+              ]
+            }
+            """).RootElement;
+
+        JsonSerializerOptions options = new(AIJsonUtilities.DefaultOptions);
+        AIFunction func = AIFunctionFactory.Create((
+            [Description("The city to get the weather for")] string city,
+            [Description("The unit to calculate the current temperature to")] string unit = "celsius") => "sunny",
+            "get_weather", "Gets the current weather for a current location");
+
+        Assert.NotNull(func.UnderlyingMethod);
+
+        JsonElement resolvedSchema = AIJsonUtilities.CreateFunctionJsonSchema(func.UnderlyingMethod, title: func.Name, description: func.Description);
+        Assert.True(DeepEquals(expected, resolvedSchema));
+    }
+
+    [Fact]
     public static void CreateFunctionJsonSchema_TreatsIntegralTypesAsInteger_EvenWithAllowReadingFromString()
     {
         JsonSerializerOptions options = new(AIJsonUtilities.DefaultOptions) { NumberHandling = JsonNumberHandling.AllowReadingFromString };


### PR DESCRIPTION
We started honoring RequriedAllProperties for optional parameters in https://github.com/dotnet/extensions/pull/6204.
https://github.com/dotnet/extensions/blob/101a7ddfc6dd1e1e488405349475e5640e6cc16e/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs#L108

And this broke one test in OllamaSharp, looks to me the right thing to do is to update that test:
https://github.com/awaescher/OllamaSharp/blob/57ccc964450f6226a1df4e21d35685efc6ddc778/test/AbstractionMapperTests.cs#L226-L246

Adding a test to this repo since nothing broke when I removed the check.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6265)