### PR TITLE
Update Azure Open AI package referenced by eval integration tests

### DIFF
--- a/eng/packages/TestOnly.props
+++ b/eng/packages/TestOnly.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageVersion Include="Azure.AI.OpenAI" Version="2.2.0-beta.4" />
+    <PackageVersion Include="Azure.AI.OpenAI" Version="2.2.0-beta.5" />
     <PackageVersion Include="autofixture" Version="4.17.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageVersion Include="AwesomeAssertions" Version="8.0.2" />


### PR DESCRIPTION
This change is required to address the following error when running eval integration tests - looks like the version of OpenAI package referenced in the product code was incompatible with the preview version of Azure Open AI package referenced in the test code.

```
System.TypeLoadException
  HResult=0x80131522
  Message=Could not load type 'OpenAI.RealtimeConversation.RealtimeConversationClient' from assembly 'OpenAI, Version=2.2.0.0, Culture=neutral, PublicKeyToken=b4187f3e65366280'.
  Source=Azure.AI.OpenAI
  StackTrace:
   at Azure.AI.OpenAI.AzureOpenAIClientOptions.GetRawServiceApiValueForClient(Object client)
   at Azure.AI.OpenAI.Chat.AzureChatClient..ctor(ClientPipeline pipeline, String deploymentName, Uri endpoint, AzureOpenAIClientOptions options)
   at Azure.AI.OpenAI.AzureOpenAIClient.GetChatClient(String deploymentName)
   at Microsoft.Extensions.AI.Evaluation.Integration.Tests.Setup.CreateChatConfiguration() in Q:\src\extensions\test\Libraries\Microsoft.Extensions.AI.Evaluation.Integration.Tests\Setup.cs:line 19
```