### PR TITLE
Introduce Context property on EvaluationMetric

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Console/Program.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Console/Program.cs
@@ -90,7 +90,7 @@ internal sealed class Program
 
         var formatOpt =
             new Option<ReportCommand.Format>(
-                "--format",
+                ["-f", "--format"],
                 () => ReportCommand.Format.html,
                 "Specify the format for the generated report.");
 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/ChatConversationEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/ChatConversationEvaluator.cs
@@ -49,7 +49,7 @@ public abstract class ChatConversationEvaluator : IEvaluator
 
         if (string.IsNullOrWhiteSpace(modelResponse.Text))
         {
-            result.AddDiagnosticToAllMetrics(
+            result.AddDiagnosticsToAllMetrics(
                 EvaluationDiagnostic.Error(
                     "Evaluation failed because the model response supplied for evaluation was null or empty."));
 
@@ -73,7 +73,7 @@ public abstract class ChatConversationEvaluator : IEvaluator
                     EvaluationDiagnostic.Error(
                         $"Evaluation failed because the specified limit of {inputTokenLimit} input tokens was exceeded.");
 
-                result.AddDiagnosticToAllMetrics(tokenBudgetExceeded);
+                result.AddDiagnosticsToAllMetrics(tokenBudgetExceeded);
             }
 
             if (!string.IsNullOrWhiteSpace(SystemPrompt))
@@ -176,7 +176,7 @@ public abstract class ChatConversationEvaluator : IEvaluator
         if (inputTokenLimit > 0 && ignoredMessagesCount > 0)
         {
 #pragma warning disable S103 // Lines should not be too long
-            result.AddDiagnosticToAllMetrics(
+            result.AddDiagnosticsToAllMetrics(
                 EvaluationDiagnostic.Warning(
                     $"The evaluation may be inconclusive because the oldest {ignoredMessagesCount} messages in the supplied conversation history were ignored in order to stay under the specified limit of {inputTokenLimit} input tokens."));
 #pragma warning restore S103

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/ChatConversationEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/ChatConversationEvaluator.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -35,7 +34,7 @@ public abstract class ChatConversationEvaluator : IEvaluator
     protected virtual string? SystemPrompt => null;
 
     /// <inheritdoc/>
-    public async ValueTask<EvaluationResult> EvaluateAsync(
+    public virtual async ValueTask<EvaluationResult> EvaluateAsync(
         IEnumerable<ChatMessage> messages,
         ChatResponse modelResponse,
         ChatConfiguration? chatConfiguration = null,

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/EquivalenceEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/EquivalenceEvaluator.cs
@@ -50,6 +50,28 @@ public sealed class EquivalenceEvaluator : SingleNumericMetricEvaluator
     protected override bool IgnoresHistory => true;
 
     /// <inheritdoc/>
+    public override async ValueTask<EvaluationResult> EvaluateAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatResponse modelResponse,
+        ChatConfiguration? chatConfiguration = null,
+        IEnumerable<EvaluationContext>? additionalContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        EvaluationResult result =
+            await base.EvaluateAsync(
+                messages,
+                modelResponse,
+                chatConfiguration,
+                additionalContext,
+                cancellationToken).ConfigureAwait(false);
+
+        EquivalenceEvaluatorContext context = GetRelevantContext(additionalContext);
+        result.AddOrUpdateContextInAllMetrics("Ground Truth", context.GetContents());
+
+        return result;
+    }
+
+    /// <inheritdoc/>
     protected override async ValueTask<string> RenderEvaluationPromptAsync(
         ChatMessage? userRequest,
         ChatResponse modelResponse,
@@ -66,18 +88,8 @@ public sealed class EquivalenceEvaluator : SingleNumericMetricEvaluator
                 ? await RenderAsync(userRequest, cancellationToken).ConfigureAwait(false)
                 : string.Empty;
 
-        string groundTruth;
-
-        if (additionalContext?.OfType<EquivalenceEvaluatorContext>().FirstOrDefault()
-                is EquivalenceEvaluatorContext context)
-        {
-            groundTruth = context.GroundTruth;
-        }
-        else
-        {
-            throw new InvalidOperationException(
-                $"A value of type '{nameof(EquivalenceEvaluatorContext)}' was not found in the '{nameof(additionalContext)}' collection.");
-        }
+        EquivalenceEvaluatorContext context = GetRelevantContext(additionalContext);
+        string groundTruth = context.GroundTruth;
 
         string prompt =
             $$"""
@@ -148,5 +160,17 @@ public sealed class EquivalenceEvaluator : SingleNumericMetricEvaluator
             """;
 
         return prompt;
+    }
+
+    private static EquivalenceEvaluatorContext GetRelevantContext(IEnumerable<EvaluationContext>? additionalContext)
+    {
+        if (additionalContext?.OfType<EquivalenceEvaluatorContext>().FirstOrDefault()
+                is EquivalenceEvaluatorContext context)
+        {
+            return context;
+        }
+
+        throw new InvalidOperationException(
+            $"A value of type '{nameof(EquivalenceEvaluatorContext)}' was not found in the '{nameof(additionalContext)}' collection.");
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/RelevanceTruthAndCompletenessEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/RelevanceTruthAndCompletenessEvaluator.cs
@@ -145,7 +145,7 @@ public sealed partial class RelevanceTruthAndCompletenessEvaluator : ChatConvers
             if (string.IsNullOrEmpty(evaluationResponseText))
             {
                 rating = Rating.Inconclusive;
-                result.AddDiagnosticToAllMetrics(
+                result.AddDiagnosticsToAllMetrics(
                     EvaluationDiagnostic.Error(
                         "Evaluation failed because the model failed to produce a valid evaluation response."));
             }
@@ -168,7 +168,7 @@ public sealed partial class RelevanceTruthAndCompletenessEvaluator : ChatConvers
                         if (string.IsNullOrEmpty(repairedJson))
                         {
                             rating = Rating.Inconclusive;
-                            result.AddDiagnosticToAllMetrics(
+                            result.AddDiagnosticsToAllMetrics(
                                 EvaluationDiagnostic.Error(
                                     $"""
                                     Failed to repair the following response from the model and parse scores for '{RelevanceMetricName}', '{TruthMetricName}' and '{CompletenessMetricName}'.:
@@ -183,7 +183,7 @@ public sealed partial class RelevanceTruthAndCompletenessEvaluator : ChatConvers
                     catch (JsonException ex)
                     {
                         rating = Rating.Inconclusive;
-                        result.AddDiagnosticToAllMetrics(
+                        result.AddDiagnosticsToAllMetrics(
                             EvaluationDiagnostic.Error(
                                 $"""
                                 Failed to repair the following response from the model and parse scores for '{RelevanceMetricName}', '{TruthMetricName}' and '{CompletenessMetricName}'.:
@@ -281,7 +281,7 @@ public sealed partial class RelevanceTruthAndCompletenessEvaluator : ChatConvers
 
             if (!string.IsNullOrWhiteSpace(rating.Error))
             {
-                result.AddDiagnosticToAllMetrics(EvaluationDiagnostic.Error(rating.Error!));
+                result.AddDiagnosticsToAllMetrics(EvaluationDiagnostic.Error(rating.Error!));
             }
         }
     }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/SingleNumericMetricEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/SingleNumericMetricEvaluator.cs
@@ -105,7 +105,7 @@ public abstract class SingleNumericMetricEvaluator : ChatConversationEvaluator
 
             if (string.IsNullOrEmpty(evaluationResponseText))
             {
-                metric.AddDiagnostic(
+                metric.AddDiagnostics(
                     EvaluationDiagnostic.Error(
                         "Evaluation failed because the model failed to produce a valid evaluation response."));
             }
@@ -115,7 +115,7 @@ public abstract class SingleNumericMetricEvaluator : ChatConversationEvaluator
             }
             else
             {
-                metric.AddDiagnostic(
+                metric.AddDiagnostics(
                     EvaluationDiagnostic.Error(
                         $"Failed to parse '{evaluationResponseText!}' as an integer score for '{MetricName}'."));
             }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/EvalTypes.d.ts
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/EvalTypes.d.ts
@@ -94,6 +94,9 @@ type BaseEvaluationMetric = {
     $type: string;
     name: string;
     interpretation?: EvaluationMetricInterpretation;
+    context?: {
+        [K: string]: AIContent[]
+    };
     diagnostics?: EvaluationDiagnostic[];
     metadata: { 
         [K: string]: string 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/ScoreDetail.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/ScoreDetail.tsx
@@ -32,7 +32,7 @@ export const ScoreDetail = ({ scenario, scoreSummary }: { scenario: ScenarioRunR
             onMetricSelect={setSelectedMetric}
             selectedMetric={selectedMetric} />
         {selectedMetric && <MetricDetailsSection metric={selectedMetric} />}
-        <ConversationDetails messages={messages} model={model} usage={usage} />
+        <ConversationDetails messages={messages} model={model} usage={usage} selectedMetric={selectedMetric} />
         {scenario.chatDetails && scenario.chatDetails.turnDetails.length > 0 && <ChatDetailsSection chatDetails={scenario.chatDetails} />}
     </div>);
 };

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/Styles.ts
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/Styles.ts
@@ -127,6 +127,14 @@ export const useStyles = makeStyles({
         backgroundColor: tokens.colorNeutralBackground3,
         border: '1px solid ' + tokens.colorNeutralStroke2,
     },
+    contextBubble: {
+        padding: '0.75rem 1rem',
+        borderRadius: '12px',
+        overflow: 'hidden',
+        wordBreak: 'break-word',
+        backgroundColor: tokens.colorBrandBackground2,
+        border: '1px solid ' + tokens.colorNeutralStroke2,
+    },
     cacheHitIcon: {
         color: tokens.colorPaletteGreenForeground1,
     },

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/EvaluationMetricExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/EvaluationMetricExtensions.cs
@@ -97,6 +97,6 @@ internal static class EvaluationMetricExtensions
     internal static void LogJsonData(this EvaluationMetric metric, JsonNode data)
     {
         string serializedData = data.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
-        metric.AddDiagnostic(EvaluationDiagnostic.Informational(serializedData));
+        metric.AddDiagnostics(EvaluationDiagnostic.Informational(serializedData));
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/GroundednessProEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/GroundednessProEvaluator.cs
@@ -63,6 +63,9 @@ public sealed class GroundednessProEvaluator()
                 contentSafetyServicePayloadFormat: ContentSafetyServicePayloadFormat.QuestionAnswer.ToString(),
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
+        GroundednessProEvaluatorContext context = GetRelevantContext(additionalContext);
+        result.AddOrUpdateContextInAllMetrics("Grounding Context", context.GetContents());
+
         return result;
     }
 
@@ -70,15 +73,20 @@ public sealed class GroundednessProEvaluator()
     protected override IReadOnlyList<EvaluationContext>? FilterAdditionalContext(
         IEnumerable<EvaluationContext>? additionalContext)
     {
+        GroundednessProEvaluatorContext context = GetRelevantContext(additionalContext);
+        return [context];
+    }
+
+    private static GroundednessProEvaluatorContext GetRelevantContext(
+        IEnumerable<EvaluationContext>? additionalContext)
+    {
         if (additionalContext?.OfType<GroundednessProEvaluatorContext>().FirstOrDefault()
                 is GroundednessProEvaluatorContext context)
         {
-            return [context];
+            return context;
         }
-        else
-        {
-            throw new InvalidOperationException(
-                $"A value of type '{nameof(GroundednessProEvaluatorContext)}' was not found in the '{nameof(additionalContext)}' collection.");
-        }
+
+        throw new InvalidOperationException(
+            $"A value of type '{nameof(GroundednessProEvaluatorContext)}' was not found in the '{nameof(additionalContext)}' collection.");
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/UngroundedAttributesEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/UngroundedAttributesEvaluator.cs
@@ -67,6 +67,9 @@ public sealed class UngroundedAttributesEvaluator()
                 contentSafetyServicePayloadFormat: ContentSafetyServicePayloadFormat.QueryResponse.ToString(),
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
+        UngroundedAttributesEvaluatorContext context = GetRelevantContext(additionalContext);
+        result.AddOrUpdateContextInAllMetrics("Grounding Context", context.GetContents());
+
         return result;
     }
 
@@ -74,15 +77,20 @@ public sealed class UngroundedAttributesEvaluator()
     protected override IReadOnlyList<EvaluationContext>? FilterAdditionalContext(
         IEnumerable<EvaluationContext>? additionalContext)
     {
+        UngroundedAttributesEvaluatorContext context = GetRelevantContext(additionalContext);
+        return [context];
+    }
+
+    private static UngroundedAttributesEvaluatorContext GetRelevantContext(
+        IEnumerable<EvaluationContext>? additionalContext)
+    {
         if (additionalContext?.OfType<UngroundedAttributesEvaluatorContext>().FirstOrDefault()
                 is UngroundedAttributesEvaluatorContext context)
         {
-            return [context];
+            return context;
         }
-        else
-        {
-            throw new InvalidOperationException(
-                $"A value of type '{nameof(UngroundedAttributesEvaluatorContext)}' was not found in the '{nameof(additionalContext)}' collection.");
-        }
+
+        throw new InvalidOperationException(
+            $"A value of type '{nameof(UngroundedAttributesEvaluatorContext)}' was not found in the '{nameof(additionalContext)}' collection.");
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation/CompositeEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation/CompositeEvaluator.cs
@@ -159,7 +159,7 @@ public sealed class CompositeEvaluator : IEvaluator
                 foreach (string metricName in e.EvaluationMetricNames)
                 {
                     var metric = new EvaluationMetric(metricName);
-                    metric.AddDiagnostic(EvaluationDiagnostic.Error(message));
+                    metric.AddDiagnostics(EvaluationDiagnostic.Error(message));
                     result.Metrics.Add(metric.Name, metric);
                 }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationMetric.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationMetric.cs
@@ -44,6 +44,20 @@ public class EvaluationMetric(string name, string? reason = null)
     public EvaluationMetricInterpretation? Interpretation { get; set; }
 
 #pragma warning disable CA2227
+    /// <summary>
+    /// Gets or sets any contextual information that was considered by the <see cref="IEvaluator"/> as part of the
+    /// evaluation that produced the current <see cref="EvaluationMetric"/>.
+    /// </summary>
+    /// <remarks>
+    /// Each entry in the returned dictionary has a name (key), and a collection of <see cref="AIContent"/> objects
+    /// (value). An <see cref="IEvaluator"/> can use this dictionary to record one or more
+    /// <see cref="EvaluationContext"/>s that it considred as part of the evaluation that produced this
+    /// <see cref="EvaluationMetric"/>. For example, it can do so by including an entry with a name for the considered
+    /// <see cref="EvaluationContext"/> as the key, and the <see cref="AIContent"/> objects returned from
+    /// <see cref="EvaluationContext.GetContents"/> as the value.
+    /// </remarks>
+    public IDictionary<string, IList<AIContent>>? Context { get; set; }
+
     // CA2227: Collection properties should be read only.
     // We disable this warning because we want this type to be fully mutable for serialization purposes and for general
     // convenience.

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationMetricExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationMetricExtensions.cs
@@ -14,6 +14,31 @@ namespace Microsoft.Extensions.AI.Evaluation;
 public static class EvaluationMetricExtensions
 {
     /// <summary>
+    /// Adds or updates contextual information with the specified <paramref name="name"/> and <paramref name="value"/>
+    /// in the supplied <paramref name="metric"/>'s <see cref="EvaluationMetric.Context"/> collection.
+    /// </summary>
+    /// <param name="metric">The <see cref="EvaluationMetric"/>.</param>
+    /// <param name="name">The name for the contextual information to be added or updated.</param>
+    /// <param name="value">The contextual information to be added or updated.</param>
+    public static void AddOrUpdateContext(this EvaluationMetric metric, string name, params AIContent[] value)
+        => metric.AddOrUpdateContext(name, value as IEnumerable<AIContent>);
+
+    /// <summary>
+    /// Adds or updates contextual information with the specified <paramref name="name"/> and <paramref name="value"/>
+    /// in the supplied <paramref name="metric"/>'s <see cref="EvaluationMetric.Context"/> collection.
+    /// </summary>
+    /// <param name="metric">The <see cref="EvaluationMetric"/>.</param>
+    /// <param name="name">The name for the contextual information to be added or updated.</param>
+    /// <param name="value">The contextual information to be added or updated.</param>
+    public static void AddOrUpdateContext(this EvaluationMetric metric, string name, IEnumerable<AIContent> value)
+    {
+        _ = Throw.IfNull(metric);
+
+        metric.Context ??= new Dictionary<string, IList<AIContent>>();
+        metric.Context[name] = [.. value];
+    }
+
+    /// <summary>
     /// Determines if the supplied <paramref name="metric"/> contains any
     /// <see cref="EvaluationDiagnostic"/> matching the supplied <paramref name="predicate"/>.
     /// </summary>
@@ -73,7 +98,7 @@ public static class EvaluationMetricExtensions
 
     /// <summary>
     /// Adds or updates metadata with the specified <paramref name="name"/> and <paramref name="value"/> in the
-    /// supplied <see cref="EvaluationMetric"/>'s <see cref="EvaluationMetric.Metadata"/> collection.
+    /// supplied <paramref name="metric"/>'s <see cref="EvaluationMetric.Metadata"/> collection.
     /// </summary>
     /// <param name="metric">The <see cref="EvaluationMetric"/>.</param>
     /// <param name="name">The name of the metadata.</param>
@@ -87,7 +112,7 @@ public static class EvaluationMetricExtensions
     }
 
     /// <summary>
-    /// Adds or updates the supplied <paramref name="metadata"/> to the supplied <see cref="EvaluationMetric"/>'s
+    /// Adds or updates the supplied <paramref name="metadata"/> in the supplied <paramref name="metric"/>'s
     /// <see cref="EvaluationMetric.Metadata"/> collection.
     /// </summary>
     /// <param name="metric">The <see cref="EvaluationMetric"/>.</param>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationMetricExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationMetricExtensions.cs
@@ -41,20 +41,6 @@ public static class EvaluationMetricExtensions
     }
 
     /// <summary>
-    /// Adds the supplied <see cref="EvaluationDiagnostic"/> to the supplied <see cref="EvaluationMetric"/>'s
-    /// <see cref="EvaluationMetric.Diagnostics"/> collection.
-    /// </summary>
-    /// <param name="metric">The <see cref="EvaluationMetric"/>.</param>
-    /// <param name="diagnostic">The <see cref="EvaluationDiagnostic"/> to be added.</param>
-    public static void AddDiagnostic(this EvaluationMetric metric, EvaluationDiagnostic diagnostic)
-    {
-        _ = Throw.IfNull(metric);
-
-        metric.Diagnostics ??= new List<EvaluationDiagnostic>();
-        metric.Diagnostics.Add(diagnostic);
-    }
-
-    /// <summary>
     /// Adds the supplied <see cref="EvaluationDiagnostic"/>s to the supplied <see cref="EvaluationMetric"/>'s
     /// <see cref="EvaluationMetric.Diagnostics"/> collection.
     /// </summary>
@@ -65,9 +51,14 @@ public static class EvaluationMetricExtensions
         _ = Throw.IfNull(metric);
         _ = Throw.IfNull(diagnostics);
 
-        foreach (EvaluationDiagnostic diagnostic in diagnostics)
+        if (diagnostics.Any())
         {
-            metric.AddDiagnostic(diagnostic);
+            metric.Diagnostics ??= new List<EvaluationDiagnostic>();
+
+            foreach (EvaluationDiagnostic diagnostic in diagnostics)
+            {
+                metric.Diagnostics.Add(diagnostic);
+            }
         }
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationResultExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationResultExtensions.cs
@@ -14,6 +14,43 @@ namespace Microsoft.Extensions.AI.Evaluation;
 public static class EvaluationResultExtensions
 {
     /// <summary>
+    /// Adds or updates contextual information with the specified <paramref name="name"/> and <paramref name="value"/>
+    /// in all <see cref="EvaluationMetric"/>s contained in the supplied <paramref name="result"/>.
+    /// </summary>
+    /// <param name="result">
+    /// The <see cref="EvaluationResult"/> containing the <see cref="EvaluationMetric"/>s that are to be altered.
+    /// </param>
+    /// <param name="name">The name for the contextual information to be added or updated.</param>
+    /// <param name="value">The contextual information to be added or updated.</param>
+    public static void AddOrUpdateContextInAllMetrics(
+        this EvaluationResult result,
+        string name,
+        params AIContent[] value)
+            => result.AddOrUpdateContextInAllMetrics(name, value as IEnumerable<AIContent>);
+
+    /// <summary>
+    /// Adds or updates contextual information with the specified <paramref name="name"/> and <paramref name="value"/>
+    /// in all <see cref="EvaluationMetric"/>s contained in the supplied <paramref name="result"/>.
+    /// </summary>
+    /// <param name="result">
+    /// The <see cref="EvaluationResult"/> containing the <see cref="EvaluationMetric"/>s that are to be altered.
+    /// </param>
+    /// <param name="name">The name for the contextual information to be added or updated.</param>
+    /// <param name="value">The contextual information to be added or updated.</param>
+    public static void AddOrUpdateContextInAllMetrics(
+        this EvaluationResult result,
+        string name,
+        IEnumerable<AIContent> value)
+    {
+        _ = Throw.IfNull(result);
+
+        foreach (EvaluationMetric metric in result.Metrics.Values)
+        {
+            metric.AddOrUpdateContext(name, value);
+        }
+    }
+
+    /// <summary>
     /// Adds the supplied <paramref name="diagnostics"/> to all <see cref="EvaluationMetric"/>s contained in the
     /// supplied <paramref name="result"/>.
     /// </summary>
@@ -90,6 +127,45 @@ public static class EvaluationResultExtensions
             {
                 metric.Interpretation = interpretation;
             }
+        }
+    }
+
+    /// <summary>
+    /// Adds or updates metadata with the specified <paramref name="name"/> and <paramref name="value"/> in all
+    /// <see cref="EvaluationMetric"/>s contained in the supplied <paramref name="result"/>.
+    /// </summary>
+    /// <param name="result">
+    /// The <see cref="EvaluationResult"/> containing the <see cref="EvaluationMetric"/>s that are to be altered.
+    /// </param>
+    /// <param name="name">The name of the metadata.</param>
+    /// <param name="value">The value of the metadata.</param>
+    public static void AddOrUpdateMetadataInAllMetrics(this EvaluationResult result, string name, string value)
+    {
+        _ = Throw.IfNull(result);
+
+        foreach (EvaluationMetric metric in result.Metrics.Values)
+        {
+            metric.AddOrUpdateMetadata(name, value);
+        }
+    }
+
+    /// <summary>
+    /// Adds or updates the supplied <paramref name="metadata"/> in all <see cref="EvaluationMetric"/>s contained in
+    /// the supplied <paramref name="result"/>.
+    /// </summary>
+    /// <param name="result">
+    /// The <see cref="EvaluationResult"/> containing the <see cref="EvaluationMetric"/>s that are to be altered.
+    /// </param>
+    /// <param name="metadata">The metadata to be added or updated.</param>
+    public static void AddOrUpdateMetadataInAllMetrics(
+        this EvaluationResult result,
+        IDictionary<string, string> metadata)
+    {
+        _ = Throw.IfNull(result);
+
+        foreach (EvaluationMetric metric in result.Metrics.Values)
+        {
+            metric.AddOrUpdateMetadata(metadata);
         }
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationResultExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationResultExtensions.cs
@@ -14,24 +14,6 @@ namespace Microsoft.Extensions.AI.Evaluation;
 public static class EvaluationResultExtensions
 {
     /// <summary>
-    /// Adds the supplied <paramref name="diagnostic"/> to all <see cref="EvaluationMetric"/>s contained in the
-    /// supplied <paramref name="result"/>.
-    /// </summary>
-    /// <param name="result">
-    /// The <see cref="EvaluationResult"/> containing the <see cref="EvaluationMetric"/>s that are to be altered.
-    /// </param>
-    /// <param name="diagnostic">The <see cref="EvaluationDiagnostic"/> that is to be added.</param>
-    public static void AddDiagnosticToAllMetrics(this EvaluationResult result, EvaluationDiagnostic diagnostic)
-    {
-        _ = Throw.IfNull(result);
-
-        foreach (EvaluationMetric metric in result.Metrics.Values)
-        {
-            metric.AddDiagnostic(diagnostic);
-        }
-    }
-
-    /// <summary>
     /// Adds the supplied <paramref name="diagnostics"/> to all <see cref="EvaluationMetric"/>s contained in the
     /// supplied <paramref name="result"/>.
     /// </summary>

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/ResultsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/ResultsTests.cs
@@ -419,32 +419,32 @@ public class ResultsTests
         ReportingConfiguration reportingConfiguration = CreateReportingConfiguration(evaluator);
 
         var metric1 = new BooleanMetric("Metric with all diagnostic severities");
-        metric1.AddDiagnostic(EvaluationDiagnostic.Error("Error 1"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Error("Error 2"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 1"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 1"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 2"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Error("Error 1"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Error("Error 2"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 1"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 1"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 2"));
         metric1.Reason = "Reason for metric 1";
 
         var metric2 = new BooleanMetric("Metric with warning and informational diagnostics");
-        metric2.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 1"));
-        metric2.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 2"));
-        metric2.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 2"));
+        metric2.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 1"));
+        metric2.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 2"));
+        metric2.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 2"));
         metric2.Reason = "Reason for metric 2";
 
         var metric3 = new EvaluationMetric("Metric with error diagnostics only");
-        metric3.AddDiagnostic(EvaluationDiagnostic.Error("Error 1"));
-        metric3.AddDiagnostic(EvaluationDiagnostic.Error("Error 2"));
+        metric3.AddDiagnostics(EvaluationDiagnostic.Error("Error 1"));
+        metric3.AddDiagnostics(EvaluationDiagnostic.Error("Error 2"));
         metric3.Reason = "Reason for metric 3";
 
         HashSet<string> allowedValues = ["A", "B", "C"];
         var metric4 = new StringMetric("Metric with warning diagnostics only");
-        metric4.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 1"));
-        metric4.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 2"));
+        metric4.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 1"));
+        metric4.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 2"));
         metric4.Reason = "Reason for metric 4";
 
         var metric5 = new NumericMetric("Metric with informational diagnostics only");
-        metric5.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 1"));
+        metric5.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 1"));
         metric5.Reason = "Reason for metric 5";
 
         evaluator.TestMetrics = [metric1, metric2, metric3, metric4, metric5];
@@ -472,32 +472,32 @@ public class ResultsTests
         ReportingConfiguration reportingConfiguration = CreateReportingConfiguration(evaluator);
 
         var metric1 = new BooleanMetric("Metric with all diagnostic severities");
-        metric1.AddDiagnostic(EvaluationDiagnostic.Error("Error 1"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Error("Error 2"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 1"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 1"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 2"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Error("Error 1"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Error("Error 2"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 1"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 1"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 2"));
         metric1.Reason = "Reason for metric 1";
 
         var metric2 = new BooleanMetric("Metric with warning and informational diagnostics");
-        metric2.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 1"));
-        metric2.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 2"));
-        metric2.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 2"));
+        metric2.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 1"));
+        metric2.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 2"));
+        metric2.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 2"));
         metric2.Reason = "Reason for metric 2";
 
         var metric3 = new EvaluationMetric("Metric with error diagnostics only");
-        metric3.AddDiagnostic(EvaluationDiagnostic.Error("Error 1"));
-        metric3.AddDiagnostic(EvaluationDiagnostic.Error("Error 2"));
+        metric3.AddDiagnostics(EvaluationDiagnostic.Error("Error 1"));
+        metric3.AddDiagnostics(EvaluationDiagnostic.Error("Error 2"));
         metric3.Reason = "Reason for metric 3";
 
         HashSet<string> allowedValues = ["A", "B", "C"];
         var metric4 = new StringMetric("Metric with warning diagnostics only");
-        metric4.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 1"));
-        metric4.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 2"));
+        metric4.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 1"));
+        metric4.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 2"));
         metric4.Reason = "Reason for metric 4";
 
         var metric5 = new NumericMetric("Metric with informational diagnostics only");
-        metric5.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 1"));
+        metric5.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 1"));
         metric5.Reason = "Reason for metric 5";
 
         evaluator.TestMetrics = [metric1, metric2, metric3, metric4, metric5];
@@ -531,32 +531,32 @@ public class ResultsTests
         ReportingConfiguration reportingConfiguration = CreateReportingConfiguration(evaluator);
 
         var metric1 = new BooleanMetric("Metric with all diagnostic severities", value: true);
-        metric1.AddDiagnostic(EvaluationDiagnostic.Error("Error 1"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Error("Error 2"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 1"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 1"));
-        metric1.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 2"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Error("Error 1"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Error("Error 2"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 1"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 1"));
+        metric1.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 2"));
         metric1.Reason = "Reason for metric 1";
 
         var metric2 = new BooleanMetric("Metric with warning and informational diagnostics", value: true);
-        metric2.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 1"));
-        metric2.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 2"));
-        metric2.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 2"));
+        metric2.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 1"));
+        metric2.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 2"));
+        metric2.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 2"));
         metric2.Reason = "Reason for metric 2";
 
         var metric3 = new NumericMetric("Metric with error diagnostics only", value: 5);
-        metric3.AddDiagnostic(EvaluationDiagnostic.Error("Error 1"));
-        metric3.AddDiagnostic(EvaluationDiagnostic.Error("Error 2"));
+        metric3.AddDiagnostics(EvaluationDiagnostic.Error("Error 1"));
+        metric3.AddDiagnostics(EvaluationDiagnostic.Error("Error 2"));
         metric3.Reason = "Reason for metric 3";
 
         HashSet<string> allowedValues = ["A", "B", "C"];
         var metric4 = new StringMetric("Metric with warning diagnostics only", value: "A");
-        metric4.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 1"));
-        metric4.AddDiagnostic(EvaluationDiagnostic.Warning("Warning 2"));
+        metric4.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 1"));
+        metric4.AddDiagnostics(EvaluationDiagnostic.Warning("Warning 2"));
         metric4.Reason = "Reason for metric 4";
 
         var metric5 = new NumericMetric("Metric with informational diagnostics only", value: 4);
-        metric5.AddDiagnostic(EvaluationDiagnostic.Informational("Informational 1"));
+        metric5.AddDiagnostics(EvaluationDiagnostic.Informational("Informational 1"));
         metric5.Reason = "Reason for metric 5";
 
         evaluator.TestMetrics = [metric1, metric2, metric3, metric4, metric5];

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ResultStoreTester.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ResultStoreTester.cs
@@ -22,7 +22,7 @@ public abstract class ResultStoreTester
         BooleanMetric booleanMetric = new BooleanMetric("boolean", value: true);
 
         NumericMetric numericMetric = new NumericMetric("numeric", value: 3);
-        numericMetric.AddDiagnostic(EvaluationDiagnostic.Informational("Informational Message"));
+        numericMetric.AddDiagnostics(EvaluationDiagnostic.Informational("Informational Message"));
 
         StringMetric stringMetric = new StringMetric("string", value: "Good");
 

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ScenarioRunResultTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ScenarioRunResultTests.cs
@@ -18,17 +18,17 @@ public class ScenarioRunResultTests
     public void SerializeScenarioRunResult()
     {
         var booleanMetric = new BooleanMetric("boolean", value: true);
-        booleanMetric.AddDiagnostic(EvaluationDiagnostic.Error("error"));
-        booleanMetric.AddDiagnostic(EvaluationDiagnostic.Warning("warning"));
+        booleanMetric.AddDiagnostics(EvaluationDiagnostic.Error("error"));
+        booleanMetric.AddDiagnostics(EvaluationDiagnostic.Warning("warning"));
 
         var numericMetric = new NumericMetric("numeric", value: 3);
-        numericMetric.AddDiagnostic(EvaluationDiagnostic.Informational("info"));
+        numericMetric.AddDiagnostics(EvaluationDiagnostic.Informational("info"));
 
         var stringMetric = new StringMetric("string", value: "A");
 
         var metricWithNoValue = new EvaluationMetric("none");
-        metricWithNoValue.AddDiagnostic(EvaluationDiagnostic.Error("error"));
-        metricWithNoValue.AddDiagnostic(EvaluationDiagnostic.Informational("info"));
+        metricWithNoValue.AddDiagnostics(EvaluationDiagnostic.Error("error"));
+        metricWithNoValue.AddDiagnostics(EvaluationDiagnostic.Informational("info"));
 
         var turn1 =
             new ChatTurnDetails(
@@ -82,17 +82,17 @@ public class ScenarioRunResultTests
     public void SerializeDatasetCompact()
     {
         var booleanMetric = new BooleanMetric("boolean", value: true);
-        booleanMetric.AddDiagnostic(EvaluationDiagnostic.Error("error"));
-        booleanMetric.AddDiagnostic(EvaluationDiagnostic.Warning("warning"));
+        booleanMetric.AddDiagnostics(EvaluationDiagnostic.Error("error"));
+        booleanMetric.AddDiagnostics(EvaluationDiagnostic.Warning("warning"));
 
         var numericMetric = new NumericMetric("numeric", value: 3);
-        numericMetric.AddDiagnostic(EvaluationDiagnostic.Informational("info"));
+        numericMetric.AddDiagnostics(EvaluationDiagnostic.Informational("info"));
 
         var stringMetric = new StringMetric("string", value: "A");
 
         var metricWithNoValue = new EvaluationMetric("none");
-        metricWithNoValue.AddDiagnostic(EvaluationDiagnostic.Error("error"));
-        metricWithNoValue.AddDiagnostic(EvaluationDiagnostic.Informational("info"));
+        metricWithNoValue.AddDiagnostics(EvaluationDiagnostic.Error("error"));
+        metricWithNoValue.AddDiagnostics(EvaluationDiagnostic.Informational("info"));
 
         var turn1 =
             new ChatTurnDetails(


### PR DESCRIPTION
This allows evaluators to record contextual information that was used in the evaluation which can then be displayed in the evaluation report as depicted in the below screenshot. This PR also updates all evaluators that rely on contextual information and that ship as part of the Quality and Safety packages (i.e., `GroundednessEvaluator`, `EquivalenceEvaluator`, `GroundednessProEvaluator` and `UngroundedAttributesEvaluator`) to include contextual information as part of the `EvaluationMetric`s they produce.

![image](https://github.com/user-attachments/assets/243f8cc6-93ee-4f6c-8ea6-10e82929db16)

Also includes some cleanup for extension methods as part of public API stabilization.
- Removes extension methods for adding a single diagnostic in favor of overloads that take a `params` array which can be called in the same way.

Fixes #6033 