### PR TITLE
Skip messages that have no text when rendering conversations as part of evaluation prompts

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation/ChatMessageExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation/ChatMessageExtensions.cs
@@ -97,8 +97,9 @@ public static class ChatMessageExtensions
     /// <remarks>
     /// <para>
     /// This function only considers the <see cref="ChatMessage.Text"/> and ignores any <see cref="AIContent"/>s
-    /// present within the <see cref="ChatMessage.Contents"/> of the <paramref name="message"/> that are not
-    /// <see cref="TextContent"/>s.
+    /// (present within the <see cref="ChatMessage.Contents"/> of the <paramref name="message"/>) that are not
+    /// <see cref="TextContent"/>s. If the <paramref name="message"/> does not contain any <see cref="TextContent"/>s
+    /// then this function returns an empty string.
     /// </para>
     /// <para>
     /// The returned string is prefixed with the <see cref="ChatMessage.Role"/> and
@@ -111,6 +112,12 @@ public static class ChatMessageExtensions
     public static string RenderText(this ChatMessage message)
     {
         _ = Throw.IfNull(message);
+
+        if (!message.Contents.OfType<TextContent>().Any())
+        {
+            // Don't render messages (such as messages with role ChatRole.Tool) that don't contain any textual content.
+            return string.Empty;
+        }
 
         string? author = message.AuthorName;
         string role = message.Role.Value;
@@ -129,8 +136,10 @@ public static class ChatMessageExtensions
     /// <remarks>
     /// <para>
     /// This function only considers the <see cref="ChatMessage.Text"/> and ignores any <see cref="AIContent"/>s
-    /// present within the <see cref="ChatMessage.Contents"/> of the <paramref name="messages"/> that are not
-    /// <see cref="TextContent"/>s.
+    /// (present within the <see cref="ChatMessage.Contents"/> of the <paramref name="messages"/>) that are not
+    /// <see cref="TextContent"/>s. Any <paramref name="messages"/> that contain no <see cref="TextContent"/>s will be
+    /// skipped and will not be rendered. If none of the <paramref name="messages"/> include any
+    /// <see cref="TextContent"/>s then this function will return an empty string.
     /// </para>
     /// <para>
     /// The rendered <paramref name="messages"/> are each prefixed with the <see cref="ChatMessage.Role"/> and

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation/ChatResponseExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation/ChatResponseExtensions.cs
@@ -19,7 +19,9 @@ public static class ChatResponseExtensions
     /// <para>
     /// This function only considers the <see cref="ChatResponse.Text"/> and ignores any <see cref="AIContent"/>s
     /// (present within the <see cref="ChatMessage.Contents"/> of the <see cref="ChatResponse.Messages"/>) that are not
-    /// <see cref="TextContent"/>s.
+    /// <see cref="TextContent"/>s. Any <see cref="ChatResponse.Messages"/> that contain no <see cref="TextContent"/>s
+    /// will be skipped and will not be rendered. If none of the <see cref="ChatResponse.Messages"/> include any
+    /// <see cref="TextContent"/>s then this function will return an empty string.
     /// </para>
     /// <para>
     /// The rendered <see cref="ChatResponse.Messages"/> are each prefixed with the <see cref="ChatMessage.Role"/> and


### PR DESCRIPTION
Fixes #6043 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6349)