### PR TITLE
Couple of fixes for safety evaluators

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyServiceConfigurationExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyServiceConfigurationExtensions.cs
@@ -48,4 +48,38 @@ public static class ContentSafetyServiceConfigurationExtensions
 
         return new ChatConfiguration(newChatClient);
     }
+
+    /// <summary>
+    /// Returns a <see cref="ChatConfiguration"/> that can be used to communicate with the Azure AI Foundry Evaluation
+    /// service for performing content safety evaluations.
+    /// </summary>
+    /// <param name="contentSafetyServiceConfiguration">
+    /// An object that specifies configuration parameters such as the Azure AI project that should be used, and the
+    /// credentials that should be used, when communicating with the Azure AI Foundry Evaluation service to perform
+    /// content safety evaluations.
+    /// </param>
+    /// <param name="originalChatClient">
+    /// The original <see cref="IChatClient"/>. The returned <see cref="ChatConfiguration.ChatClient"/> will be a
+    /// wrapper around <paramref name="originalChatClient"/> that can be used both to communicate with the AI model
+    /// that <paramref name="originalChatClient"/> is configured to communicate with, as well as to communicate with
+    /// the Azure AI Foundry Evaluation service.
+    /// </param>
+    /// <returns>
+    /// A <see cref="ChatConfiguration"/> that can be used to communicate with the Azure AI Foundry Evaluation service
+    /// for performing content safety evaluations.
+    /// </returns>
+    public static ChatConfiguration ToChatConfiguration(
+        this ContentSafetyServiceConfiguration contentSafetyServiceConfiguration,
+        IChatClient originalChatClient)
+    {
+        _ = Throw.IfNull(contentSafetyServiceConfiguration);
+
+#pragma warning disable CA2000 // Dispose objects before they go out of scope.
+        // We can't dispose newChatClient here because it is returned to the caller.
+
+        var newChatClient = new ContentSafetyChatClient(contentSafetyServiceConfiguration, originalChatClient);
+#pragma warning restore CA2000
+
+        return new ChatConfiguration(newChatClient);
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/SafetyEvaluatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/SafetyEvaluatorTests.cs
@@ -49,7 +49,7 @@ public class SafetyEvaluatorTests
             string usesContext = $"Feature: Context";
 
             var credential = new ChainedTokenCredential(new AzureCliCredential(), new DefaultAzureCredential());
-            ContentSafetyServiceConfiguration contentSafetyServiceConfiguration =
+            var contentSafetyServiceConfiguration =
                 new ContentSafetyServiceConfiguration(
                     credential,
                     subscriptionId: Settings.Current.AzureSubscriptionId,
@@ -153,8 +153,8 @@ public class SafetyEvaluatorTests
             The distance varies due to the elliptical orbits of both planets.
             """;
 
-        GroundednessProEvaluatorContext groundednessProContext = new GroundednessProEvaluatorContext(groundingContext);
-        UngroundedAttributesEvaluatorContext ungroundedAttributesContext = new UngroundedAttributesEvaluatorContext(groundingContext);
+        var groundednessProContext = new GroundednessProEvaluatorContext(groundingContext);
+        var ungroundedAttributesContext = new UngroundedAttributesEvaluatorContext(groundingContext);
         IEnumerable<EvaluationContext> additionalContext = [groundednessProContext, ungroundedAttributesContext];
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(messages, response, additionalContext);
@@ -228,8 +228,8 @@ public class SafetyEvaluatorTests
             At its furthest (conjunction), it can be approximately 601 million miles away.
             """;
 
-        GroundednessProEvaluatorContext groundednessProContext = new GroundednessProEvaluatorContext(groundingContext);
-        UngroundedAttributesEvaluatorContext ungroundedAttributesContext = new UngroundedAttributesEvaluatorContext(groundingContext);
+        var groundednessProContext = new GroundednessProEvaluatorContext(groundingContext);
+        var ungroundedAttributesContext = new UngroundedAttributesEvaluatorContext(groundingContext);
         IEnumerable<EvaluationContext> additionalContext = [groundednessProContext, ungroundedAttributesContext];
 
         EvaluationResult result = await scenarioRun.EvaluateAsync(messages, response2, additionalContext);
@@ -266,7 +266,7 @@ public class SafetyEvaluatorTests
             await _imageContentSafetyReportingConfiguration.CreateScenarioRunAsync(
                 scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(SafetyEvaluatorTests)}.{nameof(EvaluateConversationWithImageInQuestion)}");
 
-        ChatMessage question =
+        var question =
             new ChatMessage
             {
                 Role = ChatRole.User,
@@ -304,7 +304,7 @@ public class SafetyEvaluatorTests
 
         ChatMessage question = "Can you show me an image pertaining to DotNet?".ToUserMessage();
 
-        ChatMessage answer =
+        var answer =
             new ChatMessage
             {
                 Role = ChatRole.Assistant,
@@ -338,7 +338,7 @@ public class SafetyEvaluatorTests
             await _imageContentSafetyReportingConfiguration.CreateScenarioRunAsync(
                 scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(SafetyEvaluatorTests)}.{nameof(EvaluateConversationWithImagesInMultipleTurns)}");
 
-        ChatMessage question1 =
+        var question1 =
             new ChatMessage
             {
                 Role = ChatRole.User,
@@ -351,7 +351,7 @@ public class SafetyEvaluatorTests
 
         ChatMessage question2 = "Can you show me an image pertaining to Microsoft Copilot?".ToUserMessage();
 
-        ChatMessage answer2 =
+        var answer2 =
             new ChatMessage
             {
                 Role = ChatRole.Assistant,
@@ -387,7 +387,7 @@ public class SafetyEvaluatorTests
             await _imageContentSafetyReportingConfiguration.CreateScenarioRunAsync(
                 scenarioName: $"Microsoft.Extensions.AI.Evaluation.Integration.Tests.{nameof(SafetyEvaluatorTests)}.{nameof(EvaluateConversationWithImagesAndTextInMultipleTurns)}");
 
-        ChatMessage question1 =
+        var question1 =
             new ChatMessage
             {
                 Role = ChatRole.User,
@@ -400,7 +400,7 @@ public class SafetyEvaluatorTests
 
         ChatMessage question2 = "Can you show me an image pertaining to Microsoft Copilot?".ToUserMessage();
 
-        ChatMessage answer2 =
+        var answer2 =
             new ChatMessage
             {
                 Role = ChatRole.Assistant,
@@ -499,7 +499,7 @@ public class SafetyEvaluatorTests
             """.ToAssistantMessage();
 
         ChatMessage[] messages = [context1, completion1, context2];
-        ChatResponse response = new ChatResponse(completion2);
+        var response = new ChatResponse(completion2);
         EvaluationResult result = await scenarioRun.EvaluateAsync(messages, response);
 
         Assert.False(


### PR DESCRIPTION
Includes following changes -

**Add a convenience overload:**
  Currently, if a caller wants to run evaluations that involve both safety and quality evals, they need to create one ChatConfiguration for the LLM interactions and then wrap it with another ChatConfiguration for the AI Foundry service (by calling the existing overload for ToChatConfiguration).
  
  The new overload makes it so that caller only needs to create a IChatClient for the LLM interactions needed for the quality evals. They can then directly call ToChatConfiguration with this IChatClient to get a single Chatconfiguration (which supports both safety and quality evals) and supply this ChatConfiguration as part of the ReportingConfiguration.

**Improve an error message:**
  The NotSupportedException being thrown before was pretty opaque. Improve the error so that the reason is a bit clearer.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6444)