### PR TITLE
Efficiency updates to BLEU score processing

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/BLEUEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/BLEUEvaluator.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -79,8 +80,8 @@ public sealed class BLEUEvaluator : IEvaluator
 
         var (score, duration) = TimingHelper.ExecuteWithTiming(() =>
         {
-            var references = context.References.Select(reference => SimpleWordTokenizer.WordTokenize(reference));
-            var hypothesis = SimpleWordTokenizer.WordTokenize(modelResponse.Text);
+            var references = context.References.Select(reference => SimpleWordTokenizer.WordTokenize(reference).ToArray()).ToArray();
+            var hypothesis = SimpleWordTokenizer.WordTokenize(modelResponse.Text).ToArray();
             return BLEUAlgorithm.SentenceBLEU(references, hypothesis, BLEUAlgorithm.DefaultBLEUWeights, SmoothingFunction.Method4);
         });
 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/BLEUEvaluatorContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/BLEUEvaluatorContext.cs
@@ -41,8 +41,8 @@ public sealed class BLEUEvaluatorContext : EvaluationContext
     /// <param name="references">
     /// The reference responses against which the response that is being evaluated is compared.
     /// </param>
-    public BLEUEvaluatorContext(params string[] references)
-        : this(references as IEnumerable<string>)
+    public BLEUEvaluatorContext(IEnumerable<string> references)
+        : this(references.ToArray())
     {
     }
 
@@ -52,11 +52,12 @@ public sealed class BLEUEvaluatorContext : EvaluationContext
     /// <param name="references">
     /// The reference responses against which the response that is being evaluated is compared.
     /// </param>
-    public BLEUEvaluatorContext(IEnumerable<string> references)
+    public BLEUEvaluatorContext(params string[] references)
         : base(
             name: BLEUContextName,
             contents: [.. references.Select(c => new TextContent(c))])
     {
         References = [.. references];
     }
+
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/Common/MatchCounter.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/Common/MatchCounter.cs
@@ -53,7 +53,7 @@ internal readonly struct MatchCounter<T> : IEnumerable<KeyValuePair<T, int>>
         }
     }
 
-    public string ToDebugString() => string.Concat(_counts.Select(v => $"{v.Key}: {v.Value}, "));
+    public string ToDebugString() => string.Join(",", _counts.Select(v => $"{v.Key}: {v.Value}"));
 
     public IEnumerator<KeyValuePair<T, int>> GetEnumerator() => _counts.GetEnumerator();
 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/Common/NGramExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/Common/NGramExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI.Evaluation.NLP.Common;
@@ -14,12 +13,16 @@ internal static class NGramExtensions
     public static NGram<T> CreateNGram<T>(this ReadOnlySpan<T> values)
         where T : IEquatable<T> => new(values);
 
+    internal static IEnumerable<NGram<T>> CreateNGrams<T>(this Span<T> input, int n)
+        where T : IEquatable<T>
+        => CreateNGrams((ReadOnlySpan<T>)input, n);
+
     /// <summary>
     /// Create a sequence of n-grams from the input sequence.
     /// </summary>
     /// <param name="input">The input sequence of items.</param>
     /// <param name="n">The size of each n-gram.</param>
-    internal static IEnumerable<NGram<T>> CreateNGrams<T>(this IEnumerable<T> input, int n)
+    internal static List<NGram<T>> CreateNGrams<T>(this ReadOnlySpan<T> input, int n)
         where T : IEquatable<T>
     {
         if (n <= 0)
@@ -27,15 +30,19 @@ internal static class NGramExtensions
             Throw.ArgumentOutOfRangeException(nameof(n), $"'{nameof(n)}' must be greater than zero.");
         }
 
-        T[] output = [.. input.Take(n)];
+        List<NGram<T>> nGrams = [];
+
+        ReadOnlySpan<T> output = input.Slice(0, Math.Min(n, input.Length));
 
         while (output.Length == n)
         {
-            yield return new NGram<T>(output);
+            nGrams.Add(new NGram<T>(output));
 
-            input = input.Skip(1);
-            output = [.. input.Take(n)];
+            input = input.Slice(1);
+            output = input.Slice(0, Math.Min(n, input.Length));
         }
+
+        return nGrams;
     }
 
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/Microsoft.Extensions.AI.Evaluation.NLP.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/Microsoft.Extensions.AI.Evaluation.NLP.csproj
@@ -17,6 +17,7 @@
 
   <PropertyGroup>
     <InjectCollectionBuilderAttributesOnLegacy>true</InjectCollectionBuilderAttributesOnLegacy>
+    <InjectSystemIndexOnLegacy>true</InjectSystemIndexOnLegacy>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.NLP.Tests/BLEUAlgorithmTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.NLP.Tests/BLEUAlgorithmTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.AI.Evaluation.NLP.Common;
 using Xunit;
@@ -15,8 +14,8 @@ public class BLEUAlgorithmTests
     [Fact]
     public void ModifiedPrecisionTests()
     {
-        IEnumerable<IEnumerable<string>> references = ["the cat is on the mat".Split(' '), "there is a cat on the mat".Split(' ')];
-        IEnumerable<string> hypothesis = "the the the the the the the".Split(' ');
+        string[][] references = ["the cat is on the mat".Split(' '), "there is a cat on the mat".Split(' ')];
+        string[] hypothesis = "the the the the the the the".Split(' ');
         RationalNumber prec = ModifiedPrecision(references, hypothesis, 1);
         Assert.Equal(0.2857, prec.ToDouble(), 4);
 
@@ -36,8 +35,8 @@ public class BLEUAlgorithmTests
             "It is the guiding principle which guarantees the military forces always being under the command of the Party".Split(' '),
             "It is the practical guide for the army always to heed the directions of the party".Split(' '),
         ];
-        IEnumerable<string> hypothesis1 = "It is a guide to action which ensures that the military always obeys the commands of the party".Split(' ');
-        IEnumerable<string> hypothesis2 = "It is to insure the troops forever hearing the activity guidebook that party direct".Split(' ');
+        string[] hypothesis1 = "It is a guide to action which ensures that the military always obeys the commands of the party".Split(' ');
+        string[] hypothesis2 = "It is to insure the troops forever hearing the activity guidebook that party direct".Split(' ');
         prec = ModifiedPrecision(references, hypothesis1, 1);
         Assert.Equal(0.9444, prec.ToDouble(), 4);
         prec = ModifiedPrecision(references, hypothesis2, 1);
@@ -76,63 +75,63 @@ public class BLEUAlgorithmTests
     [Fact]
     public void TestBrevityPenalty()
     {
-        IEnumerable<IEnumerable<string>> references = [
-            Enumerable.Repeat("a", 11),
-            Enumerable.Repeat("a", 8),
+        string[][] references = [
+            [.. Enumerable.Repeat("a", 11)],
+            [.. Enumerable.Repeat("a", 8)],
         ];
-        IEnumerable<string> hypothesis = Enumerable.Repeat("a", 7);
+        string[] hypothesis = [.. Enumerable.Repeat("a", 7)];
         int hypLength = hypothesis.Count();
         int closestRefLength = ClosestRefLength(references, hypLength);
         double brevityPenalty = BrevityPenalty(closestRefLength, hypLength);
         Assert.Equal(0.8669, brevityPenalty, 4);
 
         references = [
-            Enumerable.Repeat("a", 11),
-            Enumerable.Repeat("a", 8),
-            Enumerable.Repeat("a", 6),
-            Enumerable.Repeat("a", 7),
+            [.. Enumerable.Repeat("a", 11)],
+            [.. Enumerable.Repeat("a", 8)],
+            [.. Enumerable.Repeat("a", 6)],
+            [.. Enumerable.Repeat("a", 7)],
         ];
-        hypothesis = Enumerable.Repeat("a", 7);
+        hypothesis = [.. Enumerable.Repeat("a", 7)];
         hypLength = hypothesis.Count();
         closestRefLength = ClosestRefLength(references, hypLength);
         brevityPenalty = BrevityPenalty(closestRefLength, hypLength);
         Assert.Equal(1.0, brevityPenalty, 4);
 
         references = [
-            Enumerable.Repeat("a", 28),
-            Enumerable.Repeat("a", 28),
+            [.. Enumerable.Repeat("a", 28)],
+            [.. Enumerable.Repeat("a", 28)],
         ];
-        hypothesis = Enumerable.Repeat("a", 12);
+        hypothesis = [.. Enumerable.Repeat("a", 12)];
         hypLength = hypothesis.Count();
         closestRefLength = ClosestRefLength(references, hypLength);
         brevityPenalty = BrevityPenalty(closestRefLength, hypLength);
         Assert.Equal(0.26359, brevityPenalty, 4);
 
         references = [
-            Enumerable.Repeat("a", 13),
-            Enumerable.Repeat("a", 2),
+            [.. Enumerable.Repeat("a", 13)],
+            [.. Enumerable.Repeat("a", 2)],
         ];
-        hypothesis = Enumerable.Repeat("a", 12);
+        hypothesis = [.. Enumerable.Repeat("a", 12)];
         hypLength = hypothesis.Count();
         closestRefLength = ClosestRefLength(references, hypLength);
         brevityPenalty = BrevityPenalty(closestRefLength, hypLength);
         Assert.Equal(0.9200, brevityPenalty, 4);
 
         references = [
-            Enumerable.Repeat("a", 13),
-            Enumerable.Repeat("a", 11),
+            [.. Enumerable.Repeat("a", 13)],
+            [.. Enumerable.Repeat("a", 11)],
         ];
-        hypothesis = Enumerable.Repeat("a", 12);
+        hypothesis = [.. Enumerable.Repeat("a", 12)];
         hypLength = hypothesis.Count();
         closestRefLength = ClosestRefLength(references, hypLength);
         brevityPenalty = BrevityPenalty(closestRefLength, hypLength);
         Assert.Equal(1.0, brevityPenalty, 4);
 
         references = [
-            Enumerable.Repeat("a", 11),
-            Enumerable.Repeat("a", 13),
+            [.. Enumerable.Repeat("a", 11)],
+            [.. Enumerable.Repeat("a", 13)],
         ];
-        hypothesis = Enumerable.Repeat("a", 12);
+        hypothesis = [.. Enumerable.Repeat("a", 12)];
         hypLength = hypothesis.Count();
         closestRefLength = ClosestRefLength(references, hypLength);
         brevityPenalty = BrevityPenalty(closestRefLength, hypLength);
@@ -143,8 +142,8 @@ public class BLEUAlgorithmTests
     [Fact]
     public void TestZeroMatches()
     {
-        IEnumerable<IEnumerable<string>> references = ["The candidate has no alignment to any of the references".Split(' '),];
-        IEnumerable<string> hypothesis = "John loves Mary".Split(' ');
+        string[][] references = ["The candidate has no alignment to any of the references".Split(' '),];
+        string[] hypothesis = "John loves Mary".Split(' ');
 
         double score = SentenceBLEU(references, hypothesis, EqualWeights(hypothesis.Count()));
         Assert.Equal(0.0, score, 4);
@@ -153,8 +152,8 @@ public class BLEUAlgorithmTests
     [Fact]
     public void TestFullMatches()
     {
-        IEnumerable<IEnumerable<string>> references = ["John loves Mary".Split(' '),];
-        IEnumerable<string> hypothesis = "John loves Mary".Split(' ');
+        string[][] references = ["John loves Mary".Split(' '),];
+        string[] hypothesis = "John loves Mary".Split(' ');
 
         double score = SentenceBLEU(references, hypothesis, EqualWeights(hypothesis.Count()));
         Assert.Equal(1.0, score, 4);
@@ -163,8 +162,8 @@ public class BLEUAlgorithmTests
     [Fact]
     public void TestPartialMatchesHypothesisLongerThanReference()
     {
-        IEnumerable<IEnumerable<string>> references = ["John loves Mary".Split(' '),];
-        IEnumerable<string> hypothesis = "John loves Mary who loves Mike".Split(' ');
+        string[][] references = ["John loves Mary".Split(' '),];
+        string[] hypothesis = "John loves Mary who loves Mike".Split(' ');
 
         double score = SentenceBLEU(references, hypothesis);
         Assert.Equal(0, score, 4);
@@ -173,12 +172,12 @@ public class BLEUAlgorithmTests
     [Fact]
     public void TestSentenceBLEUExampleA()
     {
-        IEnumerable<IEnumerable<string>> references = [
+        string[][] references = [
             "It is a guide to action that ensures that the military will forever heed Party commands".Split(' '),
             "It is the guiding principle which guarantees the military forces always being under the command of the Party".Split(' '),
             "It is the practical guide for the army always to heed the directions of the party".Split(' ')
         ];
-        IEnumerable<string> hypothesis = "It is a guide to action which ensures that the military always obeys the commands of the party".Split(' ');
+        string[] hypothesis = "It is a guide to action which ensures that the military always obeys the commands of the party".Split(' ');
 
         double score = SentenceBLEU(references, hypothesis);
         Assert.Equal(0.5046, score, 4);
@@ -188,10 +187,10 @@ public class BLEUAlgorithmTests
     [Fact]
     public void TestSentenceBLEUExampleB()
     {
-        IEnumerable<IEnumerable<string>> references = [
+        string[][] references = [
             "he was interested in world history because he read the book".Split(' '),
         ];
-        IEnumerable<string> hypothesis = "he read the book because he was interested in world history".Split(' ');
+        string[] hypothesis = "he read the book because he was interested in world history".Split(' ');
 
         double score = SentenceBLEU(references, hypothesis);
         Assert.Equal(0.74009, score, 4);
@@ -200,12 +199,12 @@ public class BLEUAlgorithmTests
     [Fact]
     public void TestSentenceBLEUExampleAWithWordTokenizer()
     {
-        IEnumerable<IEnumerable<string>> references = [
-            SimpleWordTokenizer.WordTokenize("It is a guide to action that ensures that the military will forever heed Party commands"),
-            SimpleWordTokenizer.WordTokenize("It is the guiding principle which guarantees the military forces always being under the command of the Party"),
-            SimpleWordTokenizer.WordTokenize("It is the practical guide for the army always to heed the directions of the party")
+        string[][] references = [
+            SimpleWordTokenizer.WordTokenize("It is a guide to action that ensures that the military will forever heed Party commands").ToArray(),
+            SimpleWordTokenizer.WordTokenize("It is the guiding principle which guarantees the military forces always being under the command of the Party").ToArray(),
+            SimpleWordTokenizer.WordTokenize("It is the practical guide for the army always to heed the directions of the party").ToArray(),
         ];
-        IEnumerable<string> hypothesis = SimpleWordTokenizer.WordTokenize("It is a guide to action which ensures that the military always obeys the commands of the party");
+        string[] hypothesis = SimpleWordTokenizer.WordTokenize("It is a guide to action which ensures that the military always obeys the commands of the party").ToArray();
 
         double score = SentenceBLEU(references, hypothesis);
         Assert.Equal(0.5046, score, 4);
@@ -215,10 +214,10 @@ public class BLEUAlgorithmTests
     [Fact]
     public void TestSentenceBLEUExampleBWithWordTokenizer()
     {
-        IEnumerable<IEnumerable<string>> references = [
-            SimpleWordTokenizer.WordTokenize("he was interested in world history because he read the book"),
+        string[][] references = [
+            SimpleWordTokenizer.WordTokenize("he was interested in world history because he read the book").ToArray(),
         ];
-        IEnumerable<string> hypothesis = SimpleWordTokenizer.WordTokenize("he read the book because he was interested in world history");
+        string[] hypothesis = SimpleWordTokenizer.WordTokenize("he read the book because he was interested in world history").ToArray();
 
         double score = SentenceBLEU(references, hypothesis);
         Assert.Equal(0.74009, score, 4);

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.NLP.Tests/NGramTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.NLP.Tests/NGramTests.cs
@@ -62,7 +62,7 @@ public class NGramTests
     [Fact]
     public void NGramGenerationNoPadding()
     {
-        int[] input = [1, 2, 3, 4, 5];
+        ReadOnlySpan<int> input = [1, 2, 3, 4, 5];
 
         IEnumerable<NGram<int>> result = input.CreateNGrams(1);
         List<NGram<int>> expected = [[1], [2], [3], [4], [5]];


### PR DESCRIPTION
Use arrays in place of IEnumerable for internal processing, since they will be ultimately turned into arrays anyway, we might as well allocate them at the beginning and pass through the call stacks. This also saves multiple iterations over the same IEnumerator.
Add a few tweaks, like matching expressions in the tokenizer and Array.Fill
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6556)