### PR TITLE
Add memory usage metric

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -120,8 +120,8 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
             unit: "1");
 
         _ = meter.CreateObservableUpDownCounter(
-            name: ResourceUtilizationInstruments.ContainerMemoryUtilization,
-            observeValues: () => GetMeasurementWithRetry(() => (long)MemoryUtilization()),
+            name: ResourceUtilizationInstruments.ContainerMemoryUsage,
+            observeValues: () => GetMeasurementWithRetry(() => (long)MemoryUsage()),
             unit: "By",
             description: "Memory usage of the container.");
 
@@ -222,7 +222,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         return _cpuPercentage;
     }
 
-    public ulong MemoryUtilization()
+    public ulong MemoryUsage()
     {
         DateTimeOffset now = _timeProvider.GetUtcNow();
 
@@ -270,7 +270,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
 
     private double MemoryPercentage()
     {
-        ulong memoryUsage = MemoryUtilization();
+        ulong memoryUsage = MemoryUsage();
         double memoryPercentage = Math.Min(One, (double)memoryUsage / _memoryLimit);
 
         _logger.MemoryPercentageData(memoryUsage, _memoryLimit, memoryPercentage);

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -37,7 +37,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
     private DateTimeOffset _refreshAfterMemory;
     private double _cpuPercentage = double.NaN;
     private double _lastCpuCoresUsed = double.NaN;
-    private double _memoryPercentage;
+    private ulong _memoryUsage;
     private long _previousCgroupCpuTime;
     private long _previousHostCpuTime;
     private long _previousCgroupCpuPeriodCounter;
@@ -116,12 +116,18 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
 
         _ = meter.CreateObservableGauge(
             name: ResourceUtilizationInstruments.ContainerMemoryLimitUtilization,
-            observeValues: () => GetMeasurementWithRetry(MemoryUtilization),
+            observeValues: () => GetMeasurementWithRetry(MemoryPercentage),
             unit: "1");
+
+        _ = meter.CreateObservableUpDownCounter(
+            name: ResourceUtilizationInstruments.ContainerMemoryUtilization,
+            observeValues: () => GetMeasurementWithRetry(() => (long)MemoryUtilization()),
+            unit: "By",
+            description: "Memory usage of the container.");
 
         _ = meter.CreateObservableGauge(
             name: ResourceUtilizationInstruments.ProcessMemoryUtilization,
-            observeValues: () => GetMeasurementWithRetry(MemoryUtilization),
+            observeValues: () => GetMeasurementWithRetry(MemoryPercentage),
             unit: "1");
 
         // cpuRequest is a CPU request (aka guaranteed number of CPU units) for pod, for host its 1 core
@@ -216,7 +222,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         return _cpuPercentage;
     }
 
-    public double MemoryUtilization()
+    public ulong MemoryUtilization()
     {
         DateTimeOffset now = _timeProvider.GetUtcNow();
 
@@ -224,26 +230,24 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         {
             if (now < _refreshAfterMemory)
             {
-                return _memoryPercentage;
+                return _memoryUsage;
             }
         }
 
-        ulong memoryUsed = _parser.GetMemoryUsageInBytes();
+        ulong memoryUsage = _parser.GetMemoryUsageInBytes();
 
         lock (_memoryLocker)
         {
             if (now >= _refreshAfterMemory)
             {
-                double memoryPercentage = Math.Min(One, (double)memoryUsed / _memoryLimit);
-
-                _memoryPercentage = memoryPercentage;
+                _memoryUsage = memoryUsage;
                 _refreshAfterMemory = now.Add(_memoryRefreshInterval);
             }
         }
 
-        _logger.MemoryUsageData(memoryUsed, _memoryLimit, _memoryPercentage);
+        _logger.MemoryUsageData(_memoryUsage);
 
-        return _memoryPercentage;
+        return _memoryUsage;
     }
 
     /// <remarks>
@@ -264,14 +268,24 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
             memoryUsageInBytes: memoryUsed);
     }
 
-    private Measurement<double>[] GetMeasurementWithRetry(Func<double> func)
+    private double MemoryPercentage()
     {
-        if (!TryGetValueWithRetry(func, out double value))
+        ulong memoryUsage = MemoryUtilization();
+        double memoryPercentage = Math.Min(One, (double)memoryUsage / _memoryLimit);
+
+        _logger.MemoryPercentageData(memoryUsage, _memoryLimit, memoryPercentage);
+        return memoryPercentage;
+    }
+
+    private Measurement<T>[] GetMeasurementWithRetry<T>(Func<T> func)
+        where T : struct
+    {
+        if (!TryGetValueWithRetry(func, out T value))
         {
-            return Array.Empty<Measurement<double>>();
+            return Array.Empty<Measurement<T>>();
         }
 
-        return new[] { new Measurement<double>(value) };
+        return new[] { new Measurement<T>(value) };
     }
 
     private bool TryGetValueWithRetry<T>(Func<T> func, out T value)

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
@@ -23,8 +23,8 @@ internal static partial class Log
         double cpuPercentage);
 
     [LoggerMessage(2, LogLevel.Debug,
-        "Computed memory usage with MemoryUsedInBytes = {memoryUsed}, MemoryLimit = {memoryLimit}, MemoryPercentage = {memoryPercentage}.")]
-    public static partial void MemoryUsageData(
+        "Computed memory percentage with MemoryUsedInBytes = {memoryUsed}, MemoryLimit = {memoryLimit}, MemoryPercentage = {memoryPercentage}.")]
+    public static partial void MemoryPercentageData(
         this ILogger logger,
         ulong memoryUsed,
         double memoryLimit,
@@ -55,4 +55,10 @@ internal static partial class Log
     public static partial void HandleDiskStatsException(
         this ILogger logger,
         string errorMessage);
+
+    [LoggerMessage(6, LogLevel.Debug,
+        "Computed memory usage with MemoryUsedInBytes = {memoryUsed}.")]
+    public static partial void MemoryUsageData(
+        this ILogger logger,
+        ulong memoryUsed);
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Log.cs
@@ -23,7 +23,7 @@ internal static partial class Log
         double cpuPercentage);
 
     [LoggerMessage(2, LogLevel.Debug,
-        "Computed memory percentage with MemoryUsedInBytes = {memoryUsed}, MemoryLimit = {memoryLimit}, MemoryPercentage = {memoryPercentage}.")]
+        "Computed memory usage with MemoryUsedInBytes = {memoryUsed}, MemoryLimit = {memoryLimit}, MemoryPercentage = {memoryPercentage}.")]
     public static partial void MemoryPercentageData(
         this ILogger logger,
         ulong memoryUsed,
@@ -57,7 +57,7 @@ internal static partial class Log
         string errorMessage);
 
     [LoggerMessage(6, LogLevel.Debug,
-        "Computed memory usage with MemoryUsedInBytes = {memoryUsed}.")]
+        "Computed memory usage = {memoryUsed}.")]
     public static partial void MemoryUsageData(
         this ILogger logger,
         ulong memoryUsed);

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Log.cs
@@ -27,7 +27,7 @@ internal static partial class Log
 
     [LoggerMessage(4, LogLevel.Debug,
         "Computed memory usage with CurrentMemoryUsage = {currentMemoryUsage}, TotalMemory = {totalMemory}, MemoryPercentage = {memoryPercentage}.")]
-    public static partial void MemoryUsageData(
+    public static partial void MemoryPercentageData(
         this ILogger logger,
         ulong currentMemoryUsage,
         double totalMemory,
@@ -60,4 +60,10 @@ internal static partial class Log
         this ILogger logger,
         string counterName,
         string errorMessage);
+
+    [LoggerMessage(8, LogLevel.Debug,
+        "Computed memory usage = {currentMemoryUsage}.")]
+    public static partial void MemoryUsageData(
+        this ILogger logger,
+        ulong currentMemoryUsage);
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Log.cs
@@ -26,7 +26,7 @@ internal static partial class Log
         double cpuPercentage);
 
     [LoggerMessage(4, LogLevel.Debug,
-        "Computed memory usage with CurrentMemoryUsage = {currentMemoryUsage}, TotalMemory = {totalMemory}, MemoryPercentage = {memoryPercentage}.")]
+        "Computed memory usage with CurrentMemoryUsage = {currentMemoryUsage}, TotalMemory = {totalMemory}, MemoryPercentage = {memoryPercentage}")]
     public static partial void MemoryPercentageData(
         this ILogger logger,
         ulong currentMemoryUsage,

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Log.cs
@@ -26,12 +26,11 @@ internal static partial class Log
         double cpuPercentage);
 
     [LoggerMessage(4, LogLevel.Debug,
-        "Computed memory usage with CurrentMemoryUsage = {currentMemoryUsage}, TotalMemory = {totalMemory}, MemoryPercentage = {memoryPercentage}")]
-    public static partial void MemoryPercentageData(
+        "Computed memory usage for container: CurrentMemoryUsage = {currentMemoryUsage}, TotalMemory = {totalMemory}")]
+    public static partial void ContainerMemoryUsageData(
         this ILogger logger,
         ulong currentMemoryUsage,
-        double totalMemory,
-        double memoryPercentage);
+        double totalMemory);
 
 #pragma warning disable S103 // Lines should not be too long
     [LoggerMessage(5, LogLevel.Debug, "Computed CPU usage with CpuUsageKernelTicks = {cpuUsageKernelTicks}, CpuUsageUserTicks = {cpuUsageUserTicks}, OldCpuUsageTicks = {oldCpuUsageTicks}, TimeTickDelta = {timeTickDelta}, CpuUnits = {cpuUnits}, CpuPercentage = {cpuPercentage}.")]
@@ -62,8 +61,10 @@ internal static partial class Log
         string errorMessage);
 
     [LoggerMessage(8, LogLevel.Debug,
-        "Computed memory usage = {currentMemoryUsage}.")]
-    public static partial void MemoryUsageData(
+        "Computed memory usage for current process: ProcessMemoryUsage = {processMemoryUsage}, TotalMemory = {totalMemory}, MemoryPercentage = {memoryPercentage}")]
+    public static partial void ProcessMemoryPercentageData(
         this ILogger logger,
-        ulong currentMemoryUsage);
+        ulong processMemoryUsage,
+        double totalMemory,
+        double memoryPercentage);
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
@@ -131,7 +131,7 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
             observeValue: () => MemoryPercentage(() => _processInfo.GetMemoryUsage()));
 
         _ = meter.CreateObservableUpDownCounter(
-            name: ResourceUtilizationInstruments.ContainerMemoryUtilization,
+            name: ResourceUtilizationInstruments.ContainerMemoryUsage,
             observeValue: () => (long)MemoryUsage(() => _processInfo.GetMemoryUsage()),
             unit: "By",
             description: "Memory usage of the container.");

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -144,7 +144,7 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
                 _refreshAfterMemory = now.Add(_memoryRefreshInterval);
             }
 
-            _logger.MemoryUsageData((ulong)currentMemoryUsage, _totalMemory, _memoryPercentage);
+            _logger.MemoryPercentageData((ulong)currentMemoryUsage, _totalMemory, _memoryPercentage);
 
             return _memoryPercentage;
         }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -144,7 +144,7 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
                 _refreshAfterMemory = now.Add(_memoryRefreshInterval);
             }
 
-            _logger.MemoryPercentageData((ulong)currentMemoryUsage, _totalMemory, _memoryPercentage);
+            _logger.ProcessMemoryPercentageData((ulong)currentMemoryUsage, _totalMemory, _memoryPercentage);
 
             return _memoryPercentage;
         }

--- a/src/Shared/Instruments/ResourceUtilizationInstruments.cs
+++ b/src/Shared/Instruments/ResourceUtilizationInstruments.cs
@@ -51,6 +51,14 @@ internal static class ResourceUtilizationInstruments
     public const string ContainerMemoryLimitUtilization = "container.memory.limit.utilization";
 
     /// <summary>
+    /// The name of an instrument to retrieve memory consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
+    /// </summary>
+    /// <remarks>
+    /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
+    /// </remarks>
+    public const string ContainerMemoryUtilization = "container.memory.utilization";
+
+    /// <summary>
     /// The name of an instrument to retrieve CPU consumption share of the running process in range <c>[0, 1]</c>.
     /// </summary>
     /// <remarks>

--- a/src/Shared/Instruments/ResourceUtilizationInstruments.cs
+++ b/src/Shared/Instruments/ResourceUtilizationInstruments.cs
@@ -51,12 +51,12 @@ internal static class ResourceUtilizationInstruments
     public const string ContainerMemoryLimitUtilization = "container.memory.limit.utilization";
 
     /// <summary>
-    /// The name of an instrument to retrieve memory consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
+    /// The name of an instrument to retrieve memory usage measured in bytes of all processes running inside a container or control group.
     /// </summary>
     /// <remarks>
-    /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
+    /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableUpDownCounter{T}"/>.
     /// </remarks>
-    public const string ContainerMemoryUtilization = "container.memory.utilization";
+    public const string ContainerMemoryUsage = "container.memory.usage";
 
     /// <summary>
     /// The name of an instrument to retrieve CPU consumption share of the running process in range <c>[0, 1]</c>.

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization.Tests/ResourceHealthCheckExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization.Tests/ResourceHealthCheckExtensionsTests.cs
@@ -490,6 +490,7 @@ public class ResourceHealthCheckExtensionsTests
         Mock<IProcessInfo> processInfoMock = new();
         var appMemoryUsage = memoryUsed;
         processInfoMock.Setup(p => p.GetMemoryUsage()).Returns(() => appMemoryUsage);
+        processInfoMock.Setup(p => p.GetCurrentProcessMemoryUsage()).Returns(() => appMemoryUsage);
 
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION limitInfo = default;
         limitInfo.JobMemoryLimit = new UIntPtr(totalMemory);

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
@@ -220,17 +220,20 @@ public sealed class AcceptanceTest
         using var e = new ManualResetEventSlim();
 
         object? meterScope = null;
-        listener.InstrumentPublished = (Instrument instrument, MeterListener meterListener)
-            => OnInstrumentPublished(instrument, meterListener, meterScope);
-        listener.SetMeasurementEventCallback<double>((m, f, tags, _)
-            => OnMeasurementReceived(m,
+        listener.InstrumentPublished = (Instrument instrument, MeterListener meterListener) =>
+            OnInstrumentPublished(instrument, meterListener, meterScope);
+        listener.SetMeasurementEventCallback<double>((m, f, tags, _) =>
+            OnMeasurementReceived(
+                m,
                 f,
                 tags,
                 ref cpuUserTime,
                 ref cpuKernelTime,
                 ref cpuFromGauge,
                 ref cpuLimitFromGauge,
-            ref cpuRequestFromGauge, ref memoryFromGauge, ref memoryLimitFromGauge));
+                ref cpuRequestFromGauge,
+                ref memoryFromGauge,
+                ref memoryLimitFromGauge));
         listener.Start();
 
         using var host = FakeHost.CreateBuilder()
@@ -313,10 +316,11 @@ public sealed class AcceptanceTest
         using var e = new ManualResetEventSlim();
 
         object? meterScope = null;
-        listener.InstrumentPublished = (Instrument instrument, MeterListener meterListener)
-            => OnInstrumentPublished(instrument, meterListener, meterScope);
-        listener.SetMeasurementEventCallback<double>((m, f, tags, _)
-            => OnMeasurementReceived(m,
+        listener.InstrumentPublished = (Instrument instrument, MeterListener meterListener) =>
+            OnInstrumentPublished(instrument, meterListener, meterScope);
+        listener.SetMeasurementEventCallback<double>((m, f, tags, _) =>
+            OnMeasurementReceived(
+                m,
                 f,
                 tags,
                 ref cpuUserTime,
@@ -326,8 +330,7 @@ public sealed class AcceptanceTest
                 ref cpuRequestFromGauge,
                 ref memoryFromGauge,
                 ref memoryLimitFromGauge));
-        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _)
-            =>
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
         {
             if (instrument.Name == ResourceUtilizationInstruments.ContainerMemoryUsage)
             {
@@ -418,10 +421,11 @@ public sealed class AcceptanceTest
         var memoryLimitFromGauge = 0.0d;
 
         object? meterScope = null;
-        listener.InstrumentPublished = (Instrument instrument, MeterListener meterListener)
-            => OnInstrumentPublished(instrument, meterListener, meterScope);
-        listener.SetMeasurementEventCallback<double>((m, f, tags, _)
-            => OnMeasurementReceived(m,
+        listener.InstrumentPublished = (Instrument instrument, MeterListener meterListener) =>
+            OnInstrumentPublished(instrument, meterListener, meterScope);
+        listener.SetMeasurementEventCallback<double>((m, f, tags, _) =>
+            OnMeasurementReceived(
+                m,
                 f,
                 tags,
                 ref cpuUserTime,

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
@@ -223,7 +223,13 @@ public sealed class AcceptanceTest
         listener.InstrumentPublished = (Instrument instrument, MeterListener meterListener)
             => OnInstrumentPublished(instrument, meterListener, meterScope);
         listener.SetMeasurementEventCallback<double>((m, f, tags, _)
-            => OnMeasurementReceived(m, f, tags, ref cpuUserTime, ref cpuKernelTime, ref cpuFromGauge, ref cpuLimitFromGauge,
+            => OnMeasurementReceived(m,
+                f,
+                tags,
+                ref cpuUserTime,
+                ref cpuKernelTime,
+                ref cpuFromGauge,
+                ref cpuLimitFromGauge,
             ref cpuRequestFromGauge, ref memoryFromGauge, ref memoryLimitFromGauge));
         listener.Start();
 
@@ -310,13 +316,20 @@ public sealed class AcceptanceTest
         listener.InstrumentPublished = (Instrument instrument, MeterListener meterListener)
             => OnInstrumentPublished(instrument, meterListener, meterScope);
         listener.SetMeasurementEventCallback<double>((m, f, tags, _)
-            => OnMeasurementReceived(
-                m, f, tags, ref cpuUserTime, ref cpuKernelTime, ref cpuFromGauge, ref cpuLimitFromGauge,
-                ref cpuRequestFromGauge, ref memoryFromGauge, ref memoryLimitFromGauge));
+            => OnMeasurementReceived(m,
+                f,
+                tags,
+                ref cpuUserTime,
+                ref cpuKernelTime,
+                ref cpuFromGauge,
+                ref cpuLimitFromGauge,
+                ref cpuRequestFromGauge,
+                ref memoryFromGauge,
+                ref memoryLimitFromGauge));
         listener.SetMeasurementEventCallback<long>((instrument, value, tags, _)
             =>
         {
-            if (instrument.Name == ResourceUtilizationInstruments.ContainerMemoryUtilization)
+            if (instrument.Name == ResourceUtilizationInstruments.ContainerMemoryUsage)
             {
                 memoryUsageFromGauge = value;
             }
@@ -469,7 +482,7 @@ public sealed class AcceptanceTest
             instrument.Name == ResourceUtilizationInstruments.ContainerCpuRequestUtilization ||
             instrument.Name == ResourceUtilizationInstruments.ContainerCpuLimitUtilization ||
             instrument.Name == ResourceUtilizationInstruments.ContainerMemoryLimitUtilization ||
-            instrument.Name == ResourceUtilizationInstruments.ContainerMemoryUtilization)
+            instrument.Name == ResourceUtilizationInstruments.ContainerMemoryUsage)
         {
             meterListener.EnableMeasurementEvents(instrument);
         }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
@@ -94,8 +94,8 @@ public sealed class LinuxUtilizationProviderTests
         Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ContainerMemoryLimitUtilization);
         Assert.Equal(0.5, samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ContainerMemoryLimitUtilization).value);
 
-        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ContainerMemoryUtilization);
-        Assert.Equal(524288, samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ContainerMemoryUtilization).value);
+        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ContainerMemoryUsage);
+        Assert.Equal(524288, samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ContainerMemoryUsage).value);
 
         Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization);
         Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization).value));

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
@@ -403,7 +403,7 @@ public sealed class WindowsContainerSnapshotProviderTests
         var meterFactoryMock = new Mock<IMeterFactory>();
         meterFactoryMock.Setup(x => x.Create(It.IsAny<MeterOptions>()))
             .Returns(meter);
-        using var metricCollector = new MetricCollector<long>(meter, ResourceUtilizationInstruments.ContainerMemoryUtilization, fakeClock);
+        using var metricCollector = new MetricCollector<long>(meter, ResourceUtilizationInstruments.ContainerMemoryUsage, fakeClock);
 
         var options = new ResourceMonitoringOptions
         {
@@ -422,22 +422,22 @@ public sealed class WindowsContainerSnapshotProviderTests
         // Step #0 - state in the beginning:
         metricCollector.RecordObservableInstruments();
         Assert.NotNull(metricCollector.LastMeasurement?.Value);
-        Assert.Equal(200, metricCollector.LastMeasurement.Value); // Consuming 200MB initially.
+        Assert.Equal(200, metricCollector.LastMeasurement.Value); // Consuming 200 bytes initially.
 
         // Step #1 - simulate 1 millisecond passing and collect metrics again:
         fakeClock.Advance(options.MemoryConsumptionRefreshInterval - TimeSpan.FromMilliseconds(1));
         metricCollector.RecordObservableInstruments();
-        Assert.Equal(200, metricCollector.LastMeasurement.Value); // Still consuming 200MB as gauge wasn't updated.
+        Assert.Equal(200, metricCollector.LastMeasurement.Value); // Still consuming 200 bytes as metric wasn't updated.
 
         // Step #2 - simulate 2 milliseconds passing and collect metrics again:
         fakeClock.Advance(TimeSpan.FromMilliseconds(2));
         metricCollector.RecordObservableInstruments();
-        Assert.Equal(600, metricCollector.LastMeasurement.Value); // Consuming 600MB of the memory afterward.
+        Assert.Equal(600, metricCollector.LastMeasurement.Value); // Consuming 600 bytes.
 
         // Step #3 - simulate 2 milliseconds passing and collect metrics again:
         fakeClock.Advance(TimeSpan.FromMilliseconds(2));
         metricCollector.RecordObservableInstruments();
-        Assert.Equal(300, metricCollector.LastMeasurement.Value); // Consuming 300MB of the memory afterward.
+        Assert.Equal(300, metricCollector.LastMeasurement.Value); // Consuming 300 bytes.
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #6587 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6586)

Adding [`container.memory.usage`](https://github.com/open-telemetry/semantic-conventions/blob/728e5d1a0aaf8304f9876694d54115508e0faa4c/docs/system/container-metrics.md#metric-containermemoryusage) metric with `ObservableUpDownCounter` instrument type, measured in bytes.