### PR TITLE
Remove `title` and `description` keywords from root-level schemas in AIFunctionFactory.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -692,10 +692,10 @@ public static partial class AIFunctionFactory
             JsonSerializerOptions = serializerOptions;
             JsonSchema = AIJsonUtilities.CreateFunctionJsonSchema(
                 key.Method,
-                Name,
-                Description,
-                serializerOptions,
-                schemaOptions);
+                title: string.Empty, // Forces skipping of the title keyword
+                description: string.Empty, // Forces skipping of the description keyword
+                serializerOptions: serializerOptions,
+                inferenceOptions: schemaOptions);
         }
 
         public string Name { get; }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
@@ -304,7 +304,7 @@ public static partial class AIJsonUtilitiesTests
 
         Assert.NotNull(func.UnderlyingMethod);
 
-        JsonElement resolvedSchema = AIJsonUtilities.CreateFunctionJsonSchema(func.UnderlyingMethod, title: func.Name);
+        JsonElement resolvedSchema = AIJsonUtilities.CreateFunctionJsonSchema(func.UnderlyingMethod, title: string.Empty);
         AssertDeepEquals(resolvedSchema, func.JsonSchema);
     }
 
@@ -333,8 +333,6 @@ public static partial class AIJsonUtilitiesTests
 
         JsonElement expected = JsonDocument.Parse($$"""
             {
-              "title": "get_weather",
-              "description": "Gets the current weather for a current location",
               "type": "object",
               "properties": {
                 "city": {
@@ -369,11 +367,7 @@ public static partial class AIJsonUtilitiesTests
         Assert.NotNull(func.UnderlyingMethod);
         AssertDeepEquals(expected, func.JsonSchema);
 
-        JsonElement resolvedSchema = AIJsonUtilities.CreateFunctionJsonSchema(
-            func.UnderlyingMethod,
-            title: func.Name,
-            description: func.Description,
-            inferenceOptions: inferenceOptions);
+        JsonElement resolvedSchema = AIJsonUtilities.CreateFunctionJsonSchema(func.UnderlyingMethod, title: string.Empty, description: string.Empty, inferenceOptions: inferenceOptions);
         AssertDeepEquals(expected, resolvedSchema);
     }
 


### PR DESCRIPTION
As an alternative solution to https://github.com/modelcontextprotocol/csharp-sdk/pull/436, this PR removes the `title` and `description` keywords from root-level schemas in AIFunctionFactory. This is due to the fact both keywords are already represented in the resultant `AIFunction` via the `Name` and `Description` properties respectively, and because keywords beyond `type`, `properties`, and `required` is known to create problems with certain clients in the context of MCP.

Because both the `name` and `description` keywords are optional in the schema, I do not consider this to be a breaking change.

Fix https://github.com/modelcontextprotocol/csharp-sdk/issues/342. Supersedes https://github.com/modelcontextprotocol/csharp-sdk/pull/436