### PR TITLE
Fix keys for EvaluationResult.Metrics dictionary to reflect the correct metric names for Safety evaluators

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyEvaluator.cs
@@ -151,12 +151,13 @@ public abstract class ContentSafetyEvaluator(
         string annotationResult = annotationResponse.Text;
         EvaluationResult result = ContentSafetyService.ParseAnnotationResult(annotationResult);
 
-        UpdateMetrics();
+        EvaluationResult updatedResult = UpdateMetrics();
+        return updatedResult;
 
-        return result;
-
-        void UpdateMetrics()
+        EvaluationResult UpdateMetrics()
         {
+            EvaluationResult updatedResult = new EvaluationResult();
+
             foreach (EvaluationMetric metric in result.Metrics.Values)
             {
                 string contentSafetyServiceMetricName = metric.Name;
@@ -185,7 +186,11 @@ public abstract class ContentSafetyEvaluator(
                 // metric.LogJsonData(payload);
                 // metric.LogJsonData(annotationResult);
 #pragma warning restore S125
+
+                updatedResult.Metrics.Add(metric.Name, metric);
             }
+
+            return updatedResult;
         }
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyService.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyService.cs
@@ -120,7 +120,7 @@ internal sealed partial class ContentSafetyService(ContentSafetyServiceConfigura
                 }
             }
 
-            result.Metrics[metric.Name] = metric;
+            result.Metrics.Add(metric.Name, metric);
         }
 
         return result;

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ProtectedMaterialEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ProtectedMaterialEvaluator.cs
@@ -100,7 +100,7 @@ public sealed class ProtectedMaterialEvaluator()
 
             foreach (EvaluationMetric imageMetric in imageResult.Metrics.Values)
             {
-                result.Metrics[imageMetric.Name] = imageMetric;
+                result.Metrics.Add(imageMetric.Name, imageMetric);
             }
         }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/SafetyEvaluatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/SafetyEvaluatorTests.cs
@@ -153,17 +153,33 @@ public class SafetyEvaluatorTests
             The distance varies due to the elliptical orbits of both planets.
             """;
 
-        IEnumerable<EvaluationContext> additionalContext =
-            [
-                new GroundednessProEvaluatorContext(groundingContext),
-                new UngroundedAttributesEvaluatorContext(groundingContext)
-            ];
+        GroundednessProEvaluatorContext groundednessProContext = new GroundednessProEvaluatorContext(groundingContext);
+        UngroundedAttributesEvaluatorContext ungroundedAttributesContext = new UngroundedAttributesEvaluatorContext(groundingContext);
+        IEnumerable<EvaluationContext> additionalContext = [groundednessProContext, ungroundedAttributesContext];
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(messages, response, additionalContext);
 
         Assert.False(
             result.ContainsDiagnostics(d => d.Severity is EvaluationDiagnosticSeverity.Error),
             string.Join("\r\n\r\n", result.Metrics.Values.SelectMany(m => m.Diagnostics ?? []).Select(d => d.ToString())));
+
+        Assert.Equal(6, result.Metrics.Count);
+        Assert.True(result.TryGet(SelfHarmEvaluator.SelfHarmMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(SexualEvaluator.SexualMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedMaterialMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(GroundednessProEvaluator.GroundednessProMetricName, out NumericMetric? groundednessPro));
+        Assert.True(result.TryGet(UngroundedAttributesEvaluator.UngroundedAttributesMetricName, out BooleanMetric? ungroundedAttributes));
+        Assert.True(result.TryGet(IndirectAttackEvaluator.IndirectAttackMetricName, out BooleanMetric? _));
+
+        Assert.True(
+            groundednessPro.Context?.Count is 1 &&
+            groundednessPro.Context.TryGetValue(GroundednessProEvaluatorContext.GroundingContextName, out EvaluationContext? context1) &&
+            ReferenceEquals(context1, groundednessProContext));
+
+        Assert.True(
+            ungroundedAttributes.Context?.Count is 1 &&
+            ungroundedAttributes.Context.TryGetValue(UngroundedAttributesEvaluatorContext.GroundingContextName, out EvaluationContext? context2) &&
+            ReferenceEquals(context2, ungroundedAttributesContext));
     }
 
     [ConditionalFact]
@@ -212,17 +228,33 @@ public class SafetyEvaluatorTests
             At its furthest (conjunction), it can be approximately 601 million miles away.
             """;
 
-        IEnumerable<EvaluationContext> additionalContext =
-            [
-                new GroundednessProEvaluatorContext(groundingContext),
-                new UngroundedAttributesEvaluatorContext(groundingContext)
-            ];
+        GroundednessProEvaluatorContext groundednessProContext = new GroundednessProEvaluatorContext(groundingContext);
+        UngroundedAttributesEvaluatorContext ungroundedAttributesContext = new UngroundedAttributesEvaluatorContext(groundingContext);
+        IEnumerable<EvaluationContext> additionalContext = [groundednessProContext, ungroundedAttributesContext];
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(messages, response2, additionalContext);
 
         Assert.False(
             result.ContainsDiagnostics(d => d.Severity is EvaluationDiagnosticSeverity.Error),
             string.Join("\r\n\r\n", result.Metrics.Values.SelectMany(m => m.Diagnostics ?? []).Select(d => d.ToString())));
+
+        Assert.Equal(6, result.Metrics.Count);
+        Assert.True(result.TryGet(SelfHarmEvaluator.SelfHarmMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(SexualEvaluator.SexualMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedMaterialMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(GroundednessProEvaluator.GroundednessProMetricName, out NumericMetric? groundednessPro));
+        Assert.True(result.TryGet(UngroundedAttributesEvaluator.UngroundedAttributesMetricName, out BooleanMetric? ungroundedAttributes));
+        Assert.True(result.TryGet(IndirectAttackEvaluator.IndirectAttackMetricName, out BooleanMetric? _));
+
+        Assert.True(
+            groundednessPro.Context?.Count is 1 &&
+            groundednessPro.Context.TryGetValue(GroundednessProEvaluatorContext.GroundingContextName, out EvaluationContext? context1) &&
+            ReferenceEquals(context1, groundednessProContext));
+
+        Assert.True(
+            ungroundedAttributes.Context?.Count is 1 &&
+            ungroundedAttributes.Context.TryGetValue(UngroundedAttributesEvaluatorContext.GroundingContextName, out EvaluationContext? context2) &&
+            ReferenceEquals(context2, ungroundedAttributesContext));
     }
 
     [ConditionalFact]
@@ -250,6 +282,15 @@ public class SafetyEvaluatorTests
         Assert.False(
             result.ContainsDiagnostics(d => d.Severity is EvaluationDiagnosticSeverity.Error),
             string.Join("\r\n\r\n", result.Metrics.Values.SelectMany(m => m.Diagnostics ?? []).Select(d => d.ToString())));
+
+        Assert.Equal(7, result.Metrics.Count);
+        Assert.True(result.TryGet(HateAndUnfairnessEvaluator.HateAndUnfairnessMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(ViolenceEvaluator.ViolenceMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedMaterialMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedArtworkMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedFictionalCharactersMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedLogosAndBrandsMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(IndirectAttackEvaluator.IndirectAttackMetricName, out BooleanMetric? _));
     }
 
     [ConditionalFact]
@@ -277,6 +318,15 @@ public class SafetyEvaluatorTests
         Assert.False(
             result.ContainsDiagnostics(d => d.Severity is EvaluationDiagnosticSeverity.Error),
             string.Join("\r\n\r\n", result.Metrics.Values.SelectMany(m => m.Diagnostics ?? []).Select(d => d.ToString())));
+
+        Assert.Equal(7, result.Metrics.Count);
+        Assert.True(result.TryGet(HateAndUnfairnessEvaluator.HateAndUnfairnessMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(ViolenceEvaluator.ViolenceMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedMaterialMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedArtworkMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedFictionalCharactersMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedLogosAndBrandsMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(IndirectAttackEvaluator.IndirectAttackMetricName, out BooleanMetric? _));
     }
 
     [ConditionalFact]
@@ -317,6 +367,15 @@ public class SafetyEvaluatorTests
         Assert.False(
             result.ContainsDiagnostics(d => d.Severity is EvaluationDiagnosticSeverity.Error),
             string.Join("\r\n\r\n", result.Metrics.Values.SelectMany(m => m.Diagnostics ?? []).Select(d => d.ToString())));
+
+        Assert.Equal(7, result.Metrics.Count);
+        Assert.True(result.TryGet(HateAndUnfairnessEvaluator.HateAndUnfairnessMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(ViolenceEvaluator.ViolenceMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedMaterialMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedArtworkMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedFictionalCharactersMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedLogosAndBrandsMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(IndirectAttackEvaluator.IndirectAttackMetricName, out BooleanMetric? _));
     }
 
     [ConditionalFact]
@@ -370,6 +429,15 @@ public class SafetyEvaluatorTests
         Assert.False(
             result.ContainsDiagnostics(d => d.Severity is EvaluationDiagnosticSeverity.Error),
             string.Join("\r\n\r\n", result.Metrics.Values.SelectMany(m => m.Diagnostics ?? []).Select(d => d.ToString())));
+
+        Assert.Equal(7, result.Metrics.Count);
+        Assert.True(result.TryGet(HateAndUnfairnessEvaluator.HateAndUnfairnessMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(ViolenceEvaluator.ViolenceMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedMaterialMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedArtworkMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedFictionalCharactersMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(ProtectedMaterialEvaluator.ProtectedLogosAndBrandsMetricName, out BooleanMetric? _));
+        Assert.True(result.TryGet(IndirectAttackEvaluator.IndirectAttackMetricName, out BooleanMetric? _));
     }
 
     [ConditionalFact]
@@ -396,6 +464,9 @@ public class SafetyEvaluatorTests
         Assert.False(
             result.ContainsDiagnostics(d => d.Severity is EvaluationDiagnosticSeverity.Error),
             string.Join("\r\n\r\n", result.Metrics.Values.SelectMany(m => m.Diagnostics ?? []).Select(d => d.ToString())));
+
+        Assert.Single(result.Metrics);
+        Assert.True(result.TryGet(CodeVulnerabilityEvaluator.CodeVulnerabilityMetricName, out BooleanMetric? _));
     }
 
     [ConditionalFact]
@@ -434,6 +505,9 @@ public class SafetyEvaluatorTests
         Assert.False(
             result.ContainsDiagnostics(d => d.Severity is EvaluationDiagnosticSeverity.Error),
             string.Join("\r\n\r\n", result.Metrics.Values.SelectMany(m => m.Diagnostics ?? []).Select(d => d.ToString())));
+
+        Assert.Single(result.Metrics);
+        Assert.True(result.TryGet(CodeVulnerabilityEvaluator.CodeVulnerabilityMetricName, out BooleanMetric? _));
     }
 
     [ConditionalFact]
@@ -465,6 +539,13 @@ public class SafetyEvaluatorTests
         Assert.False(
             result.ContainsDiagnostics(d => d.Severity is EvaluationDiagnosticSeverity.Error),
             string.Join("\r\n\r\n", result.Metrics.Values.SelectMany(m => m.Diagnostics ?? []).Select(d => d.ToString())));
+
+        Assert.Equal(5, result.Metrics.Count);
+        Assert.True(result.TryGet(FluencyEvaluator.FluencyMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(HateAndUnfairnessEvaluator.HateAndUnfairnessMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(SelfHarmEvaluator.SelfHarmMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(SexualEvaluator.SexualMetricName, out NumericMetric? _));
+        Assert.True(result.TryGet(ViolenceEvaluator.ViolenceMetricName, out NumericMetric? _));
     }
 
     [MemberNotNull(nameof(_contentSafetyReportingConfiguration))]


### PR DESCRIPTION
This was an unfortunate regression that was introduced during a recent refactoring.

The metrics returned from the Azure AI Foundry Evaluation service have different names than the ones we use in the Safety library. We translate the EvaluationMetric.Name of the metrics returned by the service to the more display friendly names used in the library before returning the metrics to the caller.

While the returned metrics were correctly patched up, the EvaluationResult.Metrics dictionary still stored these metrics by the original names returned from the service. Unfortunately, this meant EvaluationResult.Get would throw an exception when trying to fetch metric with name ViolenceEvaluator.ViolenceMetricName.

The fix in this PR fixes the keys in the dictionary as well. This PR also updates tests to cover the case being fixed.

Fixes #6360
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6361)