### PR TITLE
AIFunctionFactory: tolerate JSON string function parameters.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -825,6 +825,21 @@ public static partial class AIFunctionFactory
                     {
                         try
                         {
+                            if (value is string potentiallyJsonString)
+                            {
+                                // Account for the parameter potentially being a JSON string.
+                                // This is needed for compatibility with Semantic Kernel,
+                                // which may pass parameters as JSON strings.
+                                try
+                                {
+                                    return JsonSerializer.Deserialize(potentiallyJsonString, typeInfo);
+                                }
+                                catch (JsonException)
+                                {
+                                    // If the string is not valid JSON, fall through to the round-trip.
+                                }
+                            }
+
                             string json = JsonSerializer.Serialize(value, serializerOptions.GetTypeInfo(value.GetType()));
                             return JsonSerializer.Deserialize(json, typeInfo);
                         }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -827,6 +827,8 @@ public static partial class AIFunctionFactory
                         {
                             if (value is string potentiallyJsonString)
                             {
+                                Debug.Assert(typeInfo.Type != typeof(string), "string parameters should not enter this branch.");
+
                                 // Account for the parameter potentially being a JSON string.
                                 // This is needed for compatibility with Semantic Kernel,
                                 // which may pass parameters as JSON strings.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -830,8 +830,8 @@ public static partial class AIFunctionFactory
                                 Debug.Assert(typeInfo.Type != typeof(string), "string parameters should not enter this branch.");
 
                                 // Account for the parameter potentially being a JSON string.
-                                // This is needed for compatibility with Semantic Kernel,
-                                // which may pass parameters as JSON strings.
+                                // The value is a string but the type is not. Try to deserialize it under the assumption that it's JSON.
+                                // If it's not, we'll fall through to the default path that makes it valid JSON and then tries to deserialize.
                                 try
                                 {
                                     return JsonSerializer.Deserialize(potentiallyJsonString, typeInfo);

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -26,6 +26,7 @@ using Microsoft.Shared.Diagnostics;
 #pragma warning disable S2333 // Redundant modifiers should not be used
 #pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 #pragma warning disable SA1202 // Public members should come before private members
+#pragma warning disable SA1203 // Constants should appear before fields
 
 namespace Microsoft.Extensions.AI;
 
@@ -825,7 +826,7 @@ public static partial class AIFunctionFactory
                     {
                         try
                         {
-                            if (value is string potentiallyJsonString)
+                            if (value is string text && IsPotentiallyJson(text))
                             {
                                 Debug.Assert(typeInfo.Type != typeof(string), "string parameters should not enter this branch.");
 
@@ -834,7 +835,7 @@ public static partial class AIFunctionFactory
                                 // If it's not, we'll fall through to the default path that makes it valid JSON and then tries to deserialize.
                                 try
                                 {
-                                    return JsonSerializer.Deserialize(potentiallyJsonString, typeInfo);
+                                    return JsonSerializer.Deserialize(text, typeInfo);
                                 }
                                 catch (JsonException)
                                 {
@@ -1037,6 +1038,35 @@ public static partial class AIFunctionFactory
             Func<object?, Type?, CancellationToken, ValueTask<object?>>? MarshalResult,
             AIJsonSchemaCreateOptions SchemaOptions);
     }
+
+    /// <summary>
+    /// Quickly checks if the specified string is potentially JSON
+    /// by checking if the first non-whitespace characters are valid JSON start tokens.
+    /// </summary>
+    /// <param name="value">The string to check.</param>
+    /// <returns>If <see langword="false"/> then the string is definitely not valid JSON.</returns>
+    private static bool IsPotentiallyJson(string value) => PotentiallyJsonRegex().IsMatch(value);
+#if NET
+    [GeneratedRegex(PotentiallyJsonRegexString, RegexOptions.IgnorePatternWhitespace)]
+    private static partial Regex PotentiallyJsonRegex();
+#else
+    private static Regex PotentiallyJsonRegex() => _potentiallyJsonRegex;
+    private static readonly Regex _potentiallyJsonRegex = new(PotentiallyJsonRegexString, RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
+#endif
+    private const string PotentiallyJsonRegexString = """
+        ^\s*        # Optional whitespace at the start of the string
+           ( null   # null literal
+           | false  # false literal
+           | true   # true literal
+           | \d     # positive number
+           | -\d    # negative number
+           | "      # string
+           | \[     # start array
+           | {      # start object
+           | //     # Start of single-line comment
+           | /\*    # Start of multi-line comment
+           )
+        """;
 
     /// <summary>
     /// Removes characters from a .NET member name that shouldn't be used in an AI function name.

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
@@ -93,6 +93,49 @@ public partial class AIFunctionFactoryTest
         AssertExtensions.EqualFunctionCallResults(15, result);
     }
 
+    [Theory]
+    [InlineData("   null")]
+    [InlineData("   false   ")]
+    [InlineData("true   ")]
+    [InlineData("42")]
+    [InlineData("0.0")]
+    [InlineData("-1e15")]
+    [InlineData("  \"I am a string!\" ")]
+    [InlineData("  {}")]
+    [InlineData("[]")]
+    public async Task Parameters_ToleratesJsonStringParameters(string jsonStringParam)
+    {
+        AIFunction func = AIFunctionFactory.Create((JsonElement param) => param);
+        JsonElement expectedResult = JsonDocument.Parse(jsonStringParam).RootElement;
+
+        var result = await func.InvokeAsync(new()
+        {
+            ["param"] = jsonStringParam
+        });
+
+        AssertExtensions.EqualFunctionCallResults(expectedResult, result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("                 \r\n")]
+    [InlineData("I am a string!")]
+    [InlineData("/* Code snippet */ int main(void) { return 0; }")]
+    [InlineData("let rec Y F x = F (Y F) x")]
+    [InlineData("+3")]
+    public async Task Parameters_ToleratesInvalidJsonStringParameters(string invalidJsonParam)
+    {
+        AIFunction func = AIFunctionFactory.Create((JsonElement param) => param);
+        JsonElement expectedResult = JsonDocument.Parse(JsonSerializer.Serialize(invalidJsonParam, JsonContext.Default.String)).RootElement;
+
+        var result = await func.InvokeAsync(new()
+        {
+            ["param"] = invalidJsonParam
+        });
+
+        AssertExtensions.EqualFunctionCallResults(expectedResult, result);
+    }
+
     [Fact]
     public async Task Parameters_MappedByType_Async()
     {


### PR DESCRIPTION
Under certain circumstances, SK kernels can pass `KernelArguments` with parameters formatted as JSON strings to `AIFunction`s created by `AIFunctionFactory`, resulting in argument exceptions. This PR updates `AIFunctionFactory` so that JSON strings are tolerated as function parameters.

FYI @rogerbarreto @SergeyMenshykh

Fix #6544.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6572)