### PR TITLE
Add schema version to server.json in MCP template

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/McpServer/McpServer-CSharp/.mcp/server.json
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/McpServer/McpServer-CSharp/.mcp/server.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://modelcontextprotocol.io/schemas/draft/2025-07-09/server.json",
   "description": "<your description here>",
   "name": "io.github.<your GitHub username here>/<your repo name>",
   "packages": [

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.Basic.verified/mcpserver/.mcp/server.json
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.Basic.verified/mcpserver/.mcp/server.json
@@ -1,4 +1,5 @@
 ﻿{
+  "$schema": "https://modelcontextprotocol.io/schemas/draft/2025-07-09/server.json",
   "description": "<your description here>",
   "name": "io.github.<your GitHub username here>/<your repo name>",
   "packages": [


### PR DESCRIPTION
The server.json schema is in draft mode, so this PR is an attempt to encode which version of the schema is being used here, despite it being draft (prerelease).

The schema is defined here:
https://github.com/modelcontextprotocol/registry/blob/main/docs/server-json/schema.json

Note that the `$schema` value right now is a URI _not_ a URL.
We could opt to point to the raw.githubusercontent.com URL but this would mean the `$schema` value diverges from `$id` currently used by the JSON schema. Also, if we pick a URL to GitHub, we would need to use a git ref in the URL which perhaps is not the worst but it would be a 2nd way of expressing the schema version (in addition to the date).

See https://github.com/modelcontextprotocol/registry/pull/167#discussion_r2195369401.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6606)