### PR TITLE
Update OpenTelemetryChatClient/EmbeddingGenerator to 1.33

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a delegating chat client that implements the OpenTelemetry Semantic Conventions for Generative AI systems.</summary>
 /// <remarks>
-/// This class provides an implementation of the Semantic Conventions for Generative AI systems v1.32, defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
+/// This class provides an implementation of the Semantic Conventions for Generative AI systems v1.33, defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
 /// The specification is still experimental and subject to change; as such, the telemetry output by this client is also subject to change.
 /// </remarks>
 public sealed partial class OpenTelemetryChatClient : DelegatingChatClient

--- a/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryConsts.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryConsts.cs
@@ -103,7 +103,14 @@ internal static class OpenTelemetryConsts
 
         public static class Tool
         {
+            public const string Name = "gen_ai.tool.name";
+            public const string Description = "gen_ai.tool.description";
             public const string Message = "gen_ai.tool.message";
+
+            public static class Call
+            {
+                public const string Id = "gen_ai.tool.call.id";
+            }
         }
 
         public static class User

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/OpenTelemetryEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/OpenTelemetryEmbeddingGeneratorTests.cs
@@ -16,9 +16,10 @@ namespace Microsoft.Extensions.AI;
 public class OpenTelemetryEmbeddingGeneratorTests
 {
     [Theory]
-    [InlineData(null)]
-    [InlineData("replacementmodel")]
-    public async Task ExpectedInformationLogged_Async(string? perRequestModelId)
+    [InlineData(null, false)]
+    [InlineData("replacementmodel", false)]
+    [InlineData("replacementmodel", true)]
+    public async Task ExpectedInformationLogged_Async(string? perRequestModelId, bool enableSensitiveData)
     {
         var sourceName = Guid.NewGuid().ToString();
         var activities = new List<Activity>();
@@ -45,7 +46,7 @@ public class OpenTelemetryEmbeddingGeneratorTests
                     AdditionalProperties = new()
                     {
                         ["system_fingerprint"] = "abcdefgh",
-                        ["AndSomethingElse"] = "value2",
+                        ["AndSomethingElse"] = "value3",
                     }
                 };
             },
@@ -56,7 +57,7 @@ public class OpenTelemetryEmbeddingGeneratorTests
 
         using var generator = innerGenerator
             .AsBuilder()
-            .UseOpenTelemetry(loggerFactory, sourceName)
+            .UseOpenTelemetry(loggerFactory, sourceName, configure: g => g.EnableSensitiveData = enableSensitiveData)
             .Build();
 
         var options = new EmbeddingGenerationOptions
@@ -85,12 +86,12 @@ public class OpenTelemetryEmbeddingGeneratorTests
 
         Assert.Equal(expectedModelName, activity.GetTagItem("gen_ai.request.model"));
         Assert.Equal(1234, activity.GetTagItem("gen_ai.request.embedding.dimensions"));
-        Assert.Equal("value1", activity.GetTagItem("gen_ai.testservice.request.service_tier"));
-        Assert.Equal("value2", activity.GetTagItem("gen_ai.testservice.request.something_else"));
+        Assert.Equal(enableSensitiveData ? "value1" : null, activity.GetTagItem("gen_ai.testservice.request.service_tier"));
+        Assert.Equal(enableSensitiveData ? "value2" : null, activity.GetTagItem("gen_ai.testservice.request.something_else"));
 
         Assert.Equal(10, activity.GetTagItem("gen_ai.response.input_tokens"));
-        Assert.Equal("abcdefgh", activity.GetTagItem("gen_ai.testservice.response.system_fingerprint"));
-        Assert.Equal("value2", activity.GetTagItem("gen_ai.testservice.response.and_something_else"));
+        Assert.Equal(enableSensitiveData ? "abcdefgh" : null, activity.GetTagItem("gen_ai.testservice.response.system_fingerprint"));
+        Assert.Equal(enableSensitiveData ? "value3" : null, activity.GetTagItem("gen_ai.testservice.response.and_something_else"));
 
         Assert.True(activity.Duration.TotalMilliseconds > 0);
     }


### PR DESCRIPTION
Also adds the Enable SensitiveData property to OpenTelemetryEmbeddingGenerators. This was missed when adding it to OpenTelemetryChatClient.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6366)