### PR TITLE
Ensure the type keyword is included when generating schemas for nullable enums.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.Create.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.Create.cs
@@ -274,6 +274,12 @@ public static partial class AIJsonUtilities
                     objSchema.InsertAtStart(TypePropertyName, "string");
                 }
 
+                // Include the type keyword in nullable enum types
+                if (Nullable.GetUnderlyingType(ctx.TypeInfo.Type)?.IsEnum is true && objSchema.ContainsKey(EnumPropertyName) && !objSchema.ContainsKey(TypePropertyName))
+                {
+                    objSchema.InsertAtStart(TypePropertyName, new JsonArray { (JsonNode)"string", (JsonNode)"null" });
+                }
+
                 // Filter potentially disallowed keywords.
                 foreach (string keyword in _schemaKeywordsDisallowedByAIVendors)
                 {

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
@@ -478,6 +478,20 @@ public static partial class AIJsonUtilitiesTests
     }
 
     [Fact]
+    public static void CreateJsonSchema_NullableEnum_IncludesTypeKeyword()
+    {
+        JsonElement expectedSchema = JsonDocument.Parse("""
+        {
+            "type": ["string", "null"],
+            "enum": ["A", "B", null]
+        }
+        """).RootElement;
+
+        JsonElement schema = AIJsonUtilities.CreateJsonSchema(typeof(MyEnumValue?), serializerOptions: JsonContext.Default.Options);
+        AssertDeepEquals(expectedSchema, schema);
+    }
+
+    [Fact]
     public static void AddAIContentType_DerivedAIContent()
     {
         JsonSerializerOptions options = new()
@@ -846,6 +860,7 @@ public static partial class AIJsonUtilitiesTests
     [JsonSerializable(typeof(DerivedAIContent))]
     [JsonSerializable(typeof(MyPoco))]
     [JsonSerializable(typeof(PocoWithTypesWithOpenAIUnsupportedKeywords))]
+    [JsonSerializable(typeof(MyEnumValue?))]
     private partial class JsonContext : JsonSerializerContext;
 
     private static bool DeepEquals(JsonElement element1, JsonElement element2)


### PR DESCRIPTION
Fixes an issue reported by @RogerBarreto.