### PR TITLE
Fix Process Metric calculation in CgroupsV2

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -163,7 +163,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         {
             _cpuUtilizationLimit100PercentExceededCounter?.Add(1);
             _cpuUtilizationLimit100PercentExceeded++;
-            Log.CounterMessage(_logger, $"CPU utilization exceeded 100%: {utilization}, Value: {_cpuUtilizationLimit100PercentExceeded}");
+            Log.CounterMessage100(_logger, _cpuUtilizationLimit100PercentExceeded);
         }
 
         // Increment counter if utilization exceeds 110%
@@ -171,7 +171,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         {
             _cpuUtilizationLimit110PercentExceededCounter?.Add(1);
             _cpuUtilizationLimit110PercentExceeded++;
-            Log.CounterMessage(_logger, $"CPU utilization exceeded 110%: {utilization}, Value: {_cpuUtilizationLimit110PercentExceeded}");
+            Log.CounterMessage110(_logger, _cpuUtilizationLimit110PercentExceeded);
         }
 
         return utilization;

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -79,7 +79,6 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
             cpuRequest = _parser.GetCgroupRequestCpuV2();
             _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuLimitUtilization, observeValue: () => CpuUtilizationWithoutHostDelta() / cpuLimit, unit: "1");
             _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuRequestUtilization, observeValue: () => CpuUtilizationWithoutHostDelta() / cpuRequest, unit: "1");
-            _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: () => CpuUtilizationWithoutHostDelta() / cpuRequest, unit: "1");
         }
         else
         {

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -79,15 +79,16 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
             cpuRequest = _parser.GetCgroupRequestCpuV2();
             _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuLimitUtilization, observeValue: () => CpuUtilizationWithoutHostDelta() / cpuLimit, unit: "1");
             _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuRequestUtilization, observeValue: () => CpuUtilizationWithoutHostDelta() / cpuRequest, unit: "1");
+            _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: () => CpuUtilizationWithoutHostDelta() / cpuRequest, unit: "1");
         }
         else
         {
             _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuLimitUtilization, observeValue: () => CpuUtilization() * _scaleRelativeToCpuLimit, unit: "1");
             _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuRequestUtilization, observeValue: () => CpuUtilization() * _scaleRelativeToCpuRequest, unit: "1");
+            _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: () => CpuUtilization() * _scaleRelativeToCpuRequest, unit: "1");
         }
 
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerMemoryLimitUtilization, observeValue: MemoryUtilization, unit: "1");
-        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: () => CpuUtilization() * _scaleRelativeToCpuRequest, unit: "1");
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessMemoryUtilization, observeValue: MemoryUtilization, unit: "1");
 
         // cpuRequest is a CPU request (aka guaranteed number of CPU units) for pod, for host its 1 core

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
@@ -44,4 +44,11 @@ internal static partial class Log
         long previousCgroupCpuTime,
         double actualElapsedNanoseconds,
         double cpuCores);
+
+    [LoggerMessage(5, LogLevel.Debug,
+        "Counters for CgroupV2 {message}, Counter = {counterValue}")]
+    public static partial void CounterMessage(
+        ILogger logger,
+        string message,
+        long counterValue);
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
@@ -46,8 +46,14 @@ internal static partial class Log
         double cpuCores);
 
     [LoggerMessage(5, LogLevel.Debug,
-        "Counters for CgroupV2 {message}")]
-    public static partial void CounterMessage(
+        "CPU utilization exceeded 100%: Counter = {counterValue}")]
+    public static partial void CounterMessage100(
         ILogger logger,
-        string message);
+        long counterValue);
+
+    [LoggerMessage(6, LogLevel.Debug,
+        "CPU utilization exceeded 110%: Counter = {counterValue}")]
+    public static partial void CounterMessage110(
+        ILogger logger,
+        long counterValue);
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
@@ -46,9 +46,8 @@ internal static partial class Log
         double cpuCores);
 
     [LoggerMessage(5, LogLevel.Debug,
-        "Counters for CgroupV2 {message}, Counter = {counterValue}")]
+        "Counters for CgroupV2 {message}")]
     public static partial void CounterMessage(
         ILogger logger,
-        string message,
-        long counterValue);
+        string message);
 }

--- a/src/Shared/Instruments/ResourceUtilizationInstruments.cs
+++ b/src/Shared/Instruments/ResourceUtilizationInstruments.cs
@@ -65,6 +65,22 @@ internal static class ResourceUtilizationInstruments
     /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableUpDownCounter{T}"/>.
     /// </remarks>
     public const string SystemNetworkConnections = "system.network.connections";
+
+    /// <summary>
+    /// The name of an instrument to count occurrences when CPU utilization exceeds 100% of the limit.
+    /// </summary>
+    /// <remarks>
+    /// The type of an instrument is <see cref="System.Diagnostics.Metrics.Counter{T}"/>.
+    /// </remarks>
+    public const string CpuUtilizationLimit100PercentExceeded = "cpu.utilization.limit.100percent.exceeded";
+
+    /// <summary>
+    /// The name of an instrument to count occurrences when CPU utilization exceeds 110% of the limit.
+    /// </summary>
+    /// <remarks>
+    /// The type of an instrument is <see cref="System.Diagnostics.Metrics.Counter{T}"/>.
+    /// </remarks>
+    public const string CpuUtilizationLimit110PercentExceeded = "cpu.utilization.limit.110percent.exceeded";
 }
 
 #pragma warning disable CS1574

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
@@ -258,7 +258,7 @@ public sealed class LinuxUtilizationProviderTests
         listener.Start();
         listener.RecordObservableInstruments();
 
-        Assert.Equal(5, samples.Count);
+        Assert.Equal(4, samples.Count);
 
         Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ContainerCpuLimitUtilization);
         Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ContainerCpuLimitUtilization).value));
@@ -268,9 +268,6 @@ public sealed class LinuxUtilizationProviderTests
 
         Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ContainerMemoryLimitUtilization);
         Assert.Equal(1, samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ContainerMemoryLimitUtilization).value);
-
-        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization);
-        Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization).value));
 
         Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessMemoryUtilization);
         Assert.Equal(1, samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessMemoryUtilization).value);


### PR DESCRIPTION
Missed updating the process metric in first check-in. Updating the same to use correct calculations behind the flag, and to ensure CpuUtilization() is not invoked at all.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6321)