### PR TITLE
Add a script to diff the contents of folders that match a specific pattern across two branches

### DIFF
--- a/scripts/DiffBranches.ps1
+++ b/scripts/DiffBranches.ps1
@@ -1,0 +1,76 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$baseline = "main",
+    
+    [Parameter(Mandatory=$true)]
+    [string]$target,
+    
+    [Parameter(Mandatory=$false)]
+    [string]$folderPattern = "*.AI.*",
+    
+    [Parameter(Mandatory=$false)]
+    [switch]$showDiff
+)
+
+function Invoke-GitCommand {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Command,
+
+        [Parameter(Mandatory=$false)]
+        [switch]$UseCmd
+    )
+
+    if ($UseCmd) {
+        $Command = "cmd.exe /c $Command"
+    }
+        
+    Write-Host "Executing $Command" -ForegroundColor Blue
+    $result = Invoke-Expression $Command
+    return $result
+}
+
+# Save the current directory
+$originalLocation = Get-Location
+
+try {
+    # Get the root directory of the git repository
+    $gitRootCommand = "git rev-parse --show-toplevel"
+    $repoRoot = Invoke-GitCommand -Command $gitRootCommand
+    Write-Host "Repo root is $repoRoot" -ForegroundColor Blue
+
+    # Change to the repository root directory
+    Set-Location $repoRoot
+    
+    # Get all changed files between the two branches
+    $gitFilesCommand = "git diff --name-only $baseline..$target"
+    $changedFiles = Invoke-GitCommand -Command $gitFilesCommand
+
+    # Filter for files under folders containing the specified pattern
+    $matchedFiles = $changedFiles | Where-Object { 
+        $path = $_
+        $folders = $path -split '/'
+        $folders | Where-Object { $_ -like $folderPattern } | Select-Object -First 1
+    }
+
+    if ($matchedFiles.Count -eq 0) {
+        Write-Host "No changes detected." -ForegroundColor Green
+    } else {
+        Write-Host "Changes detected in following files:" -ForegroundColor Yellow
+        $matchedFiles | ForEach-Object { Write-Host "  $_" }
+        
+        if ($showDiff) {
+            Write-Host "File diffs:" -ForegroundColor Yellow
+            
+            $gitDiffCommand = "git -C `"$repoRoot`" diff --color $baseline..$target -- $($matchedFiles -join ' ')"
+            
+            # Use the -UseCmd switch to run the command with cmd.exe (preserves color and paging)
+            Invoke-GitCommand -Command $gitDiffCommand -UseCmd
+        }
+    }
+}
+finally {
+    # Return to the original directory even if an error occurs
+    Set-Location $originalLocation
+}


### PR DESCRIPTION
Over recent releases, there have been multiple occasions where I found myself needing to compare the contents of two branches to figure out what is different for a subset of libraries (such as *Evaluation*).

I'd like to check in the script that I have been using for this since this may prove useful again in the future.