### PR TITLE
[Logging] Fixes LogProperties and LogPropertyIgnore attributes to work if an object being logged resides in a different assembly than the logging method

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LogPropertiesAttribute.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LogPropertiesAttribute.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Shared.DiagnosticIds;
@@ -14,7 +13,6 @@ namespace Microsoft.Extensions.Logging;
 /// </summary>
 /// <seealso cref="LoggerMessageAttribute"/>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
-[Conditional("CODE_GENERATION_ATTRIBUTES")]
 public sealed class LogPropertiesAttribute : Attribute
 {
     /// <summary>

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LogPropertyIgnoreAttribute.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LogPropertyIgnoreAttribute.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.Logging;
@@ -12,7 +11,6 @@ namespace Microsoft.Extensions.Logging;
 /// </summary>
 /// <seealso cref="LoggerMessageAttribute"/>.
 [AttributeUsage(AttributeTargets.Property)]
-[Conditional("CODE_GENERATION_ATTRIBUTES")]
 public sealed class LogPropertyIgnoreAttribute : Attribute
 {
 }

--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogPropertiesTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogPropertiesTests.cs
@@ -587,4 +587,26 @@ public class LogPropertiesTests
 
         latestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
     }
+
+    [Fact]
+    public void LogPropertiesCorrectlyLogsObjectFromAnotherAssembly()
+    {
+        LogObjectFromAnotherAssembly(_logger, new ObjectToLog
+        {
+            PropertyToIgnore = "Foo",
+            PropertyToLog = "Bar",
+            FieldToLog = new FieldToLog { Name = "Fizz", Value = "Buzz" }
+        });
+
+        Assert.Equal(1, _logger.Collector.Count);
+
+        var state = _logger.Collector.LatestRecord.StructuredState!
+            .ToDictionary(p => p.Key, p => p.Value);
+
+        Assert.Equal(4, state.Count);
+        Assert.Contains("{OriginalFormat}", state);
+        Assert.Contains("logObject.PropertyToLog", state);
+        Assert.Contains("logObject.FieldToLog.Name", state);
+        Assert.Contains("logObject.FieldToLog.Value", state);
+    }
 }

--- a/test/Generators/Microsoft.Gen.Logging/Generated/Microsoft.Gen.Logging.Generated.Tests.csproj
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/Microsoft.Gen.Logging.Generated.Tests.csproj
@@ -24,5 +24,6 @@
     <ProjectReference Include="..\..\..\..\src\Libraries\Microsoft.Extensions.Compliance.Testing\Microsoft.Extensions.Compliance.Testing.csproj" />
     <ProjectReference Include="..\..\..\..\src\Libraries\Microsoft.Extensions.Compliance.Redaction\Microsoft.Extensions.Compliance.Redaction.csproj" />
     <ProjectReference Include="..\..\..\..\src\Libraries\Microsoft.Extensions.Telemetry\Microsoft.Extensions.Telemetry.csproj" />
+    <ProjectReference Include="..\HelperLibrary\Microsoft.Gen.Logging.HelperLibrary.csproj" />
   </ItemGroup>  
 </Project>

--- a/test/Generators/Microsoft.Gen.Logging/HelperLibrary/FieldToLog.cs
+++ b/test/Generators/Microsoft.Gen.Logging/HelperLibrary/FieldToLog.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Gen.Logging.Test;
+
+public class FieldToLog
+{
+    public string? Name { get; set; }
+    public string? Value { get; set; }
+}

--- a/test/Generators/Microsoft.Gen.Logging/HelperLibrary/Microsoft.Gen.Logging.HelperLibrary.csproj
+++ b/test/Generators/Microsoft.Gen.Logging/HelperLibrary/Microsoft.Gen.Logging.HelperLibrary.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Microsoft.Gen.Logging.Test</RootNamespace>
+    <Description>Test classes for Microsoft.Gen.Logging.Generated.Tests.</Description>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>$(TestNetCoreTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsWindowsBuild)' == 'true' ">$(TestNetCoreTargetFrameworks)$(ConditionalNet462)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Libraries\Microsoft.Extensions.Telemetry.Abstractions\Microsoft.Extensions.Telemetry.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Generators/Microsoft.Gen.Logging/HelperLibrary/ObjectToLog.cs
+++ b/test/Generators/Microsoft.Gen.Logging/HelperLibrary/ObjectToLog.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Gen.Logging.Test;
+
+public class ObjectToLog
+{
+    [LogPropertyIgnore]
+    public string? PropertyToIgnore { get; set; }
+
+    public string? PropertyToLog { get; set; }
+
+    [LogProperties]
+    public FieldToLog? FieldToLog { get; set; }
+}

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/LogPropertiesExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/LogPropertiesExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Gen.Logging.Test;
 
 namespace TestClasses
 {
@@ -244,5 +245,8 @@ namespace TestClasses
 
         [LoggerMessage(6, LogLevel.Information, "Testing interface-typed argument here...")]
         public static partial void LogMethodInterfaceArg(ILogger logger, [LogProperties] IMyInterface complexParam);
+
+        [LoggerMessage(7, LogLevel.Information, "Testing logging a complex object residing in another assembly...")]
+        public static partial void LogObjectFromAnotherAssembly(ILogger logger, [LogProperties] ObjectToLog logObject);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/Unit/EmitterTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/EmitterTests.cs
@@ -45,6 +45,7 @@ public class EmitterTests
                 Assembly.GetAssembly(typeof(IRedactorProvider))!,
                 Assembly.GetAssembly(typeof(PrivateDataAttribute))!,
                 Assembly.GetAssembly(typeof(BigInteger))!,
+                Assembly.GetAssembly(typeof(ObjectToLog))!
             },
             sources,
             symbols)

--- a/test/Generators/Microsoft.Gen.Logging/Unit/Microsoft.Gen.Logging.Unit.Tests.csproj
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/Microsoft.Gen.Logging.Unit.Tests.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\..\..\src\Libraries\Microsoft.Extensions.Telemetry.Abstractions\Microsoft.Extensions.Telemetry.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\..\src\Libraries\Microsoft.Extensions.Compliance.Testing\Microsoft.Extensions.Compliance.Testing.csproj" />
     <ProjectReference Include="..\..\..\..\src\Generators\Microsoft.Gen.Logging\Microsoft.Gen.Logging.csproj" />
+    <ProjectReference Include="..\HelperLibrary\Microsoft.Gen.Logging.HelperLibrary.csproj" />
 <!--
     <ProjectReference Include="..\Generated\Microsoft.Gen.Logging.Generated.Tests.csproj" />
     -->


### PR DESCRIPTION
Fixes #6598 by removing the `Conditional` attribute from the definition of the `LogProperties` and `LogPropertyIgnore` attributes.

The `Conditional` attribute is the root cause of the bug. When a property is marked with the `LogPropertyIgnore` attribute, the associated metadata is excluded from the compiled assembly. As a result, the logging method’s code generator, which relies on reflection to determine whether a property should be logged, lacks the necessary information and ends up emitting the property regardless.

When the logging method and the object being logged are located in the same assembly, the behavior differs. In this case, the code generator does not rely on the compiled assembly and can access the metadata associated with the `LogPropertyIgnore` attribute directly. As a result, it correctly identifies which properties should be excluded from logging.

While there is a workaround, i.e. defining the `CODE_GENERATION_ATTRIBUTES` compilation symbol required by the `Conditional` attribute, it is better to fix the bug by removing the `Conditional` attribute. If a user forget to apply the workaround he/she risks leaking privacy or security sensitive data which could be stored in properties marked as `LogPropertyIgnore`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6600)