### PR TITLE
Improve handling of RawRepresentation in OpenAI{Response}ChatClient

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -261,6 +261,9 @@ internal sealed partial class OpenAIChatClient : IChatClient
 
             case DataContent dataContent when dataContent.MediaType.StartsWith("application/pdf", StringComparison.OrdinalIgnoreCase):
                 return ChatMessageContentPart.CreateFilePart(BinaryData.FromBytes(dataContent.Data), dataContent.MediaType, $"{Guid.NewGuid():N}.pdf");
+
+            case AIContent when content.RawRepresentation is ChatMessageContentPart rawContentPart:
+                return rawContentPart;
         }
 
         return null;

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -264,17 +264,22 @@ public class OpenAIResponseClientTests
         Assert.Equal("Hello! How can I assist you today?", string.Concat(updates.Select(u => u.Text)));
 
         var createdAt = DateTimeOffset.FromUnixTimeSeconds(1_741_892_091);
-        Assert.Equal(10, updates.Count);
+        Assert.Equal(17, updates.Count);
+
         for (int i = 0; i < updates.Count; i++)
         {
             Assert.Equal("resp_67d329fbc87c81919f8952fe71dafc96029dabe3ee19bb77", updates[i].ResponseId);
             Assert.Equal("resp_67d329fbc87c81919f8952fe71dafc96029dabe3ee19bb77", updates[i].ConversationId);
             Assert.Equal(createdAt, updates[i].CreatedAt);
             Assert.Equal("gpt-4o-mini-2024-07-18", updates[i].ModelId);
-            Assert.Equal(ChatRole.Assistant, updates[i].Role);
             Assert.Null(updates[i].AdditionalProperties);
-            Assert.Equal(i == 10 ? 0 : 1, updates[i].Contents.Count);
+            Assert.Equal((i >= 4 && i <= 12) || i == 16 ? 1 : 0, updates[i].Contents.Count);
             Assert.Equal(i < updates.Count - 1 ? null : ChatFinishReason.Stop, updates[i].FinishReason);
+        }
+
+        for (int i = 4; i < updates.Count; i++)
+        {
+            Assert.Equal(ChatRole.Assistant, updates[i].Role);
         }
 
         UsageContent usage = updates.SelectMany(u => u.Contents).OfType<UsageContent>().Single();


### PR DESCRIPTION
We weren't always including the original object as the RawRepresentation, and we weren't returning every streaming update raw object. Make sure we do. Also improves the ability to break glass by checking arbitrary AIContent instances for a RawRepresentation that's then used as-is.