### PR TITLE
Allow outer IChatClient middleware like OTel to expose features to inner middleware

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -80,6 +80,10 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>f57e6dc747158ab7ade4e62a75a6750d16b771e8</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Extensions.Features" Version="9.0.4" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
+      <Sha>f57e6dc747158ab7ade4e62a75a6750d16b771e8</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.4" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>f57e6dc747158ab7ade4e62a75a6750d16b771e8</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,6 +45,7 @@
     <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>9.0.4</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>9.0.4</MicrosoftExtensionsDependencyInjectionVersion>
     <MicrosoftExtensionsDiagnosticsVersion>9.0.4</MicrosoftExtensionsDiagnosticsVersion>
+    <MicrosoftExtensionsFeaturesVersion>9.0.4</MicrosoftExtensionsFeaturesVersion>
     <MicrosoftExtensionsHostingAbstractionsVersion>9.0.4</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsHostingVersion>9.0.4</MicrosoftExtensionsHostingVersion>
     <MicrosoftExtensionsHttpVersion>9.0.4</MicrosoftExtensionsHttpVersion>
@@ -99,6 +100,7 @@
     <MicrosoftExtensionsDependencyInjectionAbstractionsLTSVersion>8.0.2</MicrosoftExtensionsDependencyInjectionAbstractionsLTSVersion>
     <MicrosoftExtensionsDependencyInjectionLTSVersion>8.0.1</MicrosoftExtensionsDependencyInjectionLTSVersion>
     <MicrosoftExtensionsDiagnosticsLTSVersion>8.0.1</MicrosoftExtensionsDiagnosticsLTSVersion>
+    <MicrosoftExtensionsFeaturesLTSVersion>8.0.1</MicrosoftExtensionsFeaturesLTSVersion>
     <MicrosoftExtensionsHostingAbstractionsLTSVersion>8.0.1</MicrosoftExtensionsHostingAbstractionsLTSVersion>
     <MicrosoftExtensionsHostingLTSVersion>8.0.1</MicrosoftExtensionsHostingLTSVersion>
     <MicrosoftExtensionsHttpLTSVersion>8.0.1</MicrosoftExtensionsHttpLTSVersion>

--- a/eng/packages/General-LTS.props
+++ b/eng/packages/General-LTS.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionLTSVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="$(MicrosoftExtensionsDiagnosticsLTSVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksLTSVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Features" Version="$(MicrosoftExtensionsFeaturesLTSVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsLTSVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingLTSVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="$(MicrosoftExtensionsHttpPollyLTSVersion)" />

--- a/eng/packages/General-net9.props
+++ b/eng/packages/General-net9.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="$(MicrosoftExtensionsDiagnosticsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Features" Version="$(MicrosoftExtensionsFeaturesVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="$(MicrosoftExtensionsHttpPollyVersion)" />

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Shared.Diagnostics;
@@ -71,11 +72,12 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
     /// <param name="innerClient">The underlying <see cref="IChatClient"/>, or the next instance in a chain of clients.</param>
     /// <param name="loggerFactory">An <see cref="ILoggerFactory"/> to use for logging information about function invocation.</param>
     /// <param name="functionInvocationServices">An optional <see cref="IServiceProvider"/> to use for resolving services required by the <see cref="AIFunction"/> instances being invoked.</param>
-    public FunctionInvokingChatClient(IChatClient innerClient, ILoggerFactory? loggerFactory = null, IServiceProvider? functionInvocationServices = null)
+    /// <param name="features">An <see cref="IFeatureCollection"/> for acquiring the <see cref="ActivitySource"/> possibly set by earlier <see cref="OpenTelemetryChatClient"/> middleware.</param>
+    public FunctionInvokingChatClient(IChatClient innerClient, ILoggerFactory? loggerFactory = null, IServiceProvider? functionInvocationServices = null, IFeatureCollection? features = null)
         : base(innerClient)
     {
         _logger = (ILogger?)loggerFactory?.CreateLogger<FunctionInvokingChatClient>() ?? NullLogger.Instance;
-        _activitySource = innerClient.GetService<ActivitySource>();
+        _activitySource = features?.Get<ActivitySource>();
         _functionInvocationServices = functionInvocationServices;
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClientBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClientBuilderExtensions.cs
@@ -29,13 +29,16 @@ public static class FunctionInvokingChatClientBuilderExtensions
     {
         _ = Throw.IfNull(builder);
 
-        return builder.Use((innerClient, services) =>
+        return builder.Use((innerClientFactory, services) =>
         {
             loggerFactory ??= services.GetService<ILoggerFactory>();
 
-            var chatClient = new FunctionInvokingChatClient(innerClient, loggerFactory, services);
-            configure?.Invoke(chatClient);
-            return chatClient;
+            return features =>
+            {
+                var chatClient = new FunctionInvokingChatClient(innerClientFactory(features), loggerFactory, services, features);
+                configure?.Invoke(chatClient);
+                return chatClient;
+            };
         });
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGeneratorBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGeneratorBuilderExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Shared.Diagnostics;
@@ -31,15 +33,21 @@ public static class OpenTelemetryEmbeddingGeneratorBuilderExtensions
         string? sourceName = null,
         Action<OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>>? configure = null)
         where TEmbedding : Embedding =>
-        Throw.IfNull(builder).Use((innerGenerator, services) =>
+        Throw.IfNull(builder).Use((innerGeneratorFactory, services) =>
         {
             loggerFactory ??= services.GetService<ILoggerFactory>();
 
-            var generator = new OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>(
-                innerGenerator,
-                loggerFactory?.CreateLogger(typeof(OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>)),
-                sourceName);
-            configure?.Invoke(generator);
-            return generator;
+            return features =>
+            {
+                ActivitySource activitySource = new(OpenTelemetryChatClient.GetSourceNameOrDefault(sourceName));
+                features.Set(activitySource);
+
+                var generator = new OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>(
+                    innerGeneratorFactory(features),
+                    loggerFactory?.CreateLogger(typeof(OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>)),
+                    activitySource);
+                configure?.Invoke(generator);
+                return generator;
+            };
         });
 }

--- a/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Features" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Threading.Channels" />

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientBuilderTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientBuilderTest.cs
@@ -75,7 +75,7 @@ public class ChatClientBuilderTest
         ChatClientBuilder builder = new(innerClient);
         builder.Use(_ => null!);
         var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
-        Assert.Contains("entry at index 0", ex.Message);
+        Assert.Contains("middleware pipeline returned null", ex.Message);
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class ChatClientBuilderTest
     {
         using var innerClient = new TestChatClient();
         ChatClientBuilder builder = new(innerClient);
-        builder.Use((innerClient, serviceProvider) =>
+        builder.Use((IChatClient innerClient, IServiceProvider serviceProvider) =>
         {
             Assert.Null(serviceProvider.GetService(typeof(object)));
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/EmbeddingGeneratorBuilderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/EmbeddingGeneratorBuilderTests.cs
@@ -75,7 +75,7 @@ public class EmbeddingGeneratorBuilderTests
         var builder = innerGenerator.AsBuilder();
         builder.Use(_ => null!);
         var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
-        Assert.Contains("entry at index 0", ex.Message);
+        Assert.Contains("middleware pipeline returned null", ex.Message);
     }
 
     private sealed class InnerServiceCapturingEmbeddingGenerator(string name, IEmbeddingGenerator<string, Embedding<float>> innerGenerator) :


### PR DESCRIPTION
I've already talked a bit to @BrennanConroy, @MackinnonBuck, @stephentoub and @SteveSandersonMS about how the current IChatClient middleware is a bit awkward because there's no good way for outer middleware like UseOpenTelemetry to expose features like ActivitySource to inner middleware like UseFunctionInvocation. Today, it uses IChatClient.GetService to expose the ActivitySource, but that only works for middleware wrapping the OTel middleware, not the inner middleware the OTel middleware is tracking. And the natural place to add the OTel middleware is at the very beginning of the middleware pipeline so it can time and track the complete progress of overall middleware pipeline.

Developers might also want to add the OTel middleware underneath other middleware to observe things like function-invocation that might otherwise be hidden to the outer-layers of the middleware pipeline, but that's something that would usually be done in addition to rather than instead of the overall tracking of the middleware pipeline. 

And now that the OTel middleware exposes the ActivitySource to the inner pipeline, it could be used to track internal activities without necessarily be forced to reapply the OTel middleware between each layer. The function-invoking middleware was already doing effectively this but for the opposite reason. It was trying to work in scenarios where the function-invoking middleware wrapped the OTel middleware which was awkward. But now, that very same logic can be used to track internal calls.

And because of the two-phase approach of first building the client factory instead of directly creating the client with the middleware pipeline, we can make the ActivitySource feature available to both inner and outer middleware if we choose to. This is how we can now get rid of the GetService-wrapping to expose the ActivitySource, and still make it available to any outer function-invoking middleware while it's being constructed.

This does add a Microsoft.Extensions.Features dependency to Microsoft.Extensions.AI, but makes no changes to the core IChatClient interface or any other type in Microsoft.Extensions.AI.Abstractions. I think it's minimally invasive to existing code while giving us the functionality we desire. We also don't have to use IFeatureCollection to go with this approach. We could also use a plain `Dictionary<Type, object>` if we desire.

You'll notice that in the FunctionInvocationTrackedWithActivity we now captures an extra event because we can more conveniently wrap the OTel middleware both underneath and around the function-invoking middleware. But if we stuck to only putting the OTel middleware after the function-invoking middleware, we wouldn't have had to change the test.

```csharp
Func<ChatClientBuilder, ChatClientBuilder> configure = b =>
    b.UseOpenTelemetry(sourceName: sourceName).UseFunctionInvocation().UseOpenTelemetry(sourceName: sourceName);
```

Thanks @BrennanConroy for pointing me to how unintuitive it was that [adding UseOpenTelemetry() to the beginning of the pipeline didn't fully work here](https://github.com/ReubenBond/AccedeConcierge/blob/cafd824db85ddf74ec39b6fb6429d66a2d6497a6/src/System.Distributed.AI.Agents/Utilities/ChatClientExtensions.cs#L102-L107), and instead it had to be added later in the pipeline.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6334)