### PR TITLE
A couple of minor fixes

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/MetricCard.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/MetricCard.tsx
@@ -58,7 +58,7 @@ const useCardStyles = makeStyles({
     metricNameText: {
         fontSize: '1rem',
         fontWeight: 'normal',
-        width: '80%',
+        width: '75%',
         textAlign: 'center',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
@@ -77,6 +77,7 @@ const useCardStyles = makeStyles({
         position: 'absolute',
         top: '-0.25rem',
         left: '-0.25rem',
+        fontSize: '16px',
     },
     metricIcon: {
         position: 'absolute',
@@ -86,7 +87,7 @@ const useCardStyles = makeStyles({
     metricValueText: {
         fontSize: '1rem',
         fontWeight: 'bold',
-        width: '80%',
+        width: '75%',
         textAlign: 'center',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
@@ -214,23 +215,25 @@ export const MetricCard = ({
     }
 
     return (
-        <div className={cardClass} onClick={onClick} tabIndex={0}
-                onKeyUp={e => e.key === 'Enter' && onClick()} >
-            <div className={classes.iconPlaceholder}>
-                {isSelected ? <RadioButtonFilled className={classes.selectionIcon} /> : <RadioButtonRegular className={classes.selectionIcon} />}
-                {statusIcon && (
-                    <Tooltip content={statusTooltip} relationship="description">
-                        <span>{statusIcon}</span>
-                    </Tooltip>
-                )}
+        <Tooltip content={`${metric.name}: ${metricValue}`} relationship="description">
+            <div className={cardClass} onClick={onClick} tabIndex={0}
+                    onKeyUp={e => e.key === 'Enter' && onClick()} >
+                <div className={classes.iconPlaceholder}>
+                    {isSelected ? <RadioButtonFilled className={classes.selectionIcon} /> : <RadioButtonRegular className={classes.selectionIcon} />}
+                    {statusIcon && (
+                        <Tooltip content={statusTooltip} relationship="description">
+                            <span>{statusIcon}</span>
+                        </Tooltip>
+                    )}
+                </div>
+                <div className={classes.metricNameText}>
+                    {metric.name}
+                </div>
+                <div className={mergeClasses(fg, classes.metricValueText)}>
+                    {metricValue}
+                </div>
             </div>
-            <div className={classes.metricNameText}>
-                {metric.name}
-            </div>
-            <div className={mergeClasses(fg, classes.metricValueText)}>
-                {metricValue}
-            </div>
-        </div>
+        </Tooltip>
     );
 };
 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyService.UrlCacheKey.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyService.UrlCacheKey.cs
@@ -13,25 +13,29 @@ namespace Microsoft.Extensions.AI.Evaluation.Safety;
 internal sealed partial class ContentSafetyService
 {
     private sealed class UrlCacheKey(ContentSafetyServiceConfiguration configuration, string annotationTask)
+        : IEquatable<UrlCacheKey>
     {
         internal ContentSafetyServiceConfiguration Configuration { get; } = configuration;
         internal string AnnotationTask { get; } = annotationTask;
 
-        public override bool Equals(object? other)
+        public bool Equals(UrlCacheKey? other)
         {
-            if (other is not UrlCacheKey otherKey)
+            if (other is null)
             {
                 return false;
             }
             else
             {
                 return
-                    otherKey.Configuration.SubscriptionId == Configuration.SubscriptionId &&
-                    otherKey.Configuration.ResourceGroupName == Configuration.ResourceGroupName &&
-                    otherKey.Configuration.ProjectName == Configuration.ProjectName &&
-                    otherKey.AnnotationTask == AnnotationTask;
+                    other.Configuration.SubscriptionId == Configuration.SubscriptionId &&
+                    other.Configuration.ResourceGroupName == Configuration.ResourceGroupName &&
+                    other.Configuration.ProjectName == Configuration.ProjectName &&
+                    other.AnnotationTask == AnnotationTask;
             }
         }
+
+        public override bool Equals(object? other)
+            => other is UrlCacheKey otherKey && Equals(otherKey);
 
         public override int GetHashCode() =>
             HashCode.Combine(


### PR DESCRIPTION
1. Adds back tool tip for metrics which are useful in cases where the metric name is long and does not fit entirely in the card
2. Makes the size of the selection buttons on the left of cards consistent with the size of status icons on the right to make the alignment cleaner
3. Implement IEquatable for UrlCacheKey (per Copilot's suggestion)
4. Throw ArgumentException when the number of messages passed to ContentSafetyChatClient does not match expectations (also per Copilot's suggestion)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6340)