### PR TITLE
Issue Labeler - Predict PR labels for main and dev branches

### DIFF
--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -14,6 +14,9 @@ on:
   # Only automatically predict area labels when pull requests are first opened
   pull_request_target:
     types: opened
+    branches:
+      - main
+      - dev
 
   # Allow dispatching the workflow via the Actions UI, specifying ranges of numbers
   workflow_dispatch:


### PR DESCRIPTION
This detail was missed in #6357. The previous configuration only predicted area labels for PRs into `main` and `dev` branches.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6358)