### PR TITLE
AI Chat Web template fixes for Azure AI Search

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Services/IngestedDocument.cs
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Services/IngestedDocument.cs
@@ -21,6 +21,6 @@ public class IngestedDocument
     public required string DocumentVersion { get; set; }
 
     // The vector is not used but required for some vector databases
-    [VectorStoreRecordVector(1, DistanceFunction = DistanceFunction.CosineSimilarity)]
-    public ReadOnlyMemory<float> Vector { get; set; } = new ReadOnlyMemory<float>([0]);
+    [VectorStoreRecordVector(2, DistanceFunction = DistanceFunction.CosineSimilarity)]
+    public ReadOnlyMemory<float> Vector { get; set; } = new ReadOnlyMemory<float>([0, 0]);
 }

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Services/Ingestion/PDFDirectorySource.cs
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Services/Ingestion/PDFDirectorySource.cs
@@ -30,7 +30,7 @@ public class PDFDirectorySource(string sourceDirectory) : IIngestionSource
 #if (UseQdrant)
                 results.Add(new() { Key = Guid.CreateVersion7(), SourceId = SourceId, DocumentId = sourceFileId, DocumentVersion = sourceFileVersion });
 #else
-                results.Add(new() { Key = $"{SourceId}_{sourceFileId}", SourceId = SourceId, DocumentId = sourceFileId, DocumentVersion = sourceFileVersion });
+                results.Add(new() { Key = Guid.CreateVersion7().ToString(), SourceId = SourceId, DocumentId = sourceFileId, DocumentVersion = sourceFileVersion });
 #endif
             }
         }
@@ -58,7 +58,7 @@ public class PDFDirectorySource(string sourceDirectory) : IIngestionSource
 #if (UseQdrant)
             Key = Guid.CreateVersion7(),
 #else
-            Key = $"{Path.GetFileNameWithoutExtension(document.DocumentId)}_{pair.First.PageNumber}_{pair.First.IndexOnPage}",
+            Key = Guid.CreateVersion7().ToString(),
 #endif
             DocumentId = document.DocumentId,
             PageNumber = pair.First.PageNumber,

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/Services/IngestedDocument.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/Services/IngestedDocument.cs
@@ -17,6 +17,6 @@ public class IngestedDocument
     public required string DocumentVersion { get; set; }
 
     // The vector is not used but required for some vector databases
-    [VectorStoreRecordVector(1, DistanceFunction = DistanceFunction.CosineSimilarity)]
-    public ReadOnlyMemory<float> Vector { get; set; } = new ReadOnlyMemory<float>([0]);
+    [VectorStoreRecordVector(2, DistanceFunction = DistanceFunction.CosineSimilarity)]
+    public ReadOnlyMemory<float> Vector { get; set; } = new ReadOnlyMemory<float>([0, 0]);
 }

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/Services/Ingestion/PDFDirectorySource.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Basic.verified/aichatweb/Services/Ingestion/PDFDirectorySource.cs
@@ -27,7 +27,7 @@ public class PDFDirectorySource(string sourceDirectory) : IIngestionSource
             var existingDocumentVersion = existingDocumentsById.TryGetValue(sourceFileId, out var existingDocument) ? existingDocument.DocumentVersion : null;
             if (existingDocumentVersion != sourceFileVersion)
             {
-                results.Add(new() { Key = $"{SourceId}_{sourceFileId}", SourceId = SourceId, DocumentId = sourceFileId, DocumentVersion = sourceFileVersion });
+                results.Add(new() { Key = Guid.CreateVersion7().ToString(), SourceId = SourceId, DocumentId = sourceFileId, DocumentVersion = sourceFileVersion });
             }
         }
 
@@ -51,7 +51,7 @@ public class PDFDirectorySource(string sourceDirectory) : IIngestionSource
 
         return paragraphs.Zip(embeddings).Select((pair, index) => new IngestedChunk
         {
-            Key = $"{Path.GetFileNameWithoutExtension(document.DocumentId)}_{pair.First.PageNumber}_{pair.First.IndexOnPage}",
+            Key = Guid.CreateVersion7().ToString(),
             DocumentId = document.DocumentId,
             PageNumber = pair.First.PageNumber,
             Text = pair.First.Text,

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.BasicAspire.verified/aichatweb/aichatweb.Web/Services/IngestedDocument.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.BasicAspire.verified/aichatweb/aichatweb.Web/Services/IngestedDocument.cs
@@ -17,6 +17,6 @@ public class IngestedDocument
     public required string DocumentVersion { get; set; }
 
     // The vector is not used but required for some vector databases
-    [VectorStoreRecordVector(1, DistanceFunction = DistanceFunction.CosineSimilarity)]
-    public ReadOnlyMemory<float> Vector { get; set; } = new ReadOnlyMemory<float>([0]);
+    [VectorStoreRecordVector(2, DistanceFunction = DistanceFunction.CosineSimilarity)]
+    public ReadOnlyMemory<float> Vector { get; set; } = new ReadOnlyMemory<float>([0, 0]);
 }

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.BasicAspire.verified/aichatweb/aichatweb.Web/Services/Ingestion/PDFDirectorySource.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.BasicAspire.verified/aichatweb/aichatweb.Web/Services/Ingestion/PDFDirectorySource.cs
@@ -27,7 +27,7 @@ public class PDFDirectorySource(string sourceDirectory) : IIngestionSource
             var existingDocumentVersion = existingDocumentsById.TryGetValue(sourceFileId, out var existingDocument) ? existingDocument.DocumentVersion : null;
             if (existingDocumentVersion != sourceFileVersion)
             {
-                results.Add(new() { Key = $"{SourceId}_{sourceFileId}", SourceId = SourceId, DocumentId = sourceFileId, DocumentVersion = sourceFileVersion });
+                results.Add(new() { Key = Guid.CreateVersion7().ToString(), SourceId = SourceId, DocumentId = sourceFileId, DocumentVersion = sourceFileVersion });
             }
         }
 
@@ -51,7 +51,7 @@ public class PDFDirectorySource(string sourceDirectory) : IIngestionSource
 
         return paragraphs.Zip(embeddings).Select((pair, index) => new IngestedChunk
         {
-            Key = $"{Path.GetFileNameWithoutExtension(document.DocumentId)}_{pair.First.PageNumber}_{pair.First.IndexOnPage}",
+            Key = Guid.CreateVersion7().ToString(),
             DocumentId = document.DocumentId,
             PageNumber = pair.First.PageNumber,
             Text = pair.First.Text,

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.OpenAI_AzureAISearch.verified/aichatweb/Services/IngestedDocument.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.OpenAI_AzureAISearch.verified/aichatweb/Services/IngestedDocument.cs
@@ -17,6 +17,6 @@ public class IngestedDocument
     public required string DocumentVersion { get; set; }
 
     // The vector is not used but required for some vector databases
-    [VectorStoreRecordVector(1, DistanceFunction = DistanceFunction.CosineSimilarity)]
-    public ReadOnlyMemory<float> Vector { get; set; } = new ReadOnlyMemory<float>([0]);
+    [VectorStoreRecordVector(2, DistanceFunction = DistanceFunction.CosineSimilarity)]
+    public ReadOnlyMemory<float> Vector { get; set; } = new ReadOnlyMemory<float>([0, 0]);
 }

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.OpenAI_AzureAISearch.verified/aichatweb/Services/Ingestion/PDFDirectorySource.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.OpenAI_AzureAISearch.verified/aichatweb/Services/Ingestion/PDFDirectorySource.cs
@@ -27,7 +27,7 @@ public class PDFDirectorySource(string sourceDirectory) : IIngestionSource
             var existingDocumentVersion = existingDocumentsById.TryGetValue(sourceFileId, out var existingDocument) ? existingDocument.DocumentVersion : null;
             if (existingDocumentVersion != sourceFileVersion)
             {
-                results.Add(new() { Key = $"{SourceId}_{sourceFileId}", SourceId = SourceId, DocumentId = sourceFileId, DocumentVersion = sourceFileVersion });
+                results.Add(new() { Key = Guid.CreateVersion7().ToString(), SourceId = SourceId, DocumentId = sourceFileId, DocumentVersion = sourceFileVersion });
             }
         }
 
@@ -51,7 +51,7 @@ public class PDFDirectorySource(string sourceDirectory) : IIngestionSource
 
         return paragraphs.Zip(embeddings).Select((pair, index) => new IngestedChunk
         {
-            Key = $"{Path.GetFileNameWithoutExtension(document.DocumentId)}_{pair.First.PageNumber}_{pair.First.IndexOnPage}",
+            Key = Guid.CreateVersion7().ToString(),
             DocumentId = document.DocumentId,
             PageNumber = pair.First.PageNumber,
             Text = pair.First.Text,


### PR DESCRIPTION
I was trying to verify that the latest template works with Azure AI Search and found there are cases where it wouldn't, e.g. if your filenames contain characters that AI Search doesn't allow in keys. Also the new approach to tracking document ingestion was trying to store vectors of length 1 and AI Search requires length >= 2.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6429)