### PR TITLE
Bump FunctionInvokingChatClient.MaximumIterationsPerRequest from 10 to 40

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -61,7 +61,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
     private readonly ActivitySource? _activitySource;
 
     /// <summary>Maximum number of roundtrips allowed to the inner client.</summary>
-    private int _maximumIterationsPerRequest = 10;
+    private int _maximumIterationsPerRequest = 40; // arbitrary default to prevent runaway execution
 
     /// <summary>Maximum number of consecutive iterations that are allowed contain at least one exception result. If the limit is exceeded, we rethrow the exception instead of continuing.</summary>
     private int _maximumConsecutiveErrorsPerRequest = 3;
@@ -142,7 +142,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
     /// </summary>
     /// <value>
     /// The maximum number of iterations per request.
-    /// The default value is 10.
+    /// The default value is 40.
     /// </value>
     /// <remarks>
     /// <para>

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -36,7 +36,7 @@ public class FunctionInvokingChatClientTests
 
         Assert.False(client.AllowConcurrentInvocation);
         Assert.False(client.IncludeDetailedErrors);
-        Assert.Equal(10, client.MaximumIterationsPerRequest);
+        Assert.Equal(40, client.MaximumIterationsPerRequest);
         Assert.Equal(3, client.MaximumConsecutiveErrorsPerRequest);
         Assert.Null(client.FunctionInvoker);
     }
@@ -55,7 +55,7 @@ public class FunctionInvokingChatClientTests
         client.IncludeDetailedErrors = true;
         Assert.True(client.IncludeDetailedErrors);
 
-        Assert.Equal(10, client.MaximumIterationsPerRequest);
+        Assert.Equal(40, client.MaximumIterationsPerRequest);
         client.MaximumIterationsPerRequest = 5;
         Assert.Equal(5, client.MaximumIterationsPerRequest);
 


### PR DESCRIPTION
Folks are bumping up against the arbitrary limit of 10, as various modern models are super chatty with tools. While we need a limit to avoid runaway execution, we can make it much higher.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6599)