### PR TITLE
Reduce per-lookup overhead from key validation in HybridCache

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.cs
@@ -252,6 +252,26 @@ internal sealed partial class DefaultHybridCache : HybridCache
         return null;
     }
 
+    // reserve non-printable characters from keys, to prevent potential L2 abuse
+    private static bool ContainsReservedCharacters(ReadOnlySpan<char> key)
+    {
+        const char MaxControlChar = (char)31;
+
+#if NET8_0_OR_GREATER
+        return key.IndexOfAnyInRange((char)0, MaxControlChar) >= 0;
+#else
+        foreach (char c in key)
+        {
+            if (c <= MaxControlChar)
+            {
+                return true;
+            }
+        }
+
+        return false;
+#endif
+    }
+
     private bool ValidateKey(string key)
     {
         if (string.IsNullOrWhiteSpace(key))
@@ -274,26 +294,6 @@ internal sealed partial class DefaultHybridCache : HybridCache
 
         // nothing to complain about
         return true;
-    }
-
-    // reserve non-printable characters from keys, to prevent potential L2 abuse
-    private bool ContainsReservedCharacters(ReadOnlySpan<char> key)
-    {
-        const char MaxControlChar = (char)31;
-
-#if NET8_0_OR_GREATER
-        return key.IndexOfAnyInRange((char)0, MaxControlChar) >= 0;
-#else
-        foreach (char c in key)
-        {
-            if (c <= MaxControlChar)
-            {
-                return true;
-            }
-        }
-
-        return false;
-#endif
     }
 
     private bool TryGetExisting<T>(string key, [NotNullWhen(true)] out CacheItem<T>? value)


### PR DESCRIPTION
`IndexOfAny(char[])` has per-call overhead to figure out what to do.
On modern .NET it would eventually hit a vectorized helper, but has to analyze the values every time.

Quick test with a default `MemoryCache`:

.NET 9/10
| Method         | Job  | KeyLength | Mean       | Error    | Ratio |
|--------------- |----- |---------- |-----------:|---------:|------:|
| GetCachedValue | main | 1         |   41.35 ns | 0.650 ns |  1.00 |
| GetCachedValue | pr   | 1         |   41.71 ns | 0.824 ns |  1.01 |
|                |      |           |            |          |       |
| GetCachedValue | main | 16        |   59.67 ns | 1.192 ns |  1.00 |
| GetCachedValue | pr   | 16        |   41.36 ns | 0.852 ns |  0.69 |
|                |      |           |            |          |       |
| GetCachedValue | main | 100       |   70.41 ns | 1.420 ns |  1.00 |
| GetCachedValue | pr   | 100       |   53.16 ns | 1.043 ns |  0.76 |

Framework
| Method         | Job  | KeyLength | Mean       | Error    | Ratio |
|--------------- |----- |---------- |-----------:|---------:|------:|
| GetCachedValue | main | 1         |   179.1 ns |  3.57 ns |  1.00 |
| GetCachedValue | pr   | 1         |   120.2 ns |  2.36 ns |  0.67 |
|                |      |           |            |          |       |
| GetCachedValue | main | 16        |   187.5 ns |  3.55 ns |  1.00 |
| GetCachedValue | pr   | 16        |   136.2 ns |  2.70 ns |  0.73 |
|                |      |           |            |          |       |
| GetCachedValue | main | 100       |   296.6 ns |  5.82 ns |  1.00 |
| GetCachedValue | pr   | 100       |   208.1 ns |  4.07 ns |  0.70 |
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6441)