### PR TITLE
Add ChatOptions.Instructions

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
@@ -15,6 +15,9 @@ public class ChatOptions
     /// <related type="Article" href="https://learn.microsoft.com/dotnet/ai/microsoft-extensions-ai#stateless-vs-stateful-clients">Stateless vs. stateful clients.</related>
     public string? ConversationId { get; set; }
 
+    /// <summary>Gets or sets additional per-request instructions to be provided to the <see cref="IChatClient"/>.</summary>
+    public string? Instructions { get; set; }
+
     /// <summary>Gets or sets the temperature for generating chat responses.</summary>
     /// <remarks>
     /// This value controls the randomness of predictions made by the model. Use a lower value to decrease randomness in the response.
@@ -146,20 +149,21 @@ public class ChatOptions
     {
         ChatOptions options = new()
         {
-            ConversationId = ConversationId,
-            Temperature = Temperature,
-            MaxOutputTokens = MaxOutputTokens,
-            TopP = TopP,
-            TopK = TopK,
-            FrequencyPenalty = FrequencyPenalty,
-            PresencePenalty = PresencePenalty,
-            Seed = Seed,
-            ResponseFormat = ResponseFormat,
-            ModelId = ModelId,
-            AllowMultipleToolCalls = AllowMultipleToolCalls,
-            ToolMode = ToolMode,
-            RawRepresentationFactory = RawRepresentationFactory,
             AdditionalProperties = AdditionalProperties?.Clone(),
+            AllowMultipleToolCalls = AllowMultipleToolCalls,
+            ConversationId = ConversationId,
+            FrequencyPenalty = FrequencyPenalty,
+            Instructions = Instructions,
+            MaxOutputTokens = MaxOutputTokens,
+            ModelId = ModelId,
+            PresencePenalty = PresencePenalty,
+            RawRepresentationFactory = RawRepresentationFactory,
+            ResponseFormat = ResponseFormat,
+            Seed = Seed,
+            Temperature = Temperature,
+            ToolMode = ToolMode,
+            TopK = TopK,
+            TopP = TopP,
         };
 
         if (StopSequences is not null)

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -924,6 +924,10 @@
           "Stage": "Stable"
         },
         {
+          "Member": "string? Microsoft.Extensions.AI.ChatOptions.Instructions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
           "Member": "float? Microsoft.Extensions.AI.ChatOptions.FrequencyPenalty { get; set; }",
           "Stage": "Stable"
         },

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
@@ -283,7 +283,7 @@ internal sealed class AzureAIInferenceChatClient : IChatClient
         new(s);
 
     private ChatCompletionsOptions CreateAzureAIOptions(IEnumerable<ChatMessage> chatContents, ChatOptions? options) =>
-        new(ToAzureAIInferenceChatMessages(chatContents))
+        new(ToAzureAIInferenceChatMessages(chatContents, options))
         {
             Model = options?.ModelId ?? _metadata.DefaultModelId ??
                 throw new InvalidOperationException("No model id was provided when either constructing the client or in the chat options.")
@@ -299,7 +299,7 @@ internal sealed class AzureAIInferenceChatClient : IChatClient
 
         if (options.RawRepresentationFactory?.Invoke(this) is ChatCompletionsOptions result)
         {
-            result.Messages = ToAzureAIInferenceChatMessages(chatContents).ToList();
+            result.Messages = ToAzureAIInferenceChatMessages(chatContents, options).ToList();
             result.Model ??= options.ModelId ?? _metadata.DefaultModelId ??
                 throw new InvalidOperationException("No model id was provided when either constructing the client or in the chat options.");
         }
@@ -422,10 +422,15 @@ internal sealed class AzureAIInferenceChatClient : IChatClient
     }
 
     /// <summary>Converts an Extensions chat message enumerable to an AzureAI chat message enumerable.</summary>
-    private static IEnumerable<ChatRequestMessage> ToAzureAIInferenceChatMessages(IEnumerable<ChatMessage> inputs)
+    private static IEnumerable<ChatRequestMessage> ToAzureAIInferenceChatMessages(IEnumerable<ChatMessage> inputs, ChatOptions? options)
     {
         // Maps all of the M.E.AI types to the corresponding AzureAI types.
         // Unrecognized or non-processable content is ignored.
+
+        if (options?.Instructions is { } instructions && !string.IsNullOrWhiteSpace(instructions))
+        {
+            yield return new ChatRequestSystemMessage(instructions);
+        }
 
         foreach (ChatMessage input in inputs)
         {

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatRequest.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatRequest.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.AI;
 internal sealed class OllamaChatRequest
 {
     public required string Model { get; set; }
-    public required OllamaChatRequestMessage[] Messages { get; set; }
+    public required IList<OllamaChatRequestMessage> Messages { get; set; }
     public JsonElement? Format { get; set; }
     public bool Stream { get; set; }
     public IEnumerable<OllamaTool>? Tools { get; set; }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponseChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponseChatClient.cs
@@ -366,6 +366,12 @@ internal sealed partial class OpenAIResponseChatClient : IChatClient
         result.TopP ??= options.TopP;
         result.Temperature ??= options.Temperature;
         result.ParallelToolCallsEnabled ??= options.AllowMultipleToolCalls;
+        if (options.Instructions is { } instructions)
+        {
+            result.Instructions = string.IsNullOrEmpty(result.Instructions) ?
+                instructions :
+                $"{result.Instructions}{Environment.NewLine}{instructions}";
+        }
 
         // Populate tools if there are any.
         if (options.Tools is { Count: > 0 } tools)

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatOptionsTests.cs
@@ -15,6 +15,7 @@ public class ChatOptionsTests
     {
         ChatOptions options = new();
         Assert.Null(options.ConversationId);
+        Assert.Null(options.Instructions);
         Assert.Null(options.Temperature);
         Assert.Null(options.MaxOutputTokens);
         Assert.Null(options.TopP);
@@ -33,6 +34,7 @@ public class ChatOptionsTests
 
         ChatOptions clone = options.Clone();
         Assert.Null(clone.ConversationId);
+        Assert.Null(clone.Instructions);
         Assert.Null(clone.Temperature);
         Assert.Null(clone.MaxOutputTokens);
         Assert.Null(clone.TopP);
@@ -75,6 +77,7 @@ public class ChatOptionsTests
         Func<IChatClient, object?> rawRepresentationFactory = (c) => null;
 
         options.ConversationId = "12345";
+        options.Instructions = "Some instructions";
         options.Temperature = 0.1f;
         options.MaxOutputTokens = 2;
         options.TopP = 0.3f;
@@ -92,6 +95,7 @@ public class ChatOptionsTests
         options.AdditionalProperties = additionalProps;
 
         Assert.Equal("12345", options.ConversationId);
+        Assert.Equal("Some instructions", options.Instructions);
         Assert.Equal(0.1f, options.Temperature);
         Assert.Equal(2, options.MaxOutputTokens);
         Assert.Equal(0.3f, options.TopP);
@@ -144,6 +148,7 @@ public class ChatOptionsTests
         };
 
         options.ConversationId = "12345";
+        options.Instructions = "Some instructions";
         options.Temperature = 0.1f;
         options.MaxOutputTokens = 2;
         options.TopP = 0.3f;
@@ -170,6 +175,7 @@ public class ChatOptionsTests
         Assert.NotNull(deserialized);
 
         Assert.Equal("12345", deserialized.ConversationId);
+        Assert.Equal("Some instructions", deserialized.Instructions);
         Assert.Equal(0.1f, deserialized.Temperature);
         Assert.Equal(2, deserialized.MaxOutputTokens);
         Assert.Equal(0.3f, deserialized.TopP);


### PR DESCRIPTION
More services (especially those focused on agents) are starting to support the notion of per-request instructions, effectively system messages that aren't stored as part of a persisted chat history. For existing stateless services that don't have their own notion of separate instructions, we can just translate instructions into a system message.