### PR TITLE
Add an AIJsonSchemaTransformOptions property inside AIJsonSchemaCreateOptions and mark redundant properties in the latter as obsolete.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
@@ -43,7 +43,7 @@ public sealed record class AIJsonSchemaCreateOptions
     public AIJsonSchemaTransformOptions? TransformOptions { get; init; }
 
     /// <summary>
-    /// Gets a value indicating whether to include the type keyword in inferred schemas for .NET enums.
+    /// Gets a value indicating whether to include the type keyword in created schemas for .NET enums.
     /// </summary>
     [Obsolete("This property has been deprecated.")]
     [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -57,7 +57,7 @@ public sealed record class AIJsonSchemaCreateOptions
     public bool DisallowAdditionalProperties { get; init; }
 
     /// <summary>
-    /// Gets a value indicating whether to include the $schema keyword in inferred schemas.
+    /// Gets a value indicating whether to include the $schema keyword in created schemas.
     /// </summary>
     public bool IncludeSchemaKeyword { get; init; }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
@@ -38,14 +38,23 @@ public sealed record class AIJsonSchemaCreateOptions
     public Func<ParameterInfo, bool>? IncludeParameter { get; init; }
 
     /// <summary>
+    /// Gets a <see cref="AIJsonSchemaTransformOptions"/> governing transformations on the JSON schema after it has been generated.
+    /// </summary>
+    public AIJsonSchemaTransformOptions? TransformOptions { get; init; }
+
+    /// <summary>
     /// Gets a value indicating whether to include the type keyword in inferred schemas for .NET enums.
     /// </summary>
+    [Obsolete("This property has been deprecated.")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public bool IncludeTypeInEnumSchemas { get; init; } = true;
 
     /// <summary>
     /// Gets a value indicating whether to generate schemas with the additionalProperties set to false for .NET objects.
     /// </summary>
-    public bool DisallowAdditionalProperties { get; init; } = true;
+    [Obsolete("This property has been deprecated. Use the equivalent property in TransformOptions instead.")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public bool DisallowAdditionalProperties { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether to include the $schema keyword in inferred schemas.
@@ -55,5 +64,7 @@ public sealed record class AIJsonSchemaCreateOptions
     /// <summary>
     /// Gets a value indicating whether to mark all properties as required in the schema.
     /// </summary>
+    [Obsolete("This property has been deprecated. Use the equivalent property in TransformOptions instead.")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public bool RequireAllProperties { get; init; }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaTransformOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaTransformOptions.cs
@@ -39,6 +39,11 @@ public sealed record class AIJsonSchemaTransformOptions
     public bool UseNullableKeyword { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether to move the default keyword to the description field in the schema.
+    /// </summary>
+    public bool MoveDefaultKeywordToDescription { get; init; }
+
+    /// <summary>
     /// Gets the default options instance.
     /// </summary>
     internal static AIJsonSchemaTransformOptions Default { get; } = new();

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs
@@ -116,4 +116,11 @@ public static partial class AIJsonUtilities
     [JsonSerializable(typeof(AIFunctionArguments))]
     [EditorBrowsable(EditorBrowsableState.Never)] // Never use JsonContext directly, use DefaultOptions instead.
     private sealed partial class JsonContext : JsonSerializerContext;
+
+    [JsonSourceGenerationOptions(JsonSerializerDefaults.Web,
+        UseStringEnumConverter = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false)]
+    [JsonSerializable(typeof(JsonNode))]
+    private sealed partial class JsonContextNoIndentation : JsonSerializerContext;
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.Create.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.Create.cs
@@ -39,7 +39,7 @@ public static partial class AIJsonUtilities
     private const string DefaultPropertyName = "default";
     private const string RefPropertyName = "$ref";
 
-    /// <summary>The uri used when populating the $schema keyword in inferred schemas.</summary>
+    /// <summary>The uri used when populating the $schema keyword in created schemas.</summary>
     private const string SchemaKeywordUri = "https://json-schema.org/draft/2020-12/schema";
 
     // List of keywords used by JsonSchemaExporter but explicitly disallowed by some AI vendors.
@@ -53,7 +53,7 @@ public static partial class AIJsonUtilities
     /// <param name="title">The title keyword used by the method schema.</param>
     /// <param name="description">The description keyword used by the method schema.</param>
     /// <param name="serializerOptions">The options used to extract the schema from the specified type.</param>
-    /// <param name="inferenceOptions">The options controlling schema inference.</param>
+    /// <param name="inferenceOptions">The options controlling schema creation.</param>
     /// <returns>A JSON schema document encoded as a <see cref="JsonElement"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="method"/> is <see langword="null"/>.</exception>
     public static JsonElement CreateFunctionJsonSchema(
@@ -150,7 +150,7 @@ public static partial class AIJsonUtilities
     /// <param name="hasDefaultValue"><see langword="true"/> if the parameter is optional; otherwise, <see langword="false"/>.</param>
     /// <param name="defaultValue">The default value of the optional parameter, if applicable.</param>
     /// <param name="serializerOptions">The options used to extract the schema from the specified type.</param>
-    /// <param name="inferenceOptions">The options controlling schema inference.</param>
+    /// <param name="inferenceOptions">The options controlling schema creation.</param>
     /// <returns>A <see cref="JsonElement"/> representing the schema.</returns>
     public static JsonElement CreateJsonSchema(
         Type? type,

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
@@ -29,7 +29,8 @@ internal sealed class AzureAIInferenceChatClient : IChatClient
     {
         RequireAllProperties = true,
         DisallowAdditionalProperties = true,
-        ConvertBooleanSchemas = true
+        ConvertBooleanSchemas = true,
+        MoveDefaultKeywordToDescription = true,
     });
 
     /// <summary>Metadata about the client.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -30,7 +30,8 @@ internal sealed partial class OpenAIChatClient : IChatClient
     {
         RequireAllProperties = true,
         DisallowAdditionalProperties = true,
-        ConvertBooleanSchemas = true
+        ConvertBooleanSchemas = true,
+        MoveDefaultKeywordToDescription = true,
     });
 
     /// <summary>Gets the default OpenAI endpoint.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
@@ -26,9 +26,12 @@ public static partial class ChatClientStructuredOutputExtensions
     private static readonly AIJsonSchemaCreateOptions _inferenceOptions = new()
     {
         IncludeSchemaKeyword = true,
-        DisallowAdditionalProperties = true,
-        IncludeTypeInEnumSchemas = true,
-        RequireAllProperties = true,
+        TransformOptions = new AIJsonSchemaTransformOptions
+        {
+            DisallowAdditionalProperties = true,
+            RequireAllProperties = true,
+            MoveDefaultKeywordToDescription = true,
+        },
     };
 
     /// <summary>Sends chat messages, requesting a response matching the type <typeparamref name="T"/>.</summary>


### PR DESCRIPTION
Apart from obsoletions, I decided to be a bit more aggressive and additionally remove the implementations of the obsoleted properties.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6427)