### PR TITLE
HybridCache : simplify AOT usage with default JSON serialization

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/HybridCacheBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/HybridCacheBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Shared.Diagnostics;
 
@@ -57,6 +58,27 @@ public static class HybridCacheBuilderExtensions
         where TImplementation : class, IHybridCacheSerializerFactory
     {
         _ = Throw.IfNull(builder).Services.AddSingleton<IHybridCacheSerializerFactory, TImplementation>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Register a default <see cref="JsonSerializerOptions"/> for use with JSON serialization.
+    /// </summary>
+    /// <returns>The <see cref="IHybridCacheBuilder"/> instance.</returns>
+    public static IHybridCacheBuilder WithJsonSerializerOptions(this IHybridCacheBuilder builder, JsonSerializerOptions options)
+    {
+        _ = Throw.IfNull(builder).Services.AddKeyedSingleton<JsonSerializerOptions>(typeof(IHybridCacheSerializer<>), Throw.IfNull(options));
+        return builder;
+    }
+
+    /// <summary>
+    /// Register a <see cref="JsonSerializerOptions"/> for use with JSON serialization of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type being serialized.</typeparam>
+    /// <returns>The <see cref="IHybridCacheBuilder"/> instance.</returns>
+    public static IHybridCacheBuilder WithJsonSerializerOptions<T>(this IHybridCacheBuilder builder, JsonSerializerOptions options)
+    {
+        _ = Throw.IfNull(builder).Services.AddKeyedSingleton<JsonSerializerOptions>(typeof(IHybridCacheSerializer<T>), Throw.IfNull(options));
         return builder;
     }
 }


### PR DESCRIPTION
1. don't touch `JsonSerializerOptions.Default` in AOT mode
2. add new extension methods to register JsonSerializerOptions
3. offer a suitable error message instead, if none supplied in AOT mode
4. include `[UnconditionalSuppressMessage]` to prevent build-time consumer warnings

This has been tested successfully with an AOT published project; it now works correctly at runtime with zero build-time warnings, test code shown below; without the `WithJsonSerializerOptions` line, exception at runtime:

>  When using AOT, JsonSerializerOptions with TypeInfoResolver specified must be provided via IHybridCacheBuilder.WithJsonSerializerOptions.

Without this work, it is unclear how to register AOT JSON options, and the consumer must use `<NoWarn>$(NoWarn);IL2026;IL2104;IL3053</NoWarn>` or similar.

open questions:

- naming: With* or Add* ?
- which API review process should this follow?

Sample:

``` c#
// Licensed to the .NET Foundation under one or more agreements.
// The .NET Foundation licenses this file to you under the MIT license.

using System.Text.Json;
using System.Text.Json.Serialization;
using Microsoft.Extensions.Caching.Hybrid;
using Microsoft.Extensions.DependencyInjection;

var services = new ServiceCollection();
var jsonOptions = new JsonSerializerOptions() { TypeInfoResolver = Bar.MyJsonSerializationContext.Default };
services.AddHybridCache().WithJsonSerializerOptions(jsonOptions);
services.AddStackExchangeRedisCache(options => options.Configuration = "localhost:6379");
using var provider = services.BuildServiceProvider();

var cache = provider.GetRequiredService<HybridCache>();

int id = 42;
var obj = await cache.GetOrCreateAsync($"/ob/{id}", ct => GetTheThingAsync(id));
Console.WriteLine(obj.Id);

static ValueTask<Bar.Foo> GetTheThingAsync(int id) => new(new Bar.Foo(id));

namespace Bar
{
    [JsonSourceGenerationOptions(WriteIndented = true)]
    [JsonSerializable(typeof(Foo))]
    internal partial class MyJsonSerializationContext : JsonSerializerContext
    {
    }

    internal sealed class Foo(int id)
    {
        public int Id => id;
    }
}
```
