### PR TITLE
Add netstandard2.0 compatibility to Microsoft.Extensions.Http.Resilience and dependencies

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Microsoft.Extensions.Http.Resilience.csproj
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Microsoft.Extensions.Http.Resilience.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.Extensions.Http.Resilience</RootNamespace>
+    <TargetFrameworks>$(NetCoreTargetFrameworks);netstandard2.0;net462</TargetFrameworks>
     <Description>Resilience mechanisms for HttpClient.</Description>
     <Workstream>Resilience</Workstream>
   </PropertyGroup>

--- a/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.csproj
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.Extensions.Resilience</RootNamespace>
+    <TargetFrameworks>$(NetCoreTargetFrameworks);netstandard2.0;net462</TargetFrameworks>
     <Description>Extensions to the Polly libraries to enrich telemetry with metadata and exception summaries.</Description>
     <Workstream>Resilience</Workstream>
   </PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/extensions/issues/5022

This PR depended on this other PR https://github.com/dotnet/extensions/pull/6218