### PR TITLE
Make `CreateJsonSchema` tolerate JSO inputs that don't have a resolver set.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
@@ -186,6 +186,7 @@ public static partial class AIJsonUtilities
         JsonSerializerOptions serializerOptions,
         AIJsonSchemaCreateOptions inferenceOptions)
     {
+        serializerOptions.TypeInfoResolver ??= DefaultOptions.TypeInfoResolver;
         serializerOptions.MakeReadOnly();
 
         if (type is null)

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
@@ -444,6 +444,20 @@ public static partial class AIJsonUtilitiesTests
     }
 
     [Fact]
+    public static void CreateJsonSchema_AcceptsOptionsWithoutResolver()
+    {
+        JsonSerializerOptions options = new() { WriteIndented = true };
+        Assert.Null(options.TypeInfoResolver);
+        Assert.False(options.IsReadOnly);
+
+        JsonElement schema = AIJsonUtilities.CreateJsonSchema(typeof(AIContent), serializerOptions: options);
+        Assert.Equal(JsonValueKind.Object, schema.ValueKind);
+
+        Assert.True(options.IsReadOnly);
+        Assert.Same(options.TypeInfoResolver, AIJsonUtilities.DefaultOptions.TypeInfoResolver);
+    }
+
+    [Fact]
     public static void AddAIContentType_DerivedAIContent()
     {
         JsonSerializerOptions options = new()


### PR DESCRIPTION
Passing a JsonSerializerOptions without a set `TypeInfoResolver` to the `CreateJsonSchema` method results in an exception being thrown in order to preserve AOT compatibility. This PR handles this case more gracefully by assigning the resolver from `AIJsonUtilities.DefaultOptions`.

Fix #6347
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6348)