### PR TITLE
Improve CPU metrics calculations for CgroupV2

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/ILinuxUtilizationParser.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/ILinuxUtilizationParser.cs
@@ -24,11 +24,11 @@ internal interface ILinuxUtilizationParser
     long GetCgroupCpuUsageInNanoseconds();
 
     /// <summary>
-    /// Reads the file cpu.stat based on /proc/self/cgroup, which is part of the cgroup v2 CPU controller.
+    /// For CgroupV2 only. Reads the file cpu.stat based on /proc/self/cgroup, which is part of the cgroup v2 CPU controller.
     /// It provides statistics about the CPU usage of a cgroup from its actual slice.
     /// </summary>
     /// <returns>nanoseconds.</returns>
-    long GetCgroupCpuUsageInNanosecondsWithoutHost();
+    long GetCgroupCpuUsageInNanosecondsV2();
 
     /// <summary>
     /// Reads the file /sys/fs/cgroup/cpu.max, which is part of the cgroup v2 CPU controller.
@@ -41,14 +41,14 @@ internal interface ILinuxUtilizationParser
     float GetCgroupLimitedCpus();
 
     /// <summary>
-    /// Reads the file cpu.max based on /proc/self/cgroup, which is part of the cgroup v2 CPU controller.
+    /// For CgroupV2 only. Reads the file cpu.max based on /proc/self/cgroup, which is part of the cgroup v2 CPU controller.
     /// It is used to set the maximum amount of CPU time that can be used by a cgroup from actual slice.
     /// The file contains two fields, separated by a space.
     /// The first field is the quota, which specifies the maximum amount of CPU time (in microseconds) that can be used by the cgroup during one period.
     /// The second value is the period, which specifies the length of a period in microseconds.
     /// </summary>
     /// <returns>cpuUnits.</returns>
-    float GetCgroupLimitedCpusWithoutHost();
+    float GetCgroupLimitV2();
 
     /// <summary>
     /// Reads the file /proc/stat, which  provides information about the system’s memory usage.
@@ -85,8 +85,8 @@ internal interface ILinuxUtilizationParser
     float GetCgroupRequestCpu();
 
     /// <summary>
-    /// Reads the file cpu.weight based on /proc/self/cgroup. And calculates the Pod CPU Request in millicores based on actual slice.
+    /// For CgroupV2 only. Reads the file cpu.weight based on /proc/self/cgroup. And calculates the Pod CPU Request in millicores based on actual slice.
     /// </summary>
     /// <returns>cpuPodRequest.</returns>
-    float GetCgroupRequestCpuWithoutHost();
+    float GetCgroupRequestCpuV2();
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/ILinuxUtilizationParser.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/ILinuxUtilizationParser.cs
@@ -24,6 +24,13 @@ internal interface ILinuxUtilizationParser
     long GetCgroupCpuUsageInNanoseconds();
 
     /// <summary>
+    /// Reads the file cpu.stat based on /proc/self/cgroup, which is part of the cgroup v2 CPU controller.
+    /// It provides statistics about the CPU usage of a cgroup from its actual slice.
+    /// </summary>
+    /// <returns>nanoseconds.</returns>
+    long GetCgroupCpuUsageInNanosecondsWithoutHost();
+
+    /// <summary>
     /// Reads the file /sys/fs/cgroup/cpu.max, which is part of the cgroup v2 CPU controller.
     /// It is used to set the maximum amount of CPU time that can be used by a cgroup.
     /// The file contains two fields, separated by a space.
@@ -32,6 +39,16 @@ internal interface ILinuxUtilizationParser
     /// </summary>
     /// <returns>cpuUnits.</returns>
     float GetCgroupLimitedCpus();
+
+    /// <summary>
+    /// Reads the file cpu.max based on /proc/self/cgroup, which is part of the cgroup v2 CPU controller.
+    /// It is used to set the maximum amount of CPU time that can be used by a cgroup from actual slice.
+    /// The file contains two fields, separated by a space.
+    /// The first field is the quota, which specifies the maximum amount of CPU time (in microseconds) that can be used by the cgroup during one period.
+    /// The second value is the period, which specifies the length of a period in microseconds.
+    /// </summary>
+    /// <returns>cpuUnits.</returns>
+    float GetCgroupLimitedCpusWithoutHost();
 
     /// <summary>
     /// Reads the file /proc/stat, which  provides information about the system’s memory usage.
@@ -66,4 +83,10 @@ internal interface ILinuxUtilizationParser
     /// </summary>
     /// <returns>cpuPodRequest.</returns>
     float GetCgroupRequestCpu();
+
+    /// <summary>
+    /// Reads the file cpu.weight based on /proc/self/cgroup. And calculates the Pod CPU Request in millicores based on actual slice.
+    /// </summary>
+    /// <returns>cpuPodRequest.</returns>
+    float GetCgroupRequestCpuWithoutHost();
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/ILinuxUtilizationParser.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/ILinuxUtilizationParser.cs
@@ -24,7 +24,7 @@ internal interface ILinuxUtilizationParser
     long GetCgroupCpuUsageInNanoseconds();
 
     /// <summary>
-    /// For CgroupV2 only. Reads the file cpu.stat based on /proc/self/cgroup, which is part of the cgroup v2 CPU controller.
+    /// For CgroupV2 only and experimental. Reads the file cpu.stat based on /proc/self/cgroup, which is part of the cgroup v2 CPU controller.
     /// It provides statistics about the CPU usage of a cgroup from its actual slice.
     /// </summary>
     /// <returns>nanoseconds.</returns>
@@ -41,7 +41,7 @@ internal interface ILinuxUtilizationParser
     float GetCgroupLimitedCpus();
 
     /// <summary>
-    /// For CgroupV2 only. Reads the file cpu.max based on /proc/self/cgroup, which is part of the cgroup v2 CPU controller.
+    /// For CgroupV2 only and experimental. Reads the file cpu.max based on /proc/self/cgroup, which is part of the cgroup v2 CPU controller.
     /// It is used to set the maximum amount of CPU time that can be used by a cgroup from actual slice.
     /// The file contains two fields, separated by a space.
     /// The first field is the quota, which specifies the maximum amount of CPU time (in microseconds) that can be used by the cgroup during one period.
@@ -85,7 +85,7 @@ internal interface ILinuxUtilizationParser
     float GetCgroupRequestCpu();
 
     /// <summary>
-    /// For CgroupV2 only. Reads the file cpu.weight based on /proc/self/cgroup. And calculates the Pod CPU Request in millicores based on actual slice.
+    /// For CgroupV2 only and experimental. Reads the file cpu.weight based on /proc/self/cgroup. And calculates the Pod CPU Request in millicores based on actual slice.
     /// </summary>
     /// <returns>cpuPodRequest.</returns>
     float GetCgroupRequestCpuV2();

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV1.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV1.cs
@@ -94,6 +94,10 @@ internal sealed class LinuxUtilizationParserCgroupV1 : ILinuxUtilizationParser
         _userHz = userHz.Value;
     }
 
+    public long GetCgroupCpuUsageInNanosecondsWithoutHost() => throw new NotSupportedException();
+    public float GetCgroupLimitedCpusWithoutHost() => throw new NotSupportedException();
+    public float GetCgroupRequestCpuWithoutHost() => throw new NotSupportedException();
+
     public long GetCgroupCpuUsageInNanoseconds()
     {
         using ReturnableBufferWriter<char> bufferWriter = new(_sharedBufferWriterPool);

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV1.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV1.cs
@@ -94,9 +94,9 @@ internal sealed class LinuxUtilizationParserCgroupV1 : ILinuxUtilizationParser
         _userHz = userHz.Value;
     }
 
-    public long GetCgroupCpuUsageInNanosecondsWithoutHost() => throw new NotSupportedException();
-    public float GetCgroupLimitedCpusWithoutHost() => throw new NotSupportedException();
-    public float GetCgroupRequestCpuWithoutHost() => throw new NotSupportedException();
+    public float GetCgroupLimitV2() => throw new NotSupportedException();
+    public float GetCgroupRequestCpuV2() => throw new NotSupportedException();
+    public long GetCgroupCpuUsageInNanosecondsV2() => throw new NotSupportedException();
 
     public long GetCgroupCpuUsageInNanoseconds()
     {

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
@@ -90,12 +90,13 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
     /// </summary>
     private static readonly FileInfo _cpuPodWeight = new("/sys/fs/cgroup/cpu.weight");
 
-    private static readonly FileInfo _cpuActualSelfSliceProcFile = new("/proc/self/cgroup");
+    private static readonly FileInfo _cpuCgroupInfoFile = new("/proc/self/cgroup");
 
     private readonly IFileSystem _fileSystem;
     private readonly long _userHz;
+
     // Cache for the trimmed path string to avoid repeated file reads and processing
-    private string _cachedCgroupPath;
+    private string? _cachedCgroupPath;
 
     public LinuxUtilizationParserCgroupV2(IFileSystem fileSystem, IUserHz userHz)
     {
@@ -103,7 +104,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
         _userHz = userHz.Value;
     }
 
-    public string GetCgroupActualSlicePath(string filename)
+    public string GetCgroupPath(string filename)
     {
         // If we've already parsed the path, use the cached value
         if (_cachedCgroupPath != null)
@@ -114,71 +115,43 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
         using ReturnableBufferWriter<char> bufferWriter = new(_sharedBufferWriterPool);
 
         // Read the content of the file
-        _fileSystem.ReadFirstLine(_cpuActualSelfSliceProcFile, bufferWriter.Buffer);
+        _fileSystem.ReadFirstLine(_cpuCgroupInfoFile, bufferWriter.Buffer);
         ReadOnlySpan<char> fileContent = bufferWriter.Buffer.WrittenSpan;
 
         // Ensure the file content is not empty
         if (fileContent.IsEmpty)
         {
-            Throw.InvalidOperationException($"The file '{_cpuActualSelfSliceProcFile}' is empty or could not be read.");
+            Throw.InvalidOperationException($"The file '{_cpuCgroupInfoFile}' is empty or could not be read.");
         }
 
         // Find the index of the first colon (:)
         int colonIndex = fileContent.LastIndexOf(':');
         if (colonIndex == -1 || colonIndex + 1 >= fileContent.Length)
         {
-            Throw.InvalidOperationException($"Invalid format in file '{_cpuActualSelfSliceProcFile}'. Expected content with ':' separator.");
+            Throw.InvalidOperationException($"Invalid format in file '{_cpuCgroupInfoFile}'. Expected content with ':' separator.");
         }
 
         // Extract the part after the last colon and cache it for future use
         ReadOnlySpan<char> trimmedPath = fileContent.Slice(colonIndex + 1);
         _cachedCgroupPath = trimmedPath.ToString().TrimEnd('/') + "/";
-        
+
         return $"{PathPrefix}{_cachedCgroupPath}{filename}";
     }
 
     public long GetCgroupCpuUsageInNanoseconds()
     {
-        // The value we are interested in starts with this. We just want to make sure it is true.
-        const string Usage_usec = "usage_usec";
-
         // If the file doesn't exist, we assume that the system is a Host and we read the CPU usage from /proc/stat.
         if (!_fileSystem.Exists(_cpuacctUsage))
         {
             return GetHostCpuUsageInNanoseconds();
         }
 
-        using ReturnableBufferWriter<char> bufferWriter = new(_sharedBufferWriterPool);
-        _fileSystem.ReadAll(_cpuacctUsage, bufferWriter.Buffer);
-        ReadOnlySpan<char> usage = bufferWriter.Buffer.WrittenSpan;
-
-        if (!usage.StartsWith(Usage_usec))
-        {
-            Throw.InvalidOperationException($"Could not parse '{_cpuacctUsage}'. We expected first line of the file to start with '{Usage_usec}' but it was '{new string(usage)}' instead.");
-        }
-
-        ReadOnlySpan<char> cpuUsage = usage.Slice(Usage_usec.Length, usage.Length - Usage_usec.Length);
-
-        int next = GetNextNumber(cpuUsage, out long microseconds);
-
-        if (microseconds == -1)
-        {
-            Throw.InvalidOperationException($"Could not get cpu usage from '{_cpuacctUsage}'. Expected positive number, but got '{new string(usage)}'.");
-        }
-
-        // In cgroup v2, the Units are microseconds for usage_usec.
-        // We multiply by 1000 to convert to nanoseconds to keep the common calculation logic.
-        return microseconds * Thousand;
+        return ParseCpuUsageFromFile(_fileSystem, _cpuacctUsage);
     }
 
-    public long GetCgroupCpuUsageInNanosecondsWithoutHost()
+    public long GetCgroupCpuUsageInNanosecondsV2()
     {
-        // The value we are interested in starts with this. We just want to make sure it is true.
-        const string Usage_usec = "usage_usec";
-
-        using ReturnableBufferWriter<char> bufferWriter = new(_sharedBufferWriterPool);
-
-        FileInfo cpuUsageFile = new(GetCgroupActualSlicePath(CpuStat));
+        FileInfo cpuUsageFile = new(GetCgroupPath(CpuStat));
 
         // If the file doesn't exist, we assume that the system is a Host and we read the CPU usage from /proc/stat.
         if (!_fileSystem.Exists(cpuUsageFile))
@@ -186,27 +159,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
             return GetHostCpuUsageInNanoseconds();
         }
 
-        _fileSystem.ReadAll(cpuUsageFile, bufferWriter.Buffer);
-
-        ReadOnlySpan<char> usage = bufferWriter.Buffer.WrittenSpan;
-
-        if (!usage.StartsWith(Usage_usec))
-        {
-            Throw.InvalidOperationException($"Could not parse '{cpuUsageFile}'. We expected first line of the file to start with '{Usage_usec}' but it was '{new string(usage)}' instead.");
-        }
-
-        ReadOnlySpan<char> cpuUsage = usage.Slice(Usage_usec.Length, usage.Length - Usage_usec.Length);
-
-        int next = GetNextNumber(cpuUsage, out long microseconds);
-
-        if (microseconds == -1)
-        {
-            Throw.InvalidOperationException($"Could not get cpu usage from '{cpuUsageFile}'. Expected positive number, but got '{new string(usage)}'.");
-        }
-
-        // In cgroup v2, the Units are microseconds for usage_usec.
-        // We multiply by 1000 to convert to nanoseconds to keep the common calculation logic.
-        return microseconds * Thousand;
+        return ParseCpuUsageFromFile(_fileSystem, cpuUsageFile);
     }
 
     public long GetHostCpuUsageInNanoseconds()
@@ -269,10 +222,10 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
     /// It should be 99% of the cases when app is hosted in the container environment.
     /// Otherwise, we assume that all host's CPUs are available, which we read from proc/stat file.
     /// </remarks>
-    public float GetCgroupLimitedCpusWithoutHost()
+    public float GetCgroupLimitV2()
     {
-        FileInfo cpuLimitsFile = new(GetCgroupActualSlicePath(CpuLimit));
-        if (LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroupsWithoutHost(_fileSystem, cpuLimitsFile, out float cpus))
+        FileInfo cpuLimitsFile = new(GetCgroupPath(CpuLimit));
+        if (LinuxUtilizationParserCgroupV2.TryGetCpuLimitFromCgroupsV2(_fileSystem, cpuLimitsFile, out float cpus))
         {
             return cpus;
         }
@@ -298,10 +251,10 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
     /// If we are able to read the CPU share, we calculate the CPU request based on the weight by dividing it by 1024.
     /// If we can't read the CPU weight, we assume that the pod/vm cpu request is 1 core by default.
     /// </remarks>
-    public float GetCgroupRequestCpuWithoutHost()
+    public float GetCgroupRequestCpuV2()
     {
-        FileInfo cpuRequestsFile = new(GetCgroupActualSlicePath(CpuRequest));
-        if (TryGetCgroupRequestCpuWithoutHost(_fileSystem, cpuRequestsFile, out float cpuPodRequest))
+        FileInfo cpuRequestsFile = new(GetCgroupPath(CpuRequest));
+        if (TryGetCgroupRequestCpuV2(_fileSystem, cpuRequestsFile, out float cpuPodRequest))
         {
             return cpuPodRequest / CpuShares;
         }
@@ -558,6 +511,34 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
                 $"Could not parse '{_cpuSetCpus}'. Expected comma-separated list of integers, with dashes (\"-\") based ranges (\"0\", \"2-6,12\") but got '{new string(content)}'.");
     }
 
+    private static long ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)
+    {
+        // The value we are interested in starts with this. We just want to make sure it is true.
+        const string Usage_usec = "usage_usec";
+
+        using ReturnableBufferWriter<char> bufferWriter = new(_sharedBufferWriterPool);
+        fileSystem.ReadAll(cpuUsageFile, bufferWriter.Buffer);
+        ReadOnlySpan<char> usage = bufferWriter.Buffer.WrittenSpan;
+
+        if (!usage.StartsWith(Usage_usec))
+        {
+            Throw.InvalidOperationException($"Could not parse '{cpuUsageFile}'. We expected first line of the file to start with '{Usage_usec}' but it was '{new string(usage)}' instead.");
+        }
+
+        ReadOnlySpan<char> cpuUsage = usage.Slice(Usage_usec.Length, usage.Length - Usage_usec.Length);
+
+        int next = GetNextNumber(cpuUsage, out long microseconds);
+
+        if (microseconds == -1)
+        {
+            Throw.InvalidOperationException($"Could not get cpu usage from '{cpuUsageFile}'. Expected positive number, but got '{new string(usage)}'.");
+        }
+
+        // In cgroup v2, the Units are microseconds for usage_usec.
+        // We multiply by 1000 to convert to nanoseconds to keep the common calculation logic.
+        return microseconds * Thousand;
+    }
+
     /// <remarks>
     /// The input must contain only number. If there is something more than whitespace before the number, it will return failure (-1).
     /// </remarks>
@@ -603,49 +584,13 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
             return false;
         }
 
-        using ReturnableBufferWriter<char> bufferWriter = new(_sharedBufferWriterPool);
-        fileSystem.ReadFirstLine(_cpuCfsQuaotaPeriodUs, bufferWriter.Buffer);
-
-        ReadOnlySpan<char> quotaBuffer = bufferWriter.Buffer.WrittenSpan;
-
-        if (quotaBuffer.IsEmpty || (quotaBuffer.Length == 2 && quotaBuffer[0] == '-' && quotaBuffer[1] == '1'))
-        {
-            cpuUnits = -1;
-            return false;
-        }
-
-        if (quotaBuffer.StartsWith("max", StringComparison.InvariantCulture))
-        {
-            cpuUnits = 0;
-            return false;
-        }
-
-        _ = GetNextNumber(quotaBuffer, out long quota);
-
-        if (quota == -1)
-        {
-            Throw.InvalidOperationException($"Could not parse '{_cpuCfsQuaotaPeriodUs}'. Expected an integer but got: '{new string(quotaBuffer)}'.");
-        }
-
-        string quotaString = quota.ToString(CultureInfo.CurrentCulture);
-        int index = quotaBuffer.IndexOf(quotaString.AsSpan());
-        ReadOnlySpan<char> cpuPeriodSlice = quotaBuffer.Slice(index + quotaString.Length, quotaBuffer.Length - index - quotaString.Length);
-        _ = GetNextNumber(cpuPeriodSlice, out long period);
-
-        if (period == -1)
-        {
-            Throw.InvalidOperationException($"Could not parse '{_cpuCfsQuaotaPeriodUs}'. Expected to get an integer but got: '{new string(cpuPeriodSlice)}'.");
-        }
-
-        cpuUnits = (float)quota / period;
-
-        return true;
+        return TryParseCpuQuotaAndPeriodFromFile(fileSystem, _cpuCfsQuaotaPeriodUs, out cpuUnits);
     }
 
     /// <remarks>
     /// If the file doesn't exist, we assume that the system is a Host and we read the CPU usage from /proc/stat.
     /// </remarks>
-    private static bool TryGetCpuUnitsFromCgroupsWithoutHost(IFileSystem fileSystem, FileInfo cpuLimitsFile, out float cpuUnits)
+    private static bool TryGetCpuLimitFromCgroupsV2(IFileSystem fileSystem, FileInfo cpuLimitsFile, out float cpuUnits)
     {
         if (!fileSystem.Exists(cpuLimitsFile))
         {
@@ -653,6 +598,11 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
             return false;
         }
 
+        return TryParseCpuQuotaAndPeriodFromFile(fileSystem, cpuLimitsFile, out cpuUnits);
+    }
+
+    private static bool TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, out float cpuUnits)
+    {
         using ReturnableBufferWriter<char> bufferWriter = new(_sharedBufferWriterPool);
         fileSystem.ReadFirstLine(cpuLimitsFile, bufferWriter.Buffer);
 
@@ -694,70 +644,39 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
 
     private static bool TryGetCgroupRequestCpu(IFileSystem fileSystem, out float cpuUnits)
     {
-        const long CpuPodWeightPossibleMax = 10_000;
-        const long CpuPodWeightPossibleMin = 1;
-
         if (!fileSystem.Exists(_cpuPodWeight))
         {
             cpuUnits = 0;
             return false;
         }
 
-        using ReturnableBufferWriter<char> bufferWriter = new(_sharedBufferWriterPool);
-        fileSystem.ReadFirstLine(_cpuPodWeight, bufferWriter.Buffer);
-        ReadOnlySpan<char> cpuPodWeightBuffer = bufferWriter.Buffer.WrittenSpan;
-
-        if (cpuPodWeightBuffer.IsEmpty || (cpuPodWeightBuffer.Length == 2 && cpuPodWeightBuffer[0] == '-' && cpuPodWeightBuffer[1] == '1'))
-        {
-            Throw.InvalidOperationException(
-                $"Could not parse '{_cpuPodWeight}' content. Expected to find CPU weight but got '{new string(cpuPodWeightBuffer)}' instead.");
-        }
-
-        _ = GetNextNumber(cpuPodWeightBuffer, out long cpuPodWeight);
-
-        if (cpuPodWeight == -1)
-        {
-            Throw.InvalidOperationException(
-                $"Could not parse '{_cpuPodWeight}' content. Expected to get an integer but got: '{cpuPodWeightBuffer}'.");
-        }
-
-        if (cpuPodWeight < CpuPodWeightPossibleMin || cpuPodWeight > CpuPodWeightPossibleMax)
-        {
-            Throw.ArgumentOutOfRangeException("CPU weight",
-                $"Expected to find CPU weight in range [{CpuPodWeightPossibleMin}-{CpuPodWeightPossibleMax}] in '{_cpuPodWeight}', but got '{cpuPodWeight}' instead.");
-        }
-
-        // The formula to calculate CPU pod weight (measured in millicores) from CPU share:
-        // y = (1 + ((x - 2) * 9999) / 262142),
-        // where y is the CPU pod weight (e.g. cpuPodWeight) and x is the CPU share of cgroup v1 (e.g. cpuUnits).
-        // https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
-        // We invert the formula to calculate CPU share from CPU pod weight:
-#pragma warning disable S109 // Magic numbers should not be used - using the formula, forgive.
-        cpuUnits = ((cpuPodWeight - 1) * 262142 / 9999) + 2;
-#pragma warning restore S109 // Magic numbers should not be used
-
-        return true;
+        return TryParseCpuWeightFromFile(fileSystem, _cpuPodWeight, out cpuUnits);
     }
 
-    private static bool TryGetCgroupRequestCpuWithoutHost(IFileSystem fileSystem, FileInfo cpuRequestsFile, out float cpuUnits)
+    private static bool TryGetCgroupRequestCpuV2(IFileSystem fileSystem, FileInfo cpuRequestsFile, out float cpuUnits)
     {
-        const long CpuPodWeightPossibleMax = 10_000;
-        const long CpuPodWeightPossibleMin = 1;
-
         if (!fileSystem.Exists(cpuRequestsFile))
         {
             cpuUnits = 0;
             return false;
         }
 
+        return TryParseCpuWeightFromFile(fileSystem, cpuRequestsFile, out cpuUnits);
+    }
+
+    private static bool TryParseCpuWeightFromFile(IFileSystem fileSystem, FileInfo cpuWeightFile, out float cpuUnits)
+    {
+        const long CpuPodWeightPossibleMax = 10_000;
+        const long CpuPodWeightPossibleMin = 1;
+
         using ReturnableBufferWriter<char> bufferWriter = new(_sharedBufferWriterPool);
-        fileSystem.ReadFirstLine(cpuRequestsFile, bufferWriter.Buffer);
+        fileSystem.ReadFirstLine(cpuWeightFile, bufferWriter.Buffer);
         ReadOnlySpan<char> cpuPodWeightBuffer = bufferWriter.Buffer.WrittenSpan;
 
         if (cpuPodWeightBuffer.IsEmpty || (cpuPodWeightBuffer.Length == 2 && cpuPodWeightBuffer[0] == '-' && cpuPodWeightBuffer[1] == '1'))
         {
             Throw.InvalidOperationException(
-                $"Could not parse '{cpuRequestsFile}' content. Expected to find CPU weight but got '{new string(cpuPodWeightBuffer)}' instead.");
+                $"Could not parse '{cpuWeightFile}' content. Expected to find CPU weight but got '{new string(cpuPodWeightBuffer)}' instead.");
         }
 
         _ = GetNextNumber(cpuPodWeightBuffer, out long cpuPodWeight);
@@ -765,13 +684,13 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
         if (cpuPodWeight == -1)
         {
             Throw.InvalidOperationException(
-                $"Could not parse '{cpuRequestsFile}' content. Expected to get an integer but got: '{cpuPodWeightBuffer}'.");
+                $"Could not parse '{cpuWeightFile}' content. Expected to get an integer but got: '{cpuPodWeightBuffer}'.");
         }
 
         if (cpuPodWeight < CpuPodWeightPossibleMin || cpuPodWeight > CpuPodWeightPossibleMax)
         {
             Throw.ArgumentOutOfRangeException("CPU weight",
-                $"Expected to find CPU weight in range [{CpuPodWeightPossibleMin}-{CpuPodWeightPossibleMax}] in '{cpuRequestsFile}', but got '{cpuPodWeight}' instead.");
+                $"Expected to find CPU weight in range [{CpuPodWeightPossibleMin}-{CpuPodWeightPossibleMax}] in '{cpuWeightFile}', but got '{cpuPodWeight}' instead.");
         }
 
         // The formula to calculate CPU pod weight (measured in millicores) from CPU share:

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
@@ -21,7 +21,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
 {
     private const int Thousand = 1000;
     private const int CpuShares = 1024;
-    private const string PathPrefix = "/sys/fs/cgroup";
+    private const string CgroupPathPrefix = "/sys/fs/cgroup";
     private const string CpuStat = "cpu.stat"; // File containing CPU usage in nanoseconds.
     private const string CpuLimit = "cpu.max"; // File with amount of CPU time available to the group along with the accounting period in microseconds.
     private const string CpuRequest = "cpu.weight"; // CPU weights, also known as shares in cgroup v1, is used for resource allocation.
@@ -109,7 +109,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
         // If we've already parsed the path, use the cached value
         if (_cachedCgroupPath != null)
         {
-            return $"{PathPrefix}{_cachedCgroupPath}{filename}";
+            return $"{CgroupPathPrefix}{_cachedCgroupPath}{filename}";
         }
 
         using ReturnableBufferWriter<char> bufferWriter = new(_sharedBufferWriterPool);
@@ -135,7 +135,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
         ReadOnlySpan<char> trimmedPath = fileContent.Slice(colonIndex + 1);
         _cachedCgroupPath = trimmedPath.ToString().TrimEnd('/') + "/";
 
-        return $"{PathPrefix}{_cachedCgroupPath}{filename}";
+        return $"{CgroupPathPrefix}{_cachedCgroupPath}{filename}";
     }
 
     public long GetCgroupCpuUsageInNanoseconds()

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
@@ -21,7 +21,6 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
 {
     private const int Thousand = 1000;
     private const int CpuShares = 1024;
-    private const string CgroupPathPrefix = "/sys/fs/cgroup";
     private const string CpuStat = "cpu.stat"; // File containing CPU usage in nanoseconds.
     private const string CpuLimit = "cpu.max"; // File with amount of CPU time available to the group along with the accounting period in microseconds.
     private const string CpuRequest = "cpu.weight"; // CPU weights, also known as shares in cgroup v1, is used for resource allocation.
@@ -109,7 +108,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
         // If we've already parsed the path, use the cached value
         if (_cachedCgroupPath != null)
         {
-            return $"{CgroupPathPrefix}{_cachedCgroupPath}{filename}";
+            return $"{_cachedCgroupPath}{filename}";
         }
 
         using ReturnableBufferWriter<char> bufferWriter = new(_sharedBufferWriterPool);
@@ -133,9 +132,9 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
 
         // Extract the part after the last colon and cache it for future use
         ReadOnlySpan<char> trimmedPath = fileContent.Slice(colonIndex + 1);
-        _cachedCgroupPath = trimmedPath.ToString().TrimEnd('/') + "/";
+        _cachedCgroupPath = "/sys/fs/cgroup" + trimmedPath.ToString().TrimEnd('/') + "/";
 
-        return $"{CgroupPathPrefix}{_cachedCgroupPath}{filename}";
+        return $"{_cachedCgroupPath}{filename}";
     }
 
     public long GetCgroupCpuUsageInNanoseconds()

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
@@ -116,7 +116,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
         }
 
         // Find the index of the first colon (:)
-        int colonIndex = fileContent.IndexOf(':');
+        int colonIndex = fileContent.LastIndexOf(':');
         if (colonIndex == -1 || colonIndex + 1 >= fileContent.Length)
         {
             throw new InvalidOperationException($"Invalid format in file '{_cpuActualSelfSliceProcFile}'. Expected content with ':' separator.");
@@ -124,10 +124,15 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
 
         // Extract the part after the last colon
         ReadOnlySpan<char> trimmedPath = fileContent.Slice(colonIndex + 1);
+        string trimmedPathString = trimmedPath.ToString();
+
+        if (!trimmedPathString.EndsWith('/'))
+        {
+            trimmedPathString += '/';
+        }
 
         // Prepend the path prefix and append the filename
-        string updatedPath = $"{PathPrefix}{trimmedPath.ToString()}/{filename}";
-
+        string updatedPath = $"{PathPrefix}{trimmedPathString}{filename}";
         return updatedPath;
     }
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -119,11 +119,11 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
 
                 if (deltaCgroup > 0)
                 {
-                    double percentage = Math.Min(One, deltaCgroup / (actualElapsed * 1_000_000_000.0));
+                    double coresUsed = deltaCgroup / (actualElapsed * 1_000_000_000.0);
 
-                    Log.CpuUsageData(_logger, cgroupCpuTime, 0, _previousCgroupCpuTime, 0, percentage);
+                    Log.CpuUsageData(_logger, cgroupCpuTime, 0, _previousCgroupCpuTime, 0, coresUsed);
 
-                    _cpuPercentage = percentage;
+                    _cpuPercentage = coresUsed;
                     _refreshAfterCpu = now.Add(_cpuRefreshInterval);
                     _previousCgroupCpuTime = cgroupCpuTime;
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -119,7 +119,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
 
                 if (deltaCgroup > 0)
                 {
-                    double percentage = Math.Min(One, deltaCgroup / actualElapsed);
+                    double percentage = Math.Min(One, deltaCgroup / (actualElapsed * 1_000_000_000.0));
 
                     Log.CpuUsageData(_logger, cgroupCpuTime, 0, _previousCgroupCpuTime, 0, percentage);
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -77,6 +77,9 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         }
         else
         {
+            _previousCgroupCpuTime = _parser.GetCgroupCpuUsageInNanosecondsWithoutHost();
+            cpuLimit = _parser.GetCgroupLimitedCpusWithoutHost();
+            cpuRequest = _parser.GetCgroupRequestCpuWithoutHost();
             _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuLimitUtilization, observeValue: () => CpuUtilizationWithoutHost() / cpuLimit, unit: "1");
             _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuRequestUtilization, observeValue: () => CpuUtilizationWithoutHost() / cpuRequest, unit: "1");
         }
@@ -106,7 +109,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
             }
         }
 
-        long cgroupCpuTime = _parser.GetCgroupCpuUsageInNanoseconds();
+        long cgroupCpuTime = _parser.GetCgroupCpuUsageInNanosecondsWithoutHost();
 
         lock (_cpuLocker)
         {

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -101,7 +101,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
     public double CpuUtilizationWithoutHostDelta()
     {
         DateTimeOffset now = _timeProvider.GetUtcNow();
-        double actualElapsedNanoseconds = (now - _lastCpuMeasurementTime).TotalSeconds * 1_000_000_000.0;
+        double actualElapsedNanoseconds = (now - _lastCpuMeasurementTime).TotalNanoseconds;
 
         lock (_cpuLocker)
         {
@@ -123,7 +123,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
                 {
                     double coresUsed = deltaCgroup / actualElapsedNanoseconds;
 
-                    Log.CpuUsageData(_logger, cgroupCpuTime, 0, _previousCgroupCpuTime, 0, coresUsed);
+                    Log.CpuUsageDataV2(_logger, cgroupCpuTime, _previousCgroupCpuTime, actualElapsedNanoseconds, coresUsed);
 
                     _lastCpuCoresUsed = coresUsed;
                     _refreshAfterCpu = now.Add(_cpuRefreshInterval);

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
@@ -33,4 +33,15 @@ internal static partial class Log
     [LoggerMessage(3, LogLevel.Debug,
         "System resources information: CpuLimit = {cpuLimit}, CpuRequest = {cpuRequest}, MemoryLimit = {memoryLimit}, MemoryRequest = {memoryRequest}.")]
     public static partial void SystemResourcesInfo(ILogger logger, double cpuLimit, double cpuRequest, ulong memoryLimit, ulong memoryRequest);
+
+    [LoggerMessage(4, LogLevel.Debug,
+#pragma warning disable S103 // Lines should not be too long
+        "For CgroupV2, Computed CPU usage with CgroupCpuTime = {cgroupCpuTime}, PreviousCgroupCpuTime = {previousCgroupCpuTime}, ActualElapsedNanoseconds = {actualElapsedNanoseconds}, CpuCores = {cpuCores}.")]
+#pragma warning restore S103 // Lines should not be too long
+    public static partial void CpuUsageDataV2(
+        ILogger logger,
+        long cgroupCpuTime,
+        long previousCgroupCpuTime,
+        double actualElapsedNanoseconds,
+        double cpuCores);
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringOptions.cs
@@ -103,7 +103,7 @@ public partial class ResourceMonitoringOptions
     /// Gets or sets a value indicating whether CPU metrics are calculated via cgroup CPU limits instead of Host CPU delta.
     /// </summary>
     /// <value>
-    /// The default value is true.
+    /// The default value is <see langword="false"/>.
     /// </value>
 #pragma warning disable CA1805 // Do not initialize unnecessarily
     [Experimental(diagnosticId: DiagnosticIds.Experiments.ResourceMonitoring, UrlFormat = DiagnosticIds.UrlFormat)]

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringOptions.cs
@@ -105,8 +105,6 @@ public partial class ResourceMonitoringOptions
     /// <value>
     /// The default value is <see langword="false"/>.
     /// </value>
-#pragma warning disable CA1805 // Do not initialize unnecessarily
     [Experimental(diagnosticId: DiagnosticIds.Experiments.ResourceMonitoring, UrlFormat = DiagnosticIds.UrlFormat)]
-    public bool CalculateCpuUsageWithoutHost { get; set; } = false;
-#pragma warning restore CA1805 // Do not initialize unnecessarily
+    public bool CalculateCpuUsageWithoutHostDelta { get; set; }
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringOptions.cs
@@ -97,4 +97,12 @@ public partial class ResourceMonitoringOptions
         UrlFormat = DiagnosticIds.UrlFormat)]
     [TimeSpan(MinimumCachingInterval, MaximumCachingInterval)]
     public TimeSpan MemoryConsumptionRefreshInterval { get; set; } = DefaultRefreshInterval;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether CPU metrics are calculated via cgroup CPU limits instead of Host CPU delta.
+    /// </summary>
+    /// <value>
+    /// The default value is true.
+    /// </value>
+    public bool CalculateCpuUsageWithoutHost { get; set; } = false;
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Shared.Data.Validation;
 using Microsoft.Shared.DiagnosticIds;
 
@@ -105,6 +106,7 @@ public partial class ResourceMonitoringOptions
     /// The default value is true.
     /// </value>
 #pragma warning disable CA1805 // Do not initialize unnecessarily
+    [Experimental(diagnosticId: DiagnosticIds.Experiments.ResourceMonitoring, UrlFormat = DiagnosticIds.UrlFormat)]
     public bool CalculateCpuUsageWithoutHost { get; set; } = false;
 #pragma warning restore CA1805 // Do not initialize unnecessarily
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringOptions.cs
@@ -104,5 +104,7 @@ public partial class ResourceMonitoringOptions
     /// <value>
     /// The default value is true.
     /// </value>
+#pragma warning disable CA1805 // Do not initialize unnecessarily
     public bool CalculateCpuUsageWithoutHost { get; set; } = false;
+#pragma warning restore CA1805 // Do not initialize unnecessarily
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV1Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV1Tests.cs
@@ -35,6 +35,9 @@ public sealed class LinuxUtilizationParserCgroupV1Tests
         Assert.Throws<InvalidOperationException>(() => parser.GetHostCpuCount());
         Assert.Throws<InvalidOperationException>(() => parser.GetCgroupCpuUsageInNanoseconds());
         Assert.Throws<InvalidOperationException>(() => parser.GetCgroupRequestCpu());
+        Assert.Throws<NotSupportedException>(() => parser.GetCgroupCpuUsageInNanosecondsWithoutHost());
+        Assert.Throws<NotSupportedException>(() => parser.GetCgroupLimitedCpusWithoutHost());
+        Assert.Throws<NotSupportedException>(() => parser.GetCgroupRequestCpuWithoutHost());
     }
 
     [ConditionalFact]

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV1Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV1Tests.cs
@@ -35,9 +35,9 @@ public sealed class LinuxUtilizationParserCgroupV1Tests
         Assert.Throws<InvalidOperationException>(() => parser.GetHostCpuCount());
         Assert.Throws<InvalidOperationException>(() => parser.GetCgroupCpuUsageInNanoseconds());
         Assert.Throws<InvalidOperationException>(() => parser.GetCgroupRequestCpu());
-        Assert.Throws<NotSupportedException>(() => parser.GetCgroupCpuUsageInNanosecondsWithoutHost());
-        Assert.Throws<NotSupportedException>(() => parser.GetCgroupLimitedCpusWithoutHost());
-        Assert.Throws<NotSupportedException>(() => parser.GetCgroupRequestCpuWithoutHost());
+        Assert.Throws<NotSupportedException>(() => parser.GetCgroupCpuUsageInNanosecondsV2());
+        Assert.Throws<NotSupportedException>(() => parser.GetCgroupLimitV2());
+        Assert.Throws<NotSupportedException>(() => parser.GetCgroupRequestCpuV2());
     }
 
     [ConditionalFact]

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
@@ -412,9 +412,9 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
     }
 
     [ConditionalTheory]
-    [InlineData("0::/", "usage_usec 222222")]
-    [InlineData("0::/fakeslice", "usage_usec 222222")]
-    public void Reads_CpuUsageFromSlices_When_Valid_Input(string slicepath, string content)
+    [InlineData("0::/", "usage_usec 222222", "222222000")]
+    [InlineData("0::/fakeslice", "usage_usec 222222", "222222000")]
+    public void Reads_CpuUsageFromSlices_When_Valid_Input(string slicepath, string content, string result)
     {
         var f = new HardcodedValueFileSystem(new Dictionary<FileInfo, string>
         {
@@ -426,7 +426,8 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
         var p = new LinuxUtilizationParserCgroupV2(f, new FakeUserHz(100));
         var r = p.GetCgroupCpuUsageInNanosecondsV2();
 
-        Assert.Equal(222222000, r);
+        Assert.IsType<long>(r);
+        Assert.Equal(result, r.ToString());
     }
 
     [ConditionalFact]

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
@@ -33,13 +33,13 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
         Assert.Throws<InvalidOperationException>(() => parser.GetAvailableMemoryInBytes());
         Assert.Throws<InvalidOperationException>(() => parser.GetMemoryUsageInBytes());
         Assert.Throws<InvalidOperationException>(() => parser.GetCgroupLimitedCpus());
-        Assert.Throws<InvalidOperationException>(() => parser.GetCgroupLimitedCpusWithoutHost());
+        Assert.Throws<InvalidOperationException>(() => parser.GetCgroupLimitV2());
         Assert.Throws<InvalidOperationException>(() => parser.GetHostCpuUsageInNanoseconds());
         Assert.Throws<InvalidOperationException>(() => parser.GetHostCpuCount());
         Assert.Throws<InvalidOperationException>(() => parser.GetCgroupCpuUsageInNanoseconds());
-        Assert.Throws<InvalidOperationException>(() => parser.GetCgroupCpuUsageInNanosecondsWithoutHost());
+        Assert.Throws<InvalidOperationException>(() => parser.GetCgroupCpuUsageInNanosecondsV2());
         Assert.Throws<InvalidOperationException>(() => parser.GetCgroupRequestCpu());
-        Assert.Throws<InvalidOperationException>(() => parser.GetCgroupRequestCpuWithoutHost());
+        Assert.Throws<InvalidOperationException>(() => parser.GetCgroupRequestCpuV2());
     }
 
     [ConditionalFact]
@@ -294,7 +294,7 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
         });
 
         var p = new LinuxUtilizationParserCgroupV2(f, new FakeUserHz(100));
-        var cpus = p.GetCgroupLimitedCpusWithoutHost();
+        var cpus = p.GetCgroupLimitV2();
 
         Assert.Equal(2, cpus);
     }
@@ -311,11 +311,10 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
         });
 
         var p = new LinuxUtilizationParserCgroupV2(f, new FakeUserHz(100));
-        var r = Math.Round(p.GetCgroupRequestCpuWithoutHost());
+        var r = Math.Round(p.GetCgroupRequestCpuV2());
 
         Assert.Equal(result, r);
     }
-
 
     [ConditionalFact]
     public void Gets_Available_Cpus_From_CpuSetCpus_When_Cpu_Max_Set_To_Max_()
@@ -425,9 +424,9 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
         });
 
         var p = new LinuxUtilizationParserCgroupV2(f, new FakeUserHz(100));
-        var r = p.GetCgroupCpuUsageInNanosecondsWithoutHost();
+        var r = p.GetCgroupCpuUsageInNanosecondsV2();
 
-        Assert.Equal(222222000, r);
+        Assert.Equal(22_222_2000, r);
     }
 
     [ConditionalFact]
@@ -545,7 +544,7 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
         });
 
         var p = new LinuxUtilizationParserCgroupV2(f, new FakeUserHz(100));
-        var r = p.GetCgroupActualSlicePath(filename);
+        var r = p.GetCgroupPath(filename);
 
         Assert.Equal(result, r);
     }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
@@ -426,7 +426,7 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
         var p = new LinuxUtilizationParserCgroupV2(f, new FakeUserHz(100));
         var r = p.GetCgroupCpuUsageInNanosecondsV2();
 
-        Assert.Equal(22_222_2000, r);
+        Assert.Equal(222222000, r);
     }
 
     [ConditionalFact]

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
@@ -205,4 +205,74 @@ public sealed class LinuxUtilizationProviderTests
         var meter = meterFactory.Meters.Single();
         Assert.Equal(ResourceUtilizationInstruments.MeterName, meter.Name);
     }
+
+    [ConditionalFact]
+    [CombinatorialData]
+    public void Provider_Registers_Instruments_CgroupV2_WithoutHostCpu()
+    {
+        var meterName = Guid.NewGuid().ToString();
+        var logger = new FakeLogger<LinuxUtilizationProvider>();
+        var options = Options.Options.Create(new ResourceMonitoringOptions { CalculateCpuUsageWithoutHost = true });
+        using var meter = new Meter(nameof(Provider_Registers_Instruments_CgroupV2_WithoutHostCpu));
+        var meterFactoryMock = new Mock<IMeterFactory>();
+        meterFactoryMock.Setup(x => x.Create(It.IsAny<MeterOptions>()))
+            .Returns(meter);
+
+        var fileSystem = new HardcodedValueFileSystem(new Dictionary<FileInfo, string>
+        {
+            { new FileInfo("/proc/self/cgroup"), "0::/fakeslice" },
+            { new FileInfo("/sys/fs/cgroup/memory.max"), "9223372036854771712" },
+            { new FileInfo("/proc/stat"), "cpu 10 10 10 10 10 10 10 10 10 10"},
+            { new FileInfo("/sys/fs/cgroup/fakeslice/cpu.stat"), "usage_usec 102312"},
+            { new FileInfo("/proc/meminfo"), "MemTotal: 1024 kB"},
+            { new FileInfo("/sys/fs/cgroup/cpuset.cpus.effective"), "0-19"},
+            { new FileInfo("/sys/fs/cgroup/fakeslice/cpu.max"), "20000 100000"},
+            { new FileInfo("/sys/fs/cgroup/memory.stat"), "inactive_file 312312"},
+            { new FileInfo("/sys/fs/cgroup/memory.current"), "524288423423"},
+            { new FileInfo("/sys/fs/cgroup/fakeslice/cpu.weight"), "4"},
+        });
+
+        var parser = new LinuxUtilizationParserCgroupV2(fileSystem: fileSystem, new FakeUserHz(100));
+        var provider = new LinuxUtilizationProvider(options, parser, meterFactoryMock.Object, logger, TimeProvider.System);
+
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (ReferenceEquals(meter, instrument.Meter))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        var samples = new List<(Instrument instrument, double value)>();
+        listener.SetMeasurementEventCallback<double>((instrument, value, _, _) =>
+        {
+            if (ReferenceEquals(meter, instrument.Meter))
+            {
+                samples.Add((instrument, value));
+            }
+        });
+
+        listener.Start();
+        listener.RecordObservableInstruments();
+
+        Assert.Equal(5, samples.Count);
+
+        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ContainerCpuLimitUtilization);
+        Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ContainerCpuLimitUtilization).value));
+
+        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ContainerCpuRequestUtilization);
+        Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ContainerCpuRequestUtilization).value));
+
+        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ContainerMemoryLimitUtilization);
+        Assert.Equal(1, samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ContainerMemoryLimitUtilization).value);
+
+        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization);
+        Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization).value));
+
+        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessMemoryUtilization);
+        Assert.Equal(1, samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessMemoryUtilization).value);
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
@@ -212,7 +212,7 @@ public sealed class LinuxUtilizationProviderTests
     {
         var meterName = Guid.NewGuid().ToString();
         var logger = new FakeLogger<LinuxUtilizationProvider>();
-        var options = Options.Options.Create(new ResourceMonitoringOptions { CalculateCpuUsageWithoutHost = true });
+        var options = Options.Options.Create(new ResourceMonitoringOptions { CalculateCpuUsageWithoutHostDelta = true });
         using var meter = new Meter(nameof(Provider_Registers_Instruments_CgroupV2_WithoutHostCpu));
         var meterFactoryMock = new Mock<IMeterFactory>();
         meterFactoryMock.Setup(x => x.Create(It.IsAny<MeterOptions>()))

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/DummyLinuxUtilizationParser.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/DummyLinuxUtilizationParser.cs
@@ -9,8 +9,11 @@ internal class DummyLinuxUtilizationParser : ILinuxUtilizationParser
 {
     public ulong GetAvailableMemoryInBytes() => 1;
     public long GetCgroupCpuUsageInNanoseconds() => 0;
+    public long GetCgroupCpuUsageInNanosecondsWithoutHost() => 0;
     public float GetCgroupLimitedCpus() => 1;
+    public float GetCgroupLimitedCpusWithoutHost() => 1;
     public float GetCgroupRequestCpu() => 1;
+    public float GetCgroupRequestCpuWithoutHost() => 1;
     public ulong GetHostAvailableMemory() => 0;
     public float GetHostCpuCount() => 1;
     public long GetHostCpuUsageInNanoseconds() => 0;

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/DummyLinuxUtilizationParser.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/DummyLinuxUtilizationParser.cs
@@ -9,11 +9,11 @@ internal class DummyLinuxUtilizationParser : ILinuxUtilizationParser
 {
     public ulong GetAvailableMemoryInBytes() => 1;
     public long GetCgroupCpuUsageInNanoseconds() => 0;
-    public long GetCgroupCpuUsageInNanosecondsWithoutHost() => 0;
+    public long GetCgroupCpuUsageInNanosecondsV2() => 0;
     public float GetCgroupLimitedCpus() => 1;
-    public float GetCgroupLimitedCpusWithoutHost() => 1;
+    public float GetCgroupLimitV2() => 1;
     public float GetCgroupRequestCpu() => 1;
-    public float GetCgroupRequestCpuWithoutHost() => 1;
+    public float GetCgroupRequestCpuV2() => 1;
     public ulong GetHostAvailableMemory() => 0;
     public float GetHostCpuCount() => 1;
     public long GetHostCpuUsageInNanoseconds() => 0;

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_.verified.txt
@@ -3,9 +3,9 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '@'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass16_0.<Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass18_0.<Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '@'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass16_0.<Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '@'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass18_0.<Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=           12_period=eeeee 12.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=           12_period=eeeee 12.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.max'. Expected to get an integer but got: ' eeeee 12'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=           12_period=eeeee 12.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=           12_period=eeeee 12.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-----_period=18.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-----_period=18.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.max'. Expected to get an integer but got: ''.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-----_period=18.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-----_period=18.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-18_period=18.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-18_period=18.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.max'. Expected an integer but got: '-18 18'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-18_period=18.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-18_period=18.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-_period=d'.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-_period=d'.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.max'. Expected an integer but got: '- d''.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-_period=d'.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-_period=d'.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-_period=d--.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-_period=d--.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.max'. Expected an integer but got: '- d/:'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-_period=d--.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=-_period=d--.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=12       _period=.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=12       _period=.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=12       _period=.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=12       _period=.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.max'. Expected to get an integer but got: '        '.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=123_period=-----.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=123_period=-----.verified.txt
@@ -11,6 +11,6 @@ Could not parse '/sys/fs/cgroup/cpu.max'. Expected to get an integer but got: '
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=123_period=-----.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=123_period=-----.verified.txt
@@ -9,6 +9,7 @@ Could not parse '/sys/fs/cgroup/cpu.max'. Expected to get an integer but got: '
 '.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=2_period=d--.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=2_period=d--.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.max'. Expected to get an integer but got: ' d/:'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=2_period=d--.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=2_period=d--.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=2d2d2d_period=e3.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=2d2d2d_period=e3.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.max'. Expected to get an integer but got: 'd2d2d e3'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=2d2d2d_period=e3.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=2d2d2d_period=e3.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=3d_period=d3.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=3d_period=d3.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.max'. Expected to get an integer but got: 'd d3'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=3d_period=d3.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=3d_period=d3.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=dd1d_period=18.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=dd1d_period=18.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.max'. Expected an integer but got: 'dd1d 18'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuQuotaAndPeriodFromFile(IFileSystem fileSystem, FileInfo cpuLimitsFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=dd1d_period=18.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data_quota=dd1d_period=18.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCpuUnitsFromCgroups(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass19_0.<Throws_When_Cgroup_Cpu_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=-1.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=-1.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.weight' content. Expected to find CPU weight but got '-1' instead.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuWeightFromFile(IFileSystem fileSystem, FileInfo cpuWeightFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCgroupRequestCpu(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupRequestCpu()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass26_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=-1.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=-1.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCgroupRequestCpu(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupRequestCpu()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass23_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass26_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=0.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=0.verified.txt
@@ -6,6 +6,6 @@
 at Microsoft.Shared.Diagnostics.Throw.ArgumentOutOfRangeException(String paramName, String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCgroupRequestCpu(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupRequestCpu()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass23_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass26_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=0.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=0.verified.txt
@@ -4,6 +4,7 @@
   ParamName: CPU weight,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.ArgumentOutOfRangeException(String paramName, String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuWeightFromFile(IFileSystem fileSystem, FileInfo cpuWeightFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCgroupRequestCpu(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupRequestCpu()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass26_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=10001.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=10001.verified.txt
@@ -6,6 +6,6 @@
 at Microsoft.Shared.Diagnostics.Throw.ArgumentOutOfRangeException(String paramName, String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCgroupRequestCpu(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupRequestCpu()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass23_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass26_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=10001.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=10001.verified.txt
@@ -4,6 +4,7 @@
   ParamName: CPU weight,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.ArgumentOutOfRangeException(String paramName, String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuWeightFromFile(IFileSystem fileSystem, FileInfo cpuWeightFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCgroupRequestCpu(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupRequestCpu()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass26_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=dasrz3424.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=dasrz3424.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.weight' content. Expected to get an integer but got: 'dasrz3424'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryParseCpuWeightFromFile(IFileSystem fileSystem, FileInfo cpuWeightFile, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCgroupRequestCpu(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupRequestCpu()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass26_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=dasrz3424.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data_content=dasrz3424.verified.txt
@@ -5,6 +5,6 @@
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.TryGetCgroupRequestCpu(IFileSystem fileSystem, Single& cpuUnits)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupRequestCpu()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass23_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass26_0.<Throws_When_Cgroup_Cpu_Weight_Files_Contain_Invalid_Data>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=@#dddada_value=342322.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=@#dddada_value=342322.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.stat'. We expected first line of the file to start with 'usage_usec' but it was '@#dddada 342322' instead.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass24_0.<Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=@#dddada_value=342322.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=@#dddada_value=342322.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass21_0.<Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass24_0.<Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=dasd_value=-1.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=dasd_value=-1.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.stat'. We expected first line of the file to start with 'usage_usec' but it was 'dasd -1' instead.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass24_0.<Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=dasd_value=-1.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=dasd_value=-1.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass21_0.<Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass24_0.<Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=usage__value=12222.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=usage__value=12222.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpu.stat'. We expected first line of the file to start with 'usage_usec' but it was 'usage_ 12222' instead.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass24_0.<Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=usage__value=12222.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=usage__value=12222.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass21_0.<Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass24_0.<Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=    d  182-1923.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=    d  182-1923.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '    d  182-1923'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=    d  182-1923.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=    d  182-1923.verified.txt
@@ -3,8 +3,8 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '    d  182-1923'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=    d  182-1923.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=    d  182-1923.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '    d  182-1923'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=--.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=--.verified.txt
@@ -5,8 +5,8 @@ Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated
 '.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=--.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=--.verified.txt
@@ -5,7 +5,7 @@ Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated
 '.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=--.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=--.verified.txt
@@ -5,7 +5,7 @@ Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated
 '.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=-11.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=-11.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '-11'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=-11.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=-11.verified.txt
@@ -3,8 +3,8 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '-11'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=-11.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=-11.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '-11'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=.verified.txt
@@ -3,8 +3,8 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got ''.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got ''.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got ''.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=0-.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=0-.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '0-'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=0-.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=0-.verified.txt
@@ -3,8 +3,8 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '0-'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=0-.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=0-.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '0-'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18                   --.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18                   --.verified.txt
@@ -5,8 +5,8 @@ Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated
 '.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18                   --.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18                   --.verified.txt
@@ -5,7 +5,7 @@ Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated
 '.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18                   --.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18                   --.verified.txt
@@ -5,7 +5,7 @@ Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated
 '.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18-22.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18-22.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '1-18-22'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18-22.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18-22.verified.txt
@@ -3,8 +3,8 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '1-18-22'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18-22.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18-22.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '1-18-22'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-18.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-18.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '22-18'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-18.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-18.verified.txt
@@ -3,8 +3,8 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '22-18'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-18.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-18.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '22-18'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-d.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-d.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '22-d'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-d.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-d.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '22-d'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-d.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-d.verified.txt
@@ -3,8 +3,8 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '22-d'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=aaaa.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=aaaa.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got 'aaaa'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=aaaa.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=aaaa.verified.txt
@@ -3,8 +3,8 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got 'aaaa'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=aaaa.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=aaaa.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got 'aaaa'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=d-22.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=d-22.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got 'd-22'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|23_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=d-22.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=d-22.verified.txt
@@ -3,8 +3,8 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got 'd-22'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass15_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=d-22.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=d-22.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got 'd-22'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=  2.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=  2.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass20_0.<Throws_When_CpuUsage_Invalid>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass23_0.<Throws_When_CpuUsage_Invalid>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=  2569530 36700 245693 4860924 82283 0 4360 0dsa.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=  2569530 36700 245693 4860924 82283 0 4360 0dsa.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass20_0.<Throws_When_CpuUsage_Invalid>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass23_0.<Throws_When_CpuUsage_Invalid>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=  2569530 36700 245693.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=  2569530 36700 245693.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass20_0.<Throws_When_CpuUsage_Invalid>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass23_0.<Throws_When_CpuUsage_Invalid>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=2569530367000.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=2569530367000.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass20_0.<Throws_When_CpuUsage_Invalid>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass23_0.<Throws_When_CpuUsage_Invalid>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=asdasd  2569530 36700 245693 4860924 82283 0 4360 0 0 0.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=asdasd  2569530 36700 245693 4860924 82283 0 4360 0 0 0.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass20_0.<Throws_When_CpuUsage_Invalid>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass23_0.<Throws_When_CpuUsage_Invalid>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=cpu  2569530 36700 245693.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuUsage_Invalid_content=cpu  2569530 36700 245693.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass20_0.<Throws_When_CpuUsage_Invalid>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass23_0.<Throws_When_CpuUsage_Invalid>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-1.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-1.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass22_0.<Throws_When_Usage_Usec_Has_Negative_Value>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass25_0.<Throws_When_Usage_Usec_Has_Negative_Value>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-1.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-1.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not get cpu usage from '/sys/fs/cgroup/cpu.stat'. Expected positive number, but got 'usage_usec -1'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass25_0.<Throws_When_Usage_Usec_Has_Negative_Value>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-15.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-15.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass22_0.<Throws_When_Usage_Usec_Has_Negative_Value>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass25_0.<Throws_When_Usage_Usec_Has_Negative_Value>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-15.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-15.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not get cpu usage from '/sys/fs/cgroup/cpu.stat'. Expected positive number, but got 'usage_usec -15'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass25_0.<Throws_When_Usage_Usec_Has_Negative_Value>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-32131.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-32131.verified.txt
@@ -4,6 +4,6 @@
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass22_0.<Throws_When_Usage_Usec_Has_Negative_Value>b__0()
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass25_0.<Throws_When_Usage_Usec_Has_Negative_Value>b__0()
 at Xunit.Record.Exception(Func`1 testCode)
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-32131.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-32131.verified.txt
@@ -3,6 +3,7 @@
   Message: Could not get cpu usage from '/sys/fs/cgroup/cpu.stat'. Expected positive number, but got 'usage_usec -32131'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupCpuUsageInNanoseconds()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass25_0.<Throws_When_Usage_Usec_Has_Negative_Value>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/ResourceMonitoringOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/ResourceMonitoringOptionsTests.cs
@@ -19,17 +19,17 @@ public sealed class ResourceMonitoringOptionsTests
         };
 
         Assert.NotNull(options);
-        Assert.False(options.CalculateCpuUsageWithoutHost);
+        Assert.False(options.CalculateCpuUsageWithoutHostDelta);
     }
 
     [Fact]
-    public void CalculateCpuUsageWithoutHost_WhenSet_ReturnsExpectedValue()
+    public void CalculateCpuUsageWithoutHostDelta_WhenSet_ReturnsExpectedValue()
     {
         var options = new ResourceMonitoringOptions
         {
-            CalculateCpuUsageWithoutHost = true
+            CalculateCpuUsageWithoutHostDelta = true
         };
 
-        Assert.True(options.CalculateCpuUsageWithoutHost);
+        Assert.True(options.CalculateCpuUsageWithoutHostDelta);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/ResourceMonitoringOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/ResourceMonitoringOptionsTests.cs
@@ -19,5 +19,17 @@ public sealed class ResourceMonitoringOptionsTests
         };
 
         Assert.NotNull(options);
+        Assert.False(options.CalculateCpuUsageWithoutHost);
+    }
+
+    [Fact]
+    public void CalculateCpuUsageWithoutHost_WhenSet_ReturnsExpectedValue()
+    {
+        var options = new ResourceMonitoringOptions
+        {
+            CalculateCpuUsageWithoutHost = true
+        };
+
+        Assert.True(options.CalculateCpuUsageWithoutHost);
     }
 }


### PR DESCRIPTION
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6289)
 
Problem Statement: 
1. Current code is always assuming that container cgroup is at fixed location (/sys/fs/cgroup), which may not be the case always. The correct cgroup path should be retrieved from "**/proc/self/cgroup**" file.
![image](https://github.com/user-attachments/assets/1390871c-49f2-4bbf-8ee5-39633026fc66)
2. We are using delta Host CPU for containers % of usages. A better option would be to use cpu limits (cpu.max) set by the Cgroups itself. Host CPU delta might change due to factors other than the container usages.
