### PR TITLE
Add back net9.0 version of the aieval dotnet tool

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Console/Microsoft.Extensions.AI.Evaluation.Console.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Console/Microsoft.Extensions.AI.Evaluation.Console.csproj
@@ -3,9 +3,7 @@
   <PropertyGroup>
     <Description>A command line dotnet tool for generating reports and managing evaluation data.</Description>
     <OutputType>Exe</OutputType>
-    <!-- Building only one TFM due to bug: https://github.com/dotnet/sdk/issues/47696 
-         Once this is fixed, we can go back to building multiple. -->
-    <TargetFrameworks>$(MinimumSupportedTfmForPackaging)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.Extensions.AI.Evaluation.Console</RootNamespace>
     <!-- EA0000: Use source generated logging methods for improved performance. -->
     <NoWarn>$(NoWarn);EA0000</NoWarn>
@@ -20,6 +18,15 @@
     <EnablePackageValidation>false</EnablePackageValidation>
     <MinCodeCoverage>8</MinCodeCoverage>
     <MinMutationScore>0</MinMutationScore>
+  </PropertyGroup>
+
+  <!--
+  Disable parallel build to work around https://github.com/dotnet/sdk/issues/47696. The problem has been fixed in
+  https://github.com/dotnet/sdk/pull/47788, however the fix has not yet been back ported to the dotnet 9 SDK. We can
+  remove this workaround once the fix is available in the dotnet 9 SDK.
+  -->
+  <PropertyGroup>
+    <BuildInParallel>false</BuildInParallel>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In #6148, we disabled net9.0 TFM for the aieval tool to work around the race described in https://github.com/dotnet/sdk/issues/47696. The underlying issue was subsequently fixed in the SDK (via https://github.com/dotnet/sdk/pull/47788). However, this fix has not been backported to the dotnet 9 SDK yet.

The SDK team is working on backporting the fix (see discussion in https://github.com/dotnet/sdk/pull/47788#issuecomment-2861167925). But in the meanwhile, we can add back the net9.0 TFM and continue to work around the race by disabling parallel build.

This would help users of the aieval tool sidestep errors such as the ones described in #6388 when they dont have dotnet8 installed on the machine.

We can remove this workaround, once the backported fix is available in the dotnet 9 SDK.