### PR TITLE
Remove AsChatClient/AsEmbeddingGenerator APIs

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIClientExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIClientExtensions.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Shared.Diagnostics;
 using OpenAI;
 using OpenAI.Audio;
 using OpenAI.Chat;
@@ -16,15 +13,6 @@ namespace Microsoft.Extensions.AI;
 /// <summary>Provides extension methods for working with <see cref="OpenAIClient"/>s.</summary>
 public static class OpenAIClientExtensions
 {
-    /// <summary>Gets an <see cref="IChatClient"/> for use with this <see cref="OpenAIClient"/>.</summary>
-    /// <param name="openAIClient">The client.</param>
-    /// <param name="modelId">The model.</param>
-    /// <returns>An <see cref="IChatClient"/> that can be used to converse via the <see cref="OpenAIClient"/>.</returns>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This method will be removed in an upcoming release.")]
-    public static IChatClient AsChatClient(this OpenAIClient openAIClient, string modelId) =>
-        new OpenAIChatClient(Throw.IfNull(openAIClient).GetChatClient(modelId));
-
     /// <summary>Gets an <see cref="IChatClient"/> for use with this <see cref="ChatClient"/>.</summary>
     /// <param name="chatClient">The client.</param>
     /// <returns>An <see cref="IChatClient"/> that can be used to converse via the <see cref="ChatClient"/>.</returns>
@@ -43,16 +31,6 @@ public static class OpenAIClientExtensions
     [Experimental("MEAI001")]
     public static ISpeechToTextClient AsISpeechToTextClient(this AudioClient audioClient) =>
         new OpenAISpeechToTextClient(audioClient);
-
-    /// <summary>Gets an <see cref="IEmbeddingGenerator{String, Single}"/> for use with this <see cref="OpenAIClient"/>.</summary>
-    /// <param name="openAIClient">The client.</param>
-    /// <param name="modelId">The model to use.</param>
-    /// <param name="dimensions">The number of dimensions to generate in each embedding.</param>
-    /// <returns>An <see cref="IEmbeddingGenerator{String, Embedding}"/> that can be used to generate embeddings via the <see cref="EmbeddingClient"/>.</returns>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This method will be removed in an upcoming release.")]
-    public static IEmbeddingGenerator<string, Embedding<float>> AsEmbeddingGenerator(this OpenAIClient openAIClient, string modelId, int? dimensions = null) =>
-        new OpenAIEmbeddingGenerator(Throw.IfNull(openAIClient).GetEmbeddingClient(modelId), dimensions);
 
     /// <summary>Gets an <see cref="IEmbeddingGenerator{String, Single}"/> for use with this <see cref="EmbeddingClient"/>.</summary>
     /// <param name="embeddingClient">The client.</param>


### PR DESCRIPTION
These methods were marked as obsolete in [Remove non-AsXx surface area from M.E.AI.OpenAI/AzureAIInference (#6138)](https://github.com/dotnet/extensions/pull/6138/files#diff-cafca5cb037f3a61fd2013d87230747c733a131b08bf79d147c3112af5b15769). That change was included in 9.4.0-preview.1.25207.5. Since they were released as obsolete for a preview version already, we can proceed with deleting them.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6327)