### PR TITLE
Add reporting tests that show NLP results.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/BLEUEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/BLEUEvaluator.cs
@@ -86,7 +86,7 @@ public sealed class BLEUEvaluator : IEvaluator
         });
 
         metric.Value = score;
-        string durationText = $"{duration.TotalSeconds.ToString("F2", CultureInfo.InvariantCulture)} s";
+        string durationText = $"{duration.TotalSeconds.ToString("F4", CultureInfo.InvariantCulture)} s";
         metric.AddOrUpdateMetadata(name: "evaluation-duration", value: durationText);
         metric.AddOrUpdateContext(context);
         metric.Interpretation = metric.Interpret();

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/F1Evaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/F1Evaluator.cs
@@ -77,7 +77,7 @@ public sealed class F1Evaluator : IEvaluator
         });
 
         metric.Value = score;
-        string durationText = $"{duration.TotalSeconds.ToString("F2", CultureInfo.InvariantCulture)} s";
+        string durationText = $"{duration.TotalSeconds.ToString("F4", CultureInfo.InvariantCulture)} s";
         metric.AddOrUpdateMetadata(name: "evaluation-duration", value: durationText);
         metric.AddOrUpdateContext(context);
         metric.Interpretation = metric.Interpret();

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/GLEUEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.NLP/GLEUEvaluator.cs
@@ -86,7 +86,7 @@ public sealed class GLEUEvaluator : IEvaluator
         });
 
         metric.Value = score;
-        string durationText = $"{duration.TotalSeconds.ToString("F2", CultureInfo.InvariantCulture)} s";
+        string durationText = $"{duration.TotalSeconds.ToString("F4", CultureInfo.InvariantCulture)} s";
         metric.AddOrUpdateMetadata(name: "evaluation-duration", value: durationText);
         metric.AddOrUpdateContext(context);
         metric.Interpretation = metric.Interpret();

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationMetricExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation/EvaluationMetricExtensions.cs
@@ -177,7 +177,7 @@ public static class EvaluationMetricExtensions
 
         if (duration is not null)
         {
-            string durationText = $"{duration.Value.TotalSeconds.ToString("F2", CultureInfo.InvariantCulture)} s";
+            string durationText = $"{duration.Value.TotalSeconds.ToString("F4", CultureInfo.InvariantCulture)} s";
             metric.AddOrUpdateMetadata(name: "evaluation-duration", value: durationText);
         }
     }

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/Microsoft.Extensions.AI.Evaluation.Integration.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/Microsoft.Extensions.AI.Evaluation.Integration.Tests.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AI.Evaluation.NLP\Microsoft.Extensions.AI.Evaluation.NLP.csproj" />
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AI.OpenAI\Microsoft.Extensions.AI.OpenAI.csproj" />
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AI.Evaluation\Microsoft.Extensions.AI.Evaluation.csproj" />
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AI.Evaluation.Quality\Microsoft.Extensions.AI.Evaluation.Quality.csproj" />

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/NLPEvaluatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/NLPEvaluatorTests.cs
@@ -29,6 +29,7 @@ public class NLPEvaluatorTests
             string date = $"Date: {DateTime.UtcNow:dddd, dd MMMM yyyy}";
             string projectName = $"Project: Integration Tests";
             string testClass = $"Test Class: {nameof(NLPEvaluatorTests)}";
+            string usesContext = $"Feature: Context";
 
             IEvaluator bleuEvaluator = new BLEUEvaluator();
             IEvaluator gleuEvaluator = new GLEUEvaluator();
@@ -39,7 +40,7 @@ public class NLPEvaluatorTests
                     storageRootPath: Settings.Current.StorageRootPath,
                     evaluators: [bleuEvaluator, gleuEvaluator, f1Evaluator],
                     executionName: Constants.Version,
-                    tags: [version, date, projectName, testClass]);
+                    tags: [version, date, projectName, testClass, usesContext]);
         }
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/NLPEvaluatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/NLPEvaluatorTests.cs
@@ -4,15 +4,12 @@
 #pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods that take it.
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI.Evaluation.NLP;
 using Microsoft.Extensions.AI.Evaluation.Reporting;
 using Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
-using Microsoft.Extensions.AI.Evaluation.Tests;
 using Microsoft.TestUtilities;
 using Xunit;
 
@@ -21,7 +18,6 @@ namespace Microsoft.Extensions.AI.Evaluation.Integration.Tests;
 [Experimental("AIEVAL001")]
 public class NLPEvaluatorTests
 {
-    private static readonly ChatOptions? _chatOptions;
     private static readonly ReportingConfiguration? _nlpReportingConfiguration;
 
     static NLPEvaluatorTests()


### PR DESCRIPTION
Also increase the digits in the timing results so it shows something better than `0.00` given that these tests run so fast.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6574)