### PR TITLE
Using nr_periods from cpu.stat to get time elapsed

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/ILinuxUtilizationParser.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/ILinuxUtilizationParser.cs
@@ -28,7 +28,7 @@ internal interface ILinuxUtilizationParser
     /// It provides statistics about the CPU usage of a cgroup from its actual slice.
     /// </summary>
     /// <returns>nanoseconds.</returns>
-    long GetCgroupCpuUsageInNanosecondsV2();
+    (long cpuUsageNanoseconds, long elapsedPeriods) GetCgroupCpuUsageInNanosecondsAndCpuPeriodsV2();
 
     /// <summary>
     /// Reads the file /sys/fs/cgroup/cpu.max, which is part of the cgroup v2 CPU controller.
@@ -89,4 +89,10 @@ internal interface ILinuxUtilizationParser
     /// </summary>
     /// <returns>cpuPodRequest.</returns>
     float GetCgroupRequestCpuV2();
+
+    /// <summary>
+    /// For CgroupV2 only and experimental. Reads the CPU period interval in microseconds from cpu.max based on /proc/self/cgroup.
+    /// </summary>
+    /// <returns>The number of CPU periods.</returns>
+    long GetCgroupPeriodsIntervalInMicroSecondsV2();
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV1.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV1.cs
@@ -97,6 +97,8 @@ internal sealed class LinuxUtilizationParserCgroupV1 : ILinuxUtilizationParser
     public float GetCgroupLimitV2() => throw new NotSupportedException();
     public float GetCgroupRequestCpuV2() => throw new NotSupportedException();
     public long GetCgroupCpuUsageInNanosecondsV2() => throw new NotSupportedException();
+    public (long cpuUsageNanoseconds, long elapsedPeriods) GetCgroupCpuUsageInNanosecondsAndCpuPeriodsV2() => throw new NotSupportedException();
+    public long GetCgroupPeriodsIntervalInMicroSecondsV2() => throw new NotSupportedException();
 
     public long GetCgroupCpuUsageInNanoseconds()
     {

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
@@ -162,7 +162,7 @@ public sealed class AcceptanceTest
             .AddSingleton<IFileSystem>(new HardcodedValueFileSystem(new Dictionary<FileInfo, string>
             {
                 { new FileInfo("/proc/stat"), "cpu  10 10 10 10 10 10 10 10 10 10"},
-                { new FileInfo("/sys/fs/cgroup/cpu.stat"), "usage_usec 102312"},
+                { new FileInfo("/sys/fs/cgroup/cpu.stat"), "usage_usec 102312\nnr_periods 50"},
                 { new FileInfo("/proc/meminfo"), "MemTotal: 102312 kB"},
                 { new FileInfo("/sys/fs/cgroup/cpuset.cpus.effective"), "0-1"},
                 { new FileInfo("/sys/fs/cgroup/cpu.max"), "20000 100000"},
@@ -282,7 +282,7 @@ public sealed class AcceptanceTest
         var fileSystem = new HardcodedValueFileSystem(new Dictionary<FileInfo, string>
         {
             { new FileInfo("/proc/stat"), "cpu  10 10 10 10 10 10 10 10 10 10"},
-            { new FileInfo("/sys/fs/cgroup/cpu.stat"), "usage_usec 102"},
+            { new FileInfo("/sys/fs/cgroup/cpu.stat"), "usage_usec 102\nnr_periods 50"},
             { new FileInfo("/sys/fs/cgroup/memory.max"), "1048576" },
             { new FileInfo("/proc/meminfo"), "MemTotal: 1024 kB"},
             { new FileInfo("/sys/fs/cgroup/cpuset.cpus.effective"), "0-19"},
@@ -335,7 +335,7 @@ public sealed class AcceptanceTest
         Assert.Equal(utilization.MemoryUsedPercentage, memoryFromGauge * 100);
 
         fileSystem.ReplaceFileContent(new FileInfo("/proc/stat"), "cpu  11 10 10 10 10 10 10 10 10 10");
-        fileSystem.ReplaceFileContent(new FileInfo("/sys/fs/cgroup/cpu.stat"), "usage_usec 112");
+        fileSystem.ReplaceFileContent(new FileInfo("/sys/fs/cgroup/cpu.stat"), "usage_usec 112\nnr_periods 56");
         fileSystem.ReplaceFileContent(new FileInfo("/sys/fs/cgroup/memory.current"), "524298");
         fileSystem.ReplaceFileContent(new FileInfo("/sys/fs/cgroup/memory.stat"), "inactive_file 10");
 
@@ -370,7 +370,7 @@ public sealed class AcceptanceTest
         {
             { new FileInfo("/proc/self/cgroup"), "0::/fakeslice"},
             { new FileInfo("/proc/stat"), "cpu  10 10 10 10 10 10 10 10 10 10"},
-            { new FileInfo("/sys/fs/cgroup/fakeslice/cpu.stat"), "usage_usec 102000000"},
+            { new FileInfo("/sys/fs/cgroup/fakeslice/cpu.stat"), "usage_usec 1020000\nnr_periods 50"},
             { new FileInfo("/sys/fs/cgroup/memory.max"), "1048576" },
             { new FileInfo("/proc/meminfo"), "MemTotal: 1024 kB"},
             { new FileInfo("/sys/fs/cgroup/cpuset.cpus.effective"), "0-19"},
@@ -416,7 +416,7 @@ public sealed class AcceptanceTest
         var utilization = tracker.GetUtilization(TimeSpan.FromSeconds(5));
 
         fileSystem.ReplaceFileContent(new FileInfo("/proc/stat"), "cpu  11 10 10 10 10 10 10 10 10 10");
-        fileSystem.ReplaceFileContent(new FileInfo("/sys/fs/cgroup/fakeslice/cpu.stat"), "usage_usec 112000000");
+        fileSystem.ReplaceFileContent(new FileInfo("/sys/fs/cgroup/fakeslice/cpu.stat"), "usage_usec 1120000\nnr_periods 56");
         fileSystem.ReplaceFileContent(new FileInfo("/sys/fs/cgroup/memory.current"), "524298");
         fileSystem.ReplaceFileContent(new FileInfo("/sys/fs/cgroup/memory.stat"), "inactive_file 10");
 

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
@@ -108,7 +108,7 @@ public sealed class LinuxUtilizationProviderTests
         {
             { new FileInfo("/sys/fs/cgroup/memory.max"), "9223372036854771712" },
             { new FileInfo("/proc/stat"), "cpu 10 10 10 10 10 10 10 10 10 10"},
-            { new FileInfo("/sys/fs/cgroup/cpu.stat"), "usage_usec 102312"},
+            { new FileInfo("/sys/fs/cgroup/cpu.stat"), "usage_usec 102312\nnr_periods 50"},
             { new FileInfo("/proc/meminfo"), "MemTotal: 1024 kB"},
             { new FileInfo("/sys/fs/cgroup/cpuset.cpus.effective"), "0-19"},
             { new FileInfo("/sys/fs/cgroup/cpu/cpu.max"), "20000 100000"},
@@ -176,7 +176,7 @@ public sealed class LinuxUtilizationProviderTests
         {
             { new FileInfo("/sys/fs/cgroup/memory.max"), "9223372036854771712" },
             { new FileInfo("/proc/stat"), "cpu 10 10 10 10 10 10 10 10 10 10"},
-            { new FileInfo("/sys/fs/cgroup/cpu.stat"), "usage_usec 102312"},
+            { new FileInfo("/sys/fs/cgroup/cpu.stat"), "usage_usec 102312\nnr_periods 50"},
             { new FileInfo("/proc/meminfo"), "MemTotal: 1024 kB"},
             { new FileInfo("/sys/fs/cgroup/cpuset.cpus.effective"), "0-19"},
             { new FileInfo("/sys/fs/cgroup/cpu/cpu.max"), "20000 100000"},
@@ -223,7 +223,7 @@ public sealed class LinuxUtilizationProviderTests
             { new FileInfo("/proc/self/cgroup"), "0::/fakeslice" },
             { new FileInfo("/sys/fs/cgroup/memory.max"), "9223372036854771712" },
             { new FileInfo("/proc/stat"), "cpu 10 10 10 10 10 10 10 10 10 10"},
-            { new FileInfo("/sys/fs/cgroup/fakeslice/cpu.stat"), "usage_usec 102312"},
+            { new FileInfo("/sys/fs/cgroup/fakeslice/cpu.stat"), "usage_usec 102312\nnr_periods 50"},
             { new FileInfo("/proc/meminfo"), "MemTotal: 1024 kB"},
             { new FileInfo("/sys/fs/cgroup/cpuset.cpus.effective"), "0-19"},
             { new FileInfo("/sys/fs/cgroup/fakeslice/cpu.max"), "20000 100000"},

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/DummyLinuxUtilizationParser.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/DummyLinuxUtilizationParser.cs
@@ -9,7 +9,7 @@ internal class DummyLinuxUtilizationParser : ILinuxUtilizationParser
 {
     public ulong GetAvailableMemoryInBytes() => 1;
     public long GetCgroupCpuUsageInNanoseconds() => 0;
-    public long GetCgroupCpuUsageInNanosecondsV2() => 0;
+    public (long cpuUsageNanoseconds, long elapsedPeriods) GetCgroupCpuUsageInNanosecondsAndCpuPeriodsV2() => (0, 0);
     public float GetCgroupLimitedCpus() => 1;
     public float GetCgroupLimitV2() => 1;
     public float GetCgroupRequestCpu() => 1;
@@ -18,4 +18,5 @@ internal class DummyLinuxUtilizationParser : ILinuxUtilizationParser
     public float GetHostCpuCount() => 1;
     public long GetHostCpuUsageInNanoseconds() => 0;
     public ulong GetMemoryUsageInBytes() => 0;
+    public long GetCgroupPeriodsIntervalInMicroSecondsV2() => 1;
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '@'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetCgroupLimitedCpus()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass18_0.<Fallsback_To_Cpuset_When_Quota_And_Period_Are_Minus_One_>b__0()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=@#dddada_value=342322.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=@#dddada_value=342322.verified.txt
@@ -1,6 +1,6 @@
 ﻿{
   Type: InvalidOperationException,
-  Message: Could not parse '/sys/fs/cgroup/cpu.stat'. We expected first line of the file to start with 'usage_usec' but it was '@#dddada 342322' instead.,
+  Message: Could not parse '/sys/fs/cgroup/cpu.stat'. Expected to find 'usage_usec' but it was not present in the file content.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=dasd_value=-1.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=dasd_value=-1.verified.txt
@@ -1,6 +1,6 @@
 ﻿{
   Type: InvalidOperationException,
-  Message: Could not parse '/sys/fs/cgroup/cpu.stat'. We expected first line of the file to start with 'usage_usec' but it was 'dasd -1' instead.,
+  Message: Could not parse '/sys/fs/cgroup/cpu.stat'. Expected to find 'usage_usec' but it was not present in the file content.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=usage__value=12222.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuAcctUsage_Has_Invalid_Content_Both_Parts_content=usage__value=12222.verified.txt
@@ -1,6 +1,6 @@
 ﻿{
   Type: InvalidOperationException,
-  Message: Could not parse '/sys/fs/cgroup/cpu.stat'. We expected first line of the file to start with 'usage_usec' but it was 'usage_ 12222' instead.,
+  Message: Could not parse '/sys/fs/cgroup/cpu.stat'. Expected to find 'usage_usec' but it was not present in the file content.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=    d  182-1923.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=    d  182-1923.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '    d  182-1923'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=--.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=--.verified.txt
@@ -5,7 +5,7 @@ Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated
 '.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=-11.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=-11.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '-11'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got ''.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=0-.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=0-.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '0-'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18                   --.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18                   --.verified.txt
@@ -5,7 +5,7 @@ Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated
 '.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18-22.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=1-18-22.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '1-18-22'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-18.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-18.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '22-18'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-d.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=22-d.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got '22-d'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=aaaa.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=aaaa.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got 'aaaa'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=d-22.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_CpuSet_Has_Invalid_Content_content=d-22.verified.txt
@@ -3,7 +3,7 @@
   Message: Could not parse '/sys/fs/cgroup/cpuset.cpus.effective'. Expected comma-separated list of integers, with dashes ("-") based ranges ("0", "2-6,12") but got 'd-22'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
-at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|32_0(ReadOnlySpan`1 content)
+at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.<GetHostCpuCount>g__ThrowException|33_0(ReadOnlySpan`1 content)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.GetHostCpuCount()
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test.LinuxUtilizationParserCgroupV2Tests.<>c__DisplayClass17_0.<Throws_When_CpuSet_Has_Invalid_Content>b__0()
 at Xunit.Record.Exception(Func`1 testCode)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-1.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-1.verified.txt
@@ -1,6 +1,6 @@
 ﻿{
   Type: InvalidOperationException,
-  Message: Could not get cpu usage from '/sys/fs/cgroup/cpu.stat'. Expected positive number, but got 'usage_usec -1'.,
+  Message: Could not get usage_usec from '/sys/fs/cgroup/cpu.stat'. Expected positive number, but got 'usage_usec -1'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-15.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-15.verified.txt
@@ -1,6 +1,6 @@
 ﻿{
   Type: InvalidOperationException,
-  Message: Could not get cpu usage from '/sys/fs/cgroup/cpu.stat'. Expected positive number, but got 'usage_usec -15'.,
+  Message: Could not get usage_usec from '/sys/fs/cgroup/cpu.stat'. Expected positive number, but got 'usage_usec -15'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-32131.verified.txt
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Verified/LinuxUtilizationParserCgroupV2Tests.Throws_When_Usage_Usec_Has_Negative_Value_value=-32131.verified.txt
@@ -1,6 +1,6 @@
 ﻿{
   Type: InvalidOperationException,
-  Message: Could not get cpu usage from '/sys/fs/cgroup/cpu.stat'. Expected positive number, but got 'usage_usec -32131'.,
+  Message: Could not get usage_usec from '/sys/fs/cgroup/cpu.stat'. Expected positive number, but got 'usage_usec -32131'.,
   StackTrace:
 at Microsoft.Shared.Diagnostics.Throw.InvalidOperationException(String message)
 at Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.LinuxUtilizationParserCgroupV2.ParseCpuUsageFromFile(IFileSystem fileSystem, FileInfo cpuUsageFile)


### PR DESCRIPTION
Use the actual periods elapsed by reading nr_periods from cpu.stat instead of time delta.