### PR TITLE
Remove unused API in Safety package

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyServiceConfigurationExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyServiceConfigurationExtensions.cs
@@ -40,37 +40,12 @@ public static class ContentSafetyServiceConfigurationExtensions
 #pragma warning disable CA2000 // Dispose objects before they go out of scope.
         // We can't dispose newChatClient here because it is returned to the caller.
 
-        var newChatClient = contentSafetyServiceConfiguration.ToIChatClient(originalChatConfiguration?.ChatClient);
+        var newChatClient =
+            new ContentSafetyChatClient(
+                contentSafetyServiceConfiguration,
+                originalChatClient: originalChatConfiguration?.ChatClient);
 #pragma warning restore CA2000
 
         return new ChatConfiguration(newChatClient);
-    }
-
-    /// <summary>
-    /// Returns an <see cref="IChatClient"/> that can be used to communicate with the Azure AI Foundry Evaluation
-    /// service for performing content safety evaluations.
-    /// </summary>
-    /// <param name="contentSafetyServiceConfiguration">
-    /// An object that specifies configuration parameters such as the Azure AI project that should be used, and the
-    /// credentials that should be used, when communicating with the Azure AI Foundry Evaluation service to perform
-    /// content safety evaluations.
-    /// </param>
-    /// <param name="originalChatClient">
-    /// The original <see cref="IChatClient"/>, if any. If specified, the returned
-    /// <see cref="IChatClient"/> will be a wrapper around <paramref name="originalChatClient"/> that can be used both
-    /// to communicate with the AI model that <paramref name="originalChatClient"/> is configured to communicate with,
-    /// as well as to communicate with the Azure AI Foundry Evaluation service.
-    /// </param>
-    /// <returns>
-    /// A <see cref="ChatConfiguration"/> that can be used to communicate with the Azure AI Foundry Evaluation service
-    /// for performing content safety evaluations.
-    /// </returns>
-    public static IChatClient ToIChatClient(
-        this ContentSafetyServiceConfiguration contentSafetyServiceConfiguration,
-        IChatClient? originalChatClient = null)
-    {
-        _ = Throw.IfNull(contentSafetyServiceConfiguration);
-
-        return new ContentSafetyChatClient(contentSafetyServiceConfiguration, originalChatClient);
     }
 }


### PR DESCRIPTION
This change ensures that we will have just one way to create a ChatConfiguration for the Safety evaluators.

The removed API was also confusing because it could mislead callers into thinking that the returned IChatClient can be used like any other general purpose LLM endpoint, when in fact it is pretty specialized and only intended for internal use within the Safety evaluators.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6439)