### PR TITLE
Align EventId generation with M.E.Logging source-gen

### DIFF
--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
@@ -91,7 +91,7 @@ internal sealed partial class Emitter : EmitterBase
         }
         else
         {
-            var eventNameToCalcId = string.IsNullOrWhiteSpace(lm.EventName) ? lm.Name : lm.EventName;
+            var eventNameToCalcId = string.IsNullOrWhiteSpace(lm.EventName) ? lm.Name : lm.EventName!;
             var calculatedEventId = GetNonRandomizedHashCode(eventNameToCalcId);
             OutLn($"new({calculatedEventId}, {eventName}),");
         }

--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
@@ -91,7 +91,9 @@ internal sealed partial class Emitter : EmitterBase
         }
         else
         {
-            OutLn($"new({GetNonRandomizedHashCode(eventName)}, {eventName}),");
+            var eventNameToCalcId = string.IsNullOrWhiteSpace(lm.EventName) ? lm.Name : lm.EventName;
+            var calculatedEventId = GetNonRandomizedHashCode(eventNameToCalcId);
+            OutLn($"new({calculatedEventId}, {eventName}),");
         }
 
         OutLn($"{stateName},");

--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
@@ -581,6 +581,37 @@ public class LogMethodTests
     }
 
     [Fact]
+    public void EventIdTests()
+    {
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
+        collector.Clear();
+        EventNameTestExtensions.M1(LogLevel.Warning, logger, "Eight");
+        Assert.Equal(1, collector.Count);
+
+        var firstEventId = collector.LatestRecord.Id;
+        Assert.NotEqual(0, firstEventId.Id);
+        Assert.Equal("M1_Event", firstEventId.Name);
+
+        collector.Clear();
+        EventNameTestExtensions.M1_Event(logger, "Nine");
+        Assert.Equal(1, collector.Count);
+
+        var secondEventId = collector.LatestRecord.Id;
+        Assert.Equal(firstEventId.Id, secondEventId.Id); // Same EventName means same generated EventId
+        Assert.Equal(nameof(EventNameTestExtensions.M1_Event), secondEventId.Name);
+
+        collector.Clear();
+        EventNameTestExtensions.M2(logger, "Ten");
+        Assert.Equal(1, collector.Count);
+
+        var thirdEventId = collector.LatestRecord.Id;
+        Assert.NotEqual(thirdEventId.Id, secondEventId.Id); // Different EventName means different generated EventId
+        Assert.Equal(nameof(EventNameTestExtensions.M2), thirdEventId.Name);
+    }
+
+    [Fact]
     public void NestedClassTests()
     {
         using var logger = Utils.GetLogger();

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/EventNameTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/EventNameTestExtensions.cs
@@ -12,5 +12,13 @@ namespace TestClasses
 
         [LoggerMessage(EventName = "M1_Event")]
         public static partial void M1(LogLevel level, ILogger logger, string p0);
+
+        // This one should have the same generated EventId as the method above
+        [LoggerMessage(LogLevel.Debug)]
+        public static partial void M1_Event(ILogger logger, string p0);
+
+        // This one should have different generated EventId as the methods above
+        [LoggerMessage(LogLevel.Error)]
+        public static partial void M2(ILogger logger, string p0);
     }
 }


### PR DESCRIPTION
This fixes #6498
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6566)