### PR TITLE
Use dnx instead of dotnet tool exec in MCP server template README

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/McpServer/McpServer-CSharp/README.md
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/McpServer/McpServer-CSharp/README.md
@@ -24,10 +24,8 @@ Once the MCP server package is published to NuGet.org, you can use the following
     "servers": {
       "McpServer-CSharp": {
         "type": "stdio",
-        "command": "dotnet",
+        "command": "dnx",
         "args": [
-          "tool",
-          "exec",
           "<your package ID here>",
           "--version",
           "<your package version here>",

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.Basic.verified/mcpserver/README.md
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.Basic.verified/mcpserver/README.md
@@ -24,10 +24,8 @@ Once the MCP server package is published to NuGet.org, you can use the following
     "servers": {
       "mcpserver": {
         "type": "stdio",
-        "command": "dotnet",
+        "command": "dnx",
         "args": [
-          "tool",
-          "exec",
           "<your package ID here>",
           "--version",
           "<your package version here>",


### PR DESCRIPTION
Related to https://github.com/dotnet/extensions/issues/6518.

I spoke to @baronfel about this. `dnx` is the preferred syntax and is reminiscent of `npx`. I believe this will also provide a preferred failure mode on an old .NET SDK (OS command not found vs. dotnet giving an unhandled `args` error).

We will provide the `dnx` syntax on NuGet.org for the copy-paste VS Code config and I will prescribe `dnx` while I add NuGet support to the MCP Registry.

Apologies for not getting this into the other PR: https://github.com/dotnet/extensions/pull/6547

I am open to feedback.