### PR TITLE
Delete Microsoft.Extensions.AI.Abstractions APIs marked [Obsolete] during preview

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
@@ -12,16 +12,6 @@ namespace Microsoft.Extensions.AI;
 public class ChatOptions
 {
     /// <summary>Gets or sets an optional identifier used to associate a request with an existing conversation.</summary>
-    /// <remarks>This property is obsolete. Use <see cref="ConversationId"/> instead.</remarks>
-    [System.Obsolete("Use ConversationId instead.")]
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public string? ChatThreadId
-    {
-        get => ConversationId;
-        set => ConversationId = value;
-    }
-
-    /// <summary>Gets or sets an optional identifier used to associate a request with an existing conversation.</summary>
     /// <related type="Article" href="https://learn.microsoft.com/dotnet/ai/microsoft-extensions-ai#stateless-vs-stateful-clients">Stateless vs. stateful clients.</related>
     public string? ConversationId { get; set; }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponse.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponse.cs
@@ -73,25 +73,6 @@ public class ChatResponse
     /// or may not differ on every response, depending on whether the underlying provider uses a fixed ID for each conversation
     /// or updates it for each message.
     /// </remarks>
-    /// <remarks>This method is obsolete. Use <see cref="ConversationId"/> instead.</remarks>
-    [Obsolete("Use ConversationId instead.")]
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public string? ChatThreadId
-    {
-        get => ConversationId;
-        set => ConversationId = value;
-    }
-
-    /// <summary>Gets or sets an identifier for the state of the conversation.</summary>
-    /// <remarks>
-    /// Some <see cref="IChatClient"/> implementations are capable of storing the state for a conversation, such that
-    /// the input messages supplied to <see cref="IChatClient.GetResponseAsync"/> need only be the additional messages beyond
-    /// what's already stored. If this property is non-<see langword="null"/>, it represents an identifier for that state,
-    /// and it should be used in a subsequent <see cref="ChatOptions.ConversationId"/> instead of supplying the same messages
-    /// (and this <see cref="ChatResponse"/>'s message) as part of the <c>messages</c> parameter. Note that the value may
-    /// or may not differ on every response, depending on whether the underlying provider uses a fixed ID for each conversation
-    /// or updates it for each message.
-    /// </remarks>
     /// <related type="Article" href="https://learn.microsoft.com/dotnet/ai/microsoft-extensions-ai#stateless-vs-stateful-clients">Stateless vs. stateful clients.</related>
     public string? ConversationId { get; set; }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseUpdate.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseUpdate.cs
@@ -125,24 +125,6 @@ public class ChatResponseUpdate
     /// (and this streaming message) as part of the <c>messages</c> parameter. Note that the value may or may not differ on every
     /// response, depending on whether the underlying provider uses a fixed ID for each conversation or updates it for each message.
     /// </remarks>
-    /// <remarks>This method is obsolete. Use <see cref="ConversationId"/> instead.</remarks>
-    [Obsolete("Use ConversationId instead.")]
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public string? ChatThreadId
-    {
-        get => ConversationId;
-        set => ConversationId = value;
-    }
-
-    /// <summary>Gets or sets an identifier for the state of the conversation of which this update is a part.</summary>
-    /// <remarks>
-    /// Some <see cref="IChatClient"/> implementations are capable of storing the state for a conversation, such that
-    /// the input messages supplied to <see cref="IChatClient.GetStreamingResponseAsync"/> need only be the additional messages beyond
-    /// what's already stored. If this property is non-<see langword="null"/>, it represents an identifier for that state,
-    /// and it should be used in a subsequent <see cref="ChatOptions.ConversationId"/> instead of supplying the same messages
-    /// (and this streaming message) as part of the <c>messages</c> parameter. Note that the value may or may not differ on every
-    /// response, depending on whether the underlying provider uses a fixed ID for each conversation or updates it for each message.
-    /// </remarks>
     public string? ConversationId { get; set; }
 
     /// <summary>Gets or sets a timestamp for the response update.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/EmbeddingGeneratorExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/EmbeddingGeneratorExtensions.cs
@@ -102,35 +102,6 @@ public static class EmbeddingGeneratorExtensions
     /// This operation is equivalent to using <see cref="GenerateAsync"/> and returning the
     /// resulting <see cref="Embedding{T}"/>'s <see cref="Embedding{T}.Vector"/> property.
     /// </remarks>
-    /// <remarks>
-    /// This method is obsolete. Use <see cref="GenerateVectorAsync{TInput, TEmbeddingElement}"/> instead.
-    /// </remarks>
-    [Obsolete("Use GenerateVectorAsync<TInput, TEmbeddingElement> instead.")]
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public static async Task<ReadOnlyMemory<TEmbeddingElement>> GenerateEmbeddingVectorAsync<TInput, TEmbeddingElement>(
-        this IEmbeddingGenerator<TInput, Embedding<TEmbeddingElement>> generator,
-        TInput value,
-        EmbeddingGenerationOptions? options = null,
-        CancellationToken cancellationToken = default)
-    {
-        return await GenerateVectorAsync(generator, value, options, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>Generates an embedding vector from the specified <paramref name="value"/>.</summary>
-    /// <typeparam name="TInput">The type from which embeddings will be generated.</typeparam>
-    /// <typeparam name="TEmbeddingElement">The numeric type of the embedding data.</typeparam>
-    /// <param name="generator">The embedding generator.</param>
-    /// <param name="value">A value from which an embedding will be generated.</param>
-    /// <param name="options">The embedding generation options to configure the request.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns>The generated embedding for the specified <paramref name="value"/>.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="generator"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
-    /// <exception cref="InvalidOperationException">The generator did not produce exactly one embedding.</exception>
-    /// <remarks>
-    /// This operation is equivalent to using <see cref="GenerateAsync"/> and returning the
-    /// resulting <see cref="Embedding{T}"/>'s <see cref="Embedding{T}.Vector"/> property.
-    /// </remarks>
     public static async Task<ReadOnlyMemory<TEmbeddingElement>> GenerateVectorAsync<TInput, TEmbeddingElement>(
         this IEmbeddingGenerator<TInput, Embedding<TEmbeddingElement>> generator,
         TInput value,
@@ -139,39 +110,6 @@ public static class EmbeddingGeneratorExtensions
     {
         var embedding = await GenerateAsync(generator, value, options, cancellationToken).ConfigureAwait(false);
         return embedding.Vector;
-    }
-
-    /// <summary>Generates an embedding from the specified <paramref name="value"/>.</summary>
-    /// <typeparam name="TInput">The type from which embeddings will be generated.</typeparam>
-    /// <typeparam name="TEmbedding">The type of embedding to generate.</typeparam>
-    /// <param name="generator">The embedding generator.</param>
-    /// <param name="value">A value from which an embedding will be generated.</param>
-    /// <param name="options">The embedding generation options to configure the request.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns>
-    /// The generated embedding for the specified <paramref name="value"/>.
-    /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="generator"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
-    /// <exception cref="InvalidOperationException">The generator did not produce exactly one embedding.</exception>
-    /// <remarks>
-    /// This operations is equivalent to using <see cref="IEmbeddingGenerator{TInput, TEmbedding}.GenerateAsync"/> with a
-    /// collection composed of the single <paramref name="value"/> and then returning the first embedding element from the
-    /// resulting <see cref="GeneratedEmbeddings{TEmbedding}"/> collection.
-    /// </remarks>
-    /// <remarks>
-    /// This method is obsolete. Use <see cref="GenerateAsync{TInput, TEmbedding}"/> instead.
-    /// </remarks>
-    [Obsolete("Use GenerateAsync<TInput, TEmbedding> instead.")]
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public static async Task<TEmbedding> GenerateEmbeddingAsync<TInput, TEmbedding>(
-        this IEmbeddingGenerator<TInput, TEmbedding> generator,
-        TInput value,
-        EmbeddingGenerationOptions? options = null,
-        CancellationToken cancellationToken = default)
-        where TEmbedding : Embedding
-    {
-        return await GenerateAsync(generator, value, options, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Generates an embedding from the specified <paramref name="value"/>.</summary>


### PR DESCRIPTION
This pull request deletes `[Obsolete]` preview APIs from `Microsoft.Extensions.AI.Abstractions`, as part of preparing for the stable release.

* Deleted the `ChatThreadId` property from `ChatOptions`, `ChatResponse`, and `ChatResponseUpdate` classes. The property was marked obsolete and has been fully replaced by `ConversationId`.
* Deleted the `GenerateEmbeddingVectorAsync<TInput, TEmbeddingElement>` method from `EmbeddingGeneratorExtensions`. This method was marked obsolete and has been replaced by `GenerateVectorAsync<TInput, TEmbeddingElement>`.
* Deleted the `GenerateEmbeddingAsync<TInput, TEmbedding>` method from `EmbeddingGeneratorExtensions`. This method was marked obsolete and has been replaced by `GenerateAsync<TInput, TEmbedding>`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6414)