### PR TITLE
Add missing reference to M.E.AI.OpenAI in chat template

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/ChatWithCustomData-CSharp.Web.csproj.in
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/ChatWithCustomData-CSharp.Web.csproj.in
@@ -13,7 +13,7 @@
 #endif -->
 <!--#if (IsOllama)
     <PackageReference Include="OllamaSharp" Version="${OllamaSharpVersion}" />
-#elif (IsGHModels && !IsAspire)
+#elif ((IsGHModels || IsOpenAI) && !IsAspire)
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="${MicrosoftExtensionsAIVersion}" />
 #elif (IsAzureAiFoundry)
     <PackageReference Include="Azure.AI.Projects" Version="${AzureAIProjectsVersion}" />


### PR DESCRIPTION
Fixes an issue where the project generated by running `dotnet new aichatweb --provider openai` does not include a reference to `Microsoft.Extensions.AI.OpenAI`. This causes the project to fail to compile.

Fixes https://github.com/dotnet/extensions/issues/6271
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6275)