### PR TITLE
CompletenessEvaluator: Remove Seed parameter from ChatOptions

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/CompletenessEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/CompletenessEvaluator.cs
@@ -54,7 +54,6 @@ public sealed class CompletenessEvaluator : IEvaluator
             Temperature = 0.0f,
             MaxOutputTokens = 800,
             TopP = 1.0f,
-            Seed = 123,
             PresencePenalty = 0.0f,
             FrequencyPenalty = 0.0f,
             ResponseFormat = ChatResponseFormat.Text


### PR DESCRIPTION
Azure AI does not accept that parameter, which causes this evaluator to error out.

```
Diagnostics
Severity
Message
Error
Azure.RequestFailedException: {"detail":[{"type":"extra_forbidden","loc":["body","seed"],"msg":"Extra inputs are not permitted","input":123,"url":"https://errors.pydantic.dev/2.10/v/extra_forbidden"}]}
Status: 422 (Unprocessable Entity)
ErrorCode: Invalid input

Content:
{"error":{"code":"Invalid input","message":"{\"detail\":[{\"type\":\"extra_forbidden\",\"loc\":[\"body\",\"seed\"],\"msg\":\"Extra inputs are not permitted\",\"input\":123,\"url\":\"https://errors.pydantic.dev/2.10/v/extra_forbidden\"}]}","status":422}}
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6519)