### PR TITLE
Display images in conversation for report

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/ConversationDetails.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/ConversationDetails.tsx
@@ -4,8 +4,7 @@ import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { useReportContext } from "./ReportContext";
 import { useStyles } from "./Styles";
-import { ChatMessageDisplay } from "./Summary";
-
+import { ChatMessageDisplay, isTextContent, isImageContent } from "./Summary";
 
 export const ConversationDetails = ({ messages, model, usage }: {
     messages: ChatMessageDisplay[];
@@ -25,6 +24,40 @@ export const ConversationDetails = ({ messages, model, usage }: {
         usage?.totalTokenCount && `Total Tokens: ${usage.totalTokenCount}`,
     ].filter(Boolean).join(' • ');
 
+    const renderContent = (content: AIContent) => {
+        if (isTextContent(content)) {
+            return renderMarkdown ?
+                <ReactMarkdown>{content.text}</ReactMarkdown> :
+                <pre className={classes.preWrap}>{content.text}</pre>;
+        } else if (isImageContent(content)) {
+            const imageUrl = (content as UriContent).uri || (content as DataContent).uri;
+            return <img src={imageUrl} alt="Content" className={classes.imageContent} />;
+        }
+    };
+
+    const groupMessages = () => {
+        const result: { role: string, participantName: string, contents: AIContent[] }[] = [];
+
+        for (const message of messages) {
+            // If this message has the same role and participant as the previous one, append its content
+            const lastGroup = result[result.length - 1];
+            if (lastGroup && lastGroup.role === message.role && lastGroup.participantName === message.participantName) {
+                lastGroup.contents.push(message.content);
+            } else {
+                // Otherwise, start a new group
+                result.push({
+                    role: message.role,
+                    participantName: message.participantName,
+                    contents: [message.content]
+                });
+            }
+        }
+
+        return result;
+    };
+
+    const messageGroups = groupMessages();
+
     return (
         <div className={classes.section}>
             <div className={classes.sectionHeader} onClick={() => setIsExpanded(!isExpanded)}>
@@ -35,8 +68,8 @@ export const ConversationDetails = ({ messages, model, usage }: {
 
             {isExpanded && (
                 <div className={classes.sectionContainer}>
-                    {messages.map((message, index) => {
-                        const isFromUserSide = isUserSide(message.role);
+                    {messageGroups.map((group, index) => {
+                        const isFromUserSide = isUserSide(group.role);
                         const messageRowClass = mergeClasses(
                             classes.messageRow,
                             isFromUserSide ? classes.userMessageRow : classes.assistantMessageRow
@@ -44,11 +77,13 @@ export const ConversationDetails = ({ messages, model, usage }: {
 
                         return (
                             <div key={index} className={messageRowClass}>
-                                <div className={classes.messageParticipantName}>{message.participantName}</div>
+                                <div className={classes.messageParticipantName}>{group.participantName}</div>
                                 <div className={classes.messageBubble}>
-                                    {renderMarkdown ?
-                                        <ReactMarkdown>{message.content}</ReactMarkdown> :
-                                        <pre className={classes.preWrap}>{message.content}</pre>}
+                                    {group.contents.map((content, contentIndex) => (
+                                        <div key={contentIndex}>
+                                            {renderContent(content)}
+                                        </div>
+                                    ))}
                                 </div>
                             </div>
                         );

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/EvalTypes.d.ts
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/EvalTypes.d.ts
@@ -54,10 +54,21 @@ type AIContent = {
     $type: string;
 };
 
-// TODO: Model other types of AIContent such as function calls, function call results, images, audio etc.
+// TODO: Model other types of AIContent such as function calls, function call results, audio etc.
 type TextContent = AIContent & {
     $type: "text";
     text: string;
+};
+
+type UriContent = AIContent & {
+    $type: "uri";
+    uri: string;
+    mediaType: string;
+};
+
+type DataContent = AIContent & {
+    $type: "data";
+    uri: string;
 };
 
 type EvaluationResult = {

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/Styles.ts
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/Styles.ts
@@ -205,6 +205,10 @@ export const useStyles = makeStyles({
     preWrap: {
         whiteSpace: 'pre-wrap',
     },
+    imageContent: {
+        maxWidth: '100%',
+        maxHeight: '400px',
+    },
     executionHeaderCell: {
         display: 'flex',
         alignItems: 'center',

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/AIContentExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/AIContentExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Extensions.AI.Evaluation.Safety;
+internal static class AIContentExtensions
+{
+    internal static bool IsTextOrUsage(this AIContent content)
+        => content is TextContent || content is UsageContent;
+
+    internal static bool IsImage(this AIContent content) =>
+        (content is UriContent uriContent && uriContent.HasTopLevelMediaType("image")) ||
+        (content is DataContent dataContent && dataContent.HasTopLevelMediaType("image"));
+
+    internal static bool IsUriBase64Encoded(this DataContent dataContent)
+    {
+        ReadOnlyMemory<char> uri = dataContent.Uri.AsMemory();
+
+        int commaIndex = uri.Span.IndexOf(',');
+        if (commaIndex == -1)
+        {
+            return false;
+        }
+
+        ReadOnlyMemory<char> metadata = uri.Slice(0, commaIndex);
+
+        bool isBase64Encoded = metadata.Span.EndsWith(";base64".AsSpan(), StringComparison.OrdinalIgnoreCase);
+        return isBase64Encoded;
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/AIContentExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/AIContentExtensions.cs
@@ -9,9 +9,9 @@ internal static class AIContentExtensions
     internal static bool IsTextOrUsage(this AIContent content)
         => content is TextContent || content is UsageContent;
 
-    internal static bool IsImage(this AIContent content) =>
-        (content is UriContent uriContent && uriContent.HasTopLevelMediaType("image")) ||
-        (content is DataContent dataContent && dataContent.HasTopLevelMediaType("image"));
+    internal static bool IsImageWithSupportedFormat(this AIContent content) =>
+        (content is UriContent uriContent && IsSupportedImageFormat(uriContent.MediaType)) ||
+        (content is DataContent dataContent && IsSupportedImageFormat(dataContent.MediaType));
 
     internal static bool IsUriBase64Encoded(this DataContent dataContent)
     {
@@ -27,5 +27,16 @@ internal static class AIContentExtensions
 
         bool isBase64Encoded = metadata.Span.EndsWith(";base64".AsSpan(), StringComparison.OrdinalIgnoreCase);
         return isBase64Encoded;
+    }
+
+    private static bool IsSupportedImageFormat(string mediaType)
+    {
+        // 'image/jpeg' is the official MIME type for JPEG. However, some systems recognize 'image/jpg' as well.
+
+        return
+            mediaType.Equals("image/jpeg", StringComparison.OrdinalIgnoreCase) ||
+            mediaType.Equals("image/jpg", StringComparison.OrdinalIgnoreCase) ||
+            mediaType.Equals("image/png", StringComparison.OrdinalIgnoreCase) ||
+            mediaType.Equals("image/gif", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ChatMessageExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ChatMessageExtensions.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Extensions.AI.Evaluation.Safety;
 
 internal static class ChatMessageExtensions
 {
-    internal static bool ContainsImage(this ChatMessage message)
-        => message.Contents.Any(c => c.IsImage());
+    internal static bool ContainsImageWithSupportedFormat(this ChatMessage message)
+        => message.Contents.Any(c => c.IsImageWithSupportedFormat());
 
-    internal static bool ContainsImage(this IEnumerable<ChatMessage> conversation)
-        => conversation.Any(ContainsImage);
+    internal static bool ContainsImageWithSupportedFormat(this IEnumerable<ChatMessage> conversation)
+        => conversation.Any(ContainsImageWithSupportedFormat);
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ChatMessageExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ChatMessageExtensions.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Extensions.AI.Evaluation.Safety;
+
+internal static class ChatMessageExtensions
+{
+    internal static bool ContainsImage(this ChatMessage message)
+        => message.Contents.Any(c => c.IsImage());
+
+    internal static bool ContainsImage(this IEnumerable<ChatMessage> conversation)
+        => conversation.Any(ContainsImage);
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ChatResponseExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ChatResponseExtensions.cs
@@ -5,6 +5,6 @@ namespace Microsoft.Extensions.AI.Evaluation.Safety;
 
 internal static class ChatResponseExtensions
 {
-    internal static bool ContainsImage(this ChatResponse response)
-        => response.Messages.ContainsImage();
+    internal static bool ContainsImageWithSupportedFormat(this ChatResponse response)
+        => response.Messages.ContainsImageWithSupportedFormat();
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ChatResponseExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ChatResponseExtensions.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AI.Evaluation.Safety;
+
+internal static class ChatResponseExtensions
+{
+    internal static bool ContainsImage(this ChatResponse response)
+        => response.Messages.ContainsImage();
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyServicePayloadUtilities.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyServicePayloadUtilities.cs
@@ -471,7 +471,7 @@ internal static class ContentSafetyServicePayloadUtilities
 
                 if (areImagesSupported)
                 {
-                    if (content.IsImage())
+                    if (content.IsImageWithSupportedFormat())
                     {
                         ++imagesCount;
                     }
@@ -529,7 +529,7 @@ internal static class ContentSafetyServicePayloadUtilities
                     EvaluationDiagnostic.Warning(
                         $"The supplied conversation contained {unsupportedContentCount} instances of unsupported content within messages. " +
                         $"The current evaluation being performed by {evaluatorName} only supports content of type '{nameof(TextContent)}', '{nameof(UriContent)}' and '{nameof(DataContent)}'. " +
-                        $"For '{nameof(UriContent)}' and '{nameof(DataContent)}', only content with media type 'image/*' is supported. " +
+                        $"For '{nameof(UriContent)}' and '{nameof(DataContent)}', only content with media type 'image/png', 'image/jpeg' and 'image/gif' are supported. " +
                         $"The unsupported contents were ignored for this evaluation."));
             }
             else

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ProtectedMaterialEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ProtectedMaterialEvaluator.cs
@@ -87,7 +87,7 @@ public sealed class ProtectedMaterialEvaluator()
 
         // If images are present in the conversation, do a second evaluation for protected material in images.
         // The content safety service does not support evaluating both text and images in the same request currently.
-        if (messages.ContainsImage() || modelResponse.ContainsImage())
+        if (messages.ContainsImageWithSupportedFormat() || modelResponse.ContainsImageWithSupportedFormat())
         {
             EvaluationResult imageResult =
                 await EvaluateContentSafetyAsync(

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/Microsoft.Extensions.AI.Evaluation.Integration.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/Microsoft.Extensions.AI.Evaluation.Integration.Tests.csproj
@@ -2,9 +2,18 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework)</TargetFrameworks>
-    <RootNamespace>Microsoft.Extensions.AI.Evaluation.Integration.Tests</RootNamespace>
+    <RootNamespace>Microsoft.Extensions.AI</RootNamespace>
     <Description>Integration tests for Microsoft.Extensions.AI.Evaluation.</Description>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\Shared\ImageDataUri\dotnet.png" Link="Resources\dotnet.png"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\Shared\ImageDataUri\ImageDataUri.cs" Link="Shared\ImageDataUri\ImageDataUri.cs" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" />

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/SafetyEvaluatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/SafetyEvaluatorTests.cs
@@ -247,15 +247,15 @@ public class SafetyEvaluatorTests
             await _imageContentSafetyReportingConfiguration.CreateScenarioRunAsync(
                 scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(SafetyEvaluatorTests)}.{nameof(EvaluateConversationWithImageInAnswer)}");
 
-        ChatMessage question = "Can you show me an image pertaining to Microsoft Copilot?".ToUserMessage();
+        ChatMessage question = "Can you show me an image pertaining to DotNet?".ToUserMessage();
 
         ChatMessage answer =
             new ChatMessage
             {
                 Role = ChatRole.Assistant,
                 Contents = [
-                    new TextContent("Here's an image pertaining to Microsoft Copilot:"),
-                    new UriContent("https://uhf.microsoft.com/images/banners/RW1iGSh.png", "image/png")],
+                    new TextContent("Here's an image pertaining to DotNet:"),
+                    new DataContent(ImageDataUri.GetImageDataUri())],
             };
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(question, answer);
@@ -280,10 +280,10 @@ public class SafetyEvaluatorTests
                 Role = ChatRole.User,
                 Contents = [
                     new TextContent("What does this image depict?"),
-                    new UriContent("https://uhf.microsoft.com/images/microsoft/RE1Mu3b.png", "image/png")],
+                    new DataContent(ImageDataUri.GetImageDataUri())],
             };
 
-        ChatMessage answer1 = "The image depicts a logo for Microsoft Corporation.".ToAssistantMessage();
+        ChatMessage answer1 = "The image depicts a logo for DotNet.".ToAssistantMessage();
 
         ChatMessage question2 = "Can you show me an image pertaining to Microsoft Copilot?".ToUserMessage();
 


### PR DESCRIPTION
Also includes some fixes / improvements around how images are processed in the Safety evaluators.
* Avoid redundant / double base64 encoding for images in `DataContnet`
* Check for supported image extensions
* Add tests for `DataContent` images

This is how images are displayed in the in the report  -
![image](https://github.com/user-attachments/assets/099a8591-c3d8-4256-bee3-bda8d19a0fc6)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6286)