### PR TITLE
Add AmbientMetadata.AzureVm component

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/AzureVmMetadata.cs
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/AzureVmMetadata.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AmbientMetadata;
+
+/// <summary>
+/// Metadata for applications running on Azure Virtual Machines.
+/// Represents the Azure VM metadata supplied by the Azure Instance Metadata service:
+/// <see href="https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service"/>.
+/// </summary>
+/// <remarks>
+/// This class is initialized from an HTTP response received from a network endpoint.
+/// Therefore, in case of a network failure, it can happen that all properties will have empty values.
+/// </remarks>
+public class AzureVmMetadata
+{
+    /// <summary>
+    /// Gets or sets the Azure Region the VM is running in.
+    /// </summary>
+    public string? Location { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the VM.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the offer information for the VM image.
+    /// </summary>
+    public string? Offer { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of the OS (Linux or Windows).
+    /// </summary>
+    public string? OsType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fault domain the VM is running in.
+    /// </summary>
+    public string? PlatformFaultDomain { get; set; }
+
+    /// <summary>
+    /// Gets or sets the update domain the VM is running in.
+    /// </summary>
+    public string? PlatformUpdateDomain { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Publisher of the VM image.
+    /// </summary>
+    public string? Publisher { get; set; }
+
+    /// <summary>
+    /// Gets or sets the specific SKU for the VM image.
+    /// </summary>
+    public string? Sku { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subscription id in which the VM is executing.
+    /// </summary>
+    public string? SubscriptionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version of the VM image.
+    /// </summary>
+    public string? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets the unique identifier for the VM.
+    /// </summary>
+    public string? VmId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the scale set in which the VM is executing.
+    /// </summary>
+    public string? VmScaleSetName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the VM size.
+    /// </summary>
+    public string? VmSize { get; set; }
+}

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/AzureVmMetadataConfigurationBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/AzureVmMetadataConfigurationBuilderExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.AmbientMetadata.Internal;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.Configuration;
+
+/// <summary>
+/// Extensions for Azure Virtual Machine metadata types.
+/// </summary>
+public static class AzureVmMetadataConfigurationBuilderExtensions
+{
+    /// <summary>
+    /// Registers configuration provider for Azure applications.
+    /// </summary>
+    /// <param name="builder">The configuration builder.</param>
+    /// <param name="sectionName">Section name to save configuration into. Default set to "ambientmetadata:azurevm".</param>
+    /// <returns>The input configuration builder for call chaining.</returns>
+    /// <exception cref="ArgumentNullException">The argument <paramref name="builder"/> or <paramref name="sectionName"/> is <see langword="null" />.</exception>
+    public static IConfigurationBuilder AddAzureVmMetadata(this IConfigurationBuilder builder, string sectionName = Constants.DefaultSectionName)
+    {
+        _ = Throw.IfNull(builder);
+        _ = Throw.IfNullOrWhitespace(sectionName);
+
+        return builder.Add(new AzureVmMetadataSource(new AzureVmMetadataProvider(), sectionName));
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/AzureVmMetadataHostBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/AzureVmMetadataHostBuilderExtensions.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.AmbientMetadata.Internal;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Extensions for Azure Virtual Machine metadata types.
+/// </summary>
+public static class AzureVmMetadataHostBuilderExtensions
+{
+    /// <summary>
+    /// Registers configuration provider for applications running on Azure virtual machines and binds a model object onto the configuration.
+    /// </summary>
+    /// <param name="builder">The host builder.</param>
+    /// <param name="sectionName">Section name to bind configuration from. Default set to "ambientmetadata:azurevm".</param>
+    /// <returns>The input host builder for call chaining.</returns>
+    /// <exception cref="ArgumentNullException">The argument <paramref name="builder"/> or <paramref name="sectionName"/> is <see langword="null" />.</exception>
+    public static IHostBuilder UseAzureVmMetadata(this IHostBuilder builder, string sectionName = Constants.DefaultSectionName)
+    {
+        _ = Throw.IfNull(builder);
+        _ = Throw.IfNullOrWhitespace(sectionName);
+
+        _ = builder
+            .ConfigureHostConfiguration(builder =>
+                builder.AddAzureVmMetadata(sectionName))
+            .ConfigureServices((hostBuilderContext, serviceCollection) =>
+                serviceCollection.AddAzureVmMetadata(hostBuilderContext.Configuration.GetSection(sectionName)));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers configuration provider for applications running on Azure virtual machines and binds a model object onto the configuration.
+    /// </summary>
+    /// <typeparam name="TBuilder"><see cref="IHostApplicationBuilder"/>.</typeparam>
+    /// <param name="builder">The host builder.</param>
+    /// <param name="sectionName">Section name to bind configuration from. Default set to "ambientmetadata:azurevm".</param>
+    /// <returns>The input host builder for call chaining.</returns>
+    /// <exception cref="ArgumentNullException">The argument <paramref name="builder"/> or <paramref name="sectionName"/> is <see langword="null" />.</exception>
+    public static TBuilder UseAzureVmMetadata<TBuilder>(this TBuilder builder, string sectionName = Constants.DefaultSectionName)
+        where TBuilder : IHostApplicationBuilder
+    {
+        _ = Throw.IfNull(builder);
+        _ = Throw.IfNullOrWhitespace(sectionName);
+
+        _ = builder.Configuration.AddAzureVmMetadata(sectionName);
+        _ = builder.Services.AddAzureVmMetadata(builder.Configuration.GetSection(sectionName));
+
+        return builder;
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/AzureVmMetadataServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/AzureVmMetadataServiceCollectionExtensions.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.AmbientMetadata;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extensions for Azure Virtual Machine metadata types.
+/// </summary>
+public static class AzureVmMetadataServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds an instance of <see cref="AzureVmMetadata"/> to the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+    /// <param name="section">The configuration section to bind.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    /// <exception cref="ArgumentNullException">The argument <paramref name="services"/> or <paramref name="section"/> is <see langword="null" />.</exception>
+    public static IServiceCollection AddAzureVmMetadata(this IServiceCollection services, IConfigurationSection section)
+    {
+        _ = Throw.IfNull(services);
+        _ = Throw.IfNull(section);
+
+        _ = services
+            .AddOptions<AzureVmMetadata>()
+            .Bind(section);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds an instance of <see cref="AzureVmMetadata"/> to the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+    /// <param name="configure">The delegate to configure <see cref="AzureVmMetadata"/> with.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    /// <exception cref="ArgumentNullException">The argument <paramref name="services"/> or <paramref name="configure"/> is <see langword="null" />.</exception>
+    public static IServiceCollection AddAzureVmMetadata(this IServiceCollection services, Action<AzureVmMetadata> configure)
+    {
+        _ = Throw.IfNull(services);
+        _ = Throw.IfNull(configure);
+
+        _ = services
+            .AddOptions<AzureVmMetadata>()
+            .Configure(configure);
+
+        return services;
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Internal/AzureVmMetadataProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Internal/AzureVmMetadataProvider.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.AmbientMetadata.Internal;
+
+internal sealed class AzureVmMetadataProvider : IAzureVmMetadataProvider
+{
+    internal readonly TimeProvider Clock = TimeProvider.System;
+
+    private const int MaxAttempts = 3;
+    private const double Timeout = 500;
+
+    private static readonly AzureVmMetadata _emptyMetadata = new();
+
+    private readonly Uri _metadataUri = new("http://169.254.169.254/metadata/instance/compute?api-version=2023-07-01");
+    private readonly HttpClient _httpClient;
+
+    public AzureVmMetadataProvider(HttpClient? httpClient = null)
+    {
+        _httpClient = httpClient ?? new HttpClient();
+        _httpClient.DefaultRequestHeaders.Add("Metadata", "true");
+    }
+
+    /// <inheritdoc />
+    [SuppressMessage("Design", "CA1031: Do not catch general exception types", Justification = "Do need to catch all exceptions.")]
+    public async Task<AzureVmMetadata> GetMetadataAsync(CancellationToken cancellationToken)
+    {
+        HttpResponseMessage? response = null;
+        try
+        {
+            for (int i = 0; i < MaxAttempts; i++)
+            {
+                try
+                {
+                    response = await _httpClient.GetAsync(_metadataUri, cancellationToken).ConfigureAwait(false);
+                    break;
+                }
+                catch
+                {
+#if NET
+#pragma warning disable EA0002 // the analyzer doesn't understand that TimeProvider is actually used here
+                    await Task.Delay(TimeSpan.FromMilliseconds(i * Timeout), Clock, cancellationToken).ConfigureAwait(false);
+#pragma warning restore EA0002
+#else
+                    await Clock.Delay(TimeSpan.FromMilliseconds(i * Timeout), cancellationToken).ConfigureAwait(false);
+#endif
+                }
+            }
+
+            if (response is null)
+            {
+                return _emptyMetadata;
+            }
+#if NET
+            System.IO.Stream responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#else
+            System.IO.Stream responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#endif
+            return await JsonSerializer.DeserializeAsync(responseStream, SerializerContext.Default.AzureVmMetadata, cancellationToken).ConfigureAwait(false) ?? _emptyMetadata;
+        }
+        catch
+        {
+            return _emptyMetadata;
+        }
+        finally
+        {
+            response?.Dispose();
+        }
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Internal/AzureVmMetadataSource.cs
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Internal/AzureVmMetadataSource.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+
+namespace Microsoft.Extensions.AmbientMetadata.Internal;
+
+/// <summary>
+/// Provides virtual configuration source for information about Azure Virtual Machine instances.
+/// </summary>
+internal sealed class AzureVmMetadataSource : IConfigurationSource
+{
+    private readonly IAzureVmMetadataProvider _metadataProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureVmMetadataSource"/> class.
+    /// </summary>
+    /// <param name="metadataProvider">Azure VM metadata provider.</param>
+    /// <param name="sectionName">Section name in configuration to save configuration values to.</param>
+    public AzureVmMetadataSource(IAzureVmMetadataProvider metadataProvider, string sectionName)
+    {
+        _metadataProvider = metadataProvider;
+        SectionName = sectionName;
+    }
+
+    /// <summary>
+    /// Gets configuration section name.
+    /// </summary>
+    public string SectionName { get; }
+
+    /// <summary>
+    /// Builds <see cref="IConfigurationProvider"/> from <see cref="IAzureVmMetadataProvider"/>.
+    /// </summary>
+    /// <param name="builder">Used to build the application configuration.</param>
+    /// <returns>The configuration provider.</returns>
+    public IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+        AzureVmMetadata metadata = _metadataProvider.GetMetadataAsync(CancellationToken.None).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+
+        var provider = new MemoryConfigurationProvider(new MemoryConfigurationSource())
+        {
+            { $"{SectionName}:location", metadata.Location ?? string.Empty },
+            { $"{SectionName}:name", metadata.Name ?? string.Empty },
+            { $"{SectionName}:offer", metadata.Offer ?? string.Empty },
+            { $"{SectionName}:ostype", metadata.OsType ?? string.Empty },
+            { $"{SectionName}:platformfaultdomain", metadata.PlatformFaultDomain ?? string.Empty },
+            { $"{SectionName}:platformupdatedomain", metadata.PlatformUpdateDomain ?? string.Empty },
+            { $"{SectionName}:publisher", metadata.Publisher ?? string.Empty },
+            { $"{SectionName}:sku", metadata.Sku ?? string.Empty },
+            { $"{SectionName}:subscriptionid", metadata.SubscriptionId ?? string.Empty },
+            { $"{SectionName}:version", metadata.Version ?? string.Empty },
+            { $"{SectionName}:vmid", metadata.VmId ?? string.Empty },
+            { $"{SectionName}:vmscalesetname", metadata.VmScaleSetName ?? string.Empty },
+            { $"{SectionName}:vmsize", metadata.VmSize ?? string.Empty }
+        };
+
+        return provider;
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Internal/Constants.cs
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Internal/Constants.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AmbientMetadata.Internal;
+
+internal static class Constants
+{
+    public const string DefaultSectionName = "ambientmetadata:azurevm";
+}

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Internal/IAzureVmMetadataProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Internal/IAzureVmMetadataProvider.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.AmbientMetadata.Internal;
+
+/// <summary>
+/// An interface for obtaining metadata of the Azure Virtual Machine instances.
+/// </summary>
+internal interface IAzureVmMetadataProvider
+{
+    /// <summary>
+    /// Retrieves the metadata of the Azure Virtual Machine instance.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An instance of <see cref="AzureVmMetadata"/>.</returns>
+    /// <remarks>For more information, see <see href="https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service">here.</see>.</remarks>
+    Task<AzureVmMetadata> GetMetadataAsync(CancellationToken cancellationToken);
+}

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Internal/SerializerContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Internal/SerializerContext.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Extensions.AmbientMetadata.Internal;
+
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(AzureVmMetadata))]
+internal sealed partial class SerializerContext : JsonSerializerContext
+{
+}

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Microsoft.Extensions.AmbientMetadata.AzureVm.csproj
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Microsoft.Extensions.AmbientMetadata.AzureVm.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Microsoft.Extensions.AmbientMetadata</RootNamespace>
+    <TargetFrameworks>$(NetCoreTargetFrameworks);netstandard2.0;net462</TargetFrameworks>
+    <Description>Runtime information provider for the Azure Virtual Machine instances.</Description>
+    <Workstream>Fundamentals</Workstream>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <InjectExperimentalAttributeOnLegacy>true</InjectExperimentalAttributeOnLegacy>
+    <InjectSharedDiagnosticIds>true</InjectSharedDiagnosticIds>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Stage>dev</Stage>
+    <StageDevDiagnosticId>EXTEXP0009</StageDevDiagnosticId>
+    <MinCodeCoverage>97</MinCodeCoverage>
+    <MinMutationScore>92</MinMutationScore>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleToTest Include="$(AssemblyName).Tests" />
+    <InternalsVisibleToDynamicProxyGenAssembly2 Include="*" />
+  </ItemGroup>
+</Project>

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Microsoft.Extensions.AmbientMetadata.AzureVm.json
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/Microsoft.Extensions.AmbientMetadata.AzureVm.json
@@ -1,0 +1,107 @@
+{
+  "Name": "Microsoft.Extensions.AmbientMetadata.AzureVm, Version=9.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "class Microsoft.Extensions.AmbientMetadata.AzureVmMetadata",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.AzureVmMetadata();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.Location { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.Name { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.Offer { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.OsType { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.PlatformFaultDomain { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.PlatformUpdateDomain { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.Publisher { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.Sku { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.SubscriptionId { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.Version { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.VmId { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.VmScaleSetName { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.AzureVmMetadata.VmSize { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Configuration.AzureVmMetadataConfigurationBuilderExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Configuration.IConfigurationBuilder Microsoft.Extensions.Configuration.AzureVmMetadataConfigurationBuilderExtensions.AddAzureVmMetadata(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, string sectionName = \"ambientmetadata:azurevm\");",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Hosting.AzureVmMetadataHostBuilderExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Hosting.AzureVmMetadataHostBuilderExtensions.UseAzureVmMetadata(this Microsoft.Extensions.Hosting.IHostBuilder builder, string sectionName = \"ambientmetadata:azurevm\");",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static TBuilder Microsoft.Extensions.Hosting.AzureVmMetadataHostBuilderExtensions.UseAzureVmMetadata<TBuilder>(this TBuilder builder, string sectionName = \"ambientmetadata:azurevm\");",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.DependencyInjection.AzureVmMetadataServiceCollectionExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.DependencyInjection.AzureVmMetadataServiceCollectionExtensions.AddAzureVmMetadata(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.DependencyInjection.AzureVmMetadataServiceCollectionExtensions.AddAzureVmMetadata(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.AmbientMetadata.AzureVmMetadata> configure);",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/README.md
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm/README.md
@@ -1,0 +1,74 @@
+# Microsoft.Extensions.AmbientMetadata.AzureVm
+
+This flows runtime information for Azure virtual machine instance ambient metadata such as the location, name, offer, etc. This information can be useful to enrich telemetry.
+
+## Install the package
+
+From the command-line:
+
+```console
+dotnet add package Microsoft.Extensions.AmbientMetadata.AzureVm
+```
+
+Or directly in the C# project file:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.Extensions.AmbientMetadata.AzureVm" Version="[CURRENTVERSION]" />
+</ItemGroup>
+```
+
+## Usage Example
+
+### Configuration
+
+The configuration can be load automatically from the Azure VM endpoint using the following method:
+
+```csharp
+public static IConfigurationBuilder AddAzureVmMetadata(this IConfigurationBuilder builder)
+```
+
+Alternatively, for purposes of unit testing or emulating Azure Virtual machine environment, all metadata values can be read from the `ambientmetadata:azurevm` section.
+
+```json
+{
+  "AmbientMetadata": {
+    "AzureVm": {
+      "Location": "East US",
+      "Offer": "Standard_DS1_v2"
+      ...
+    }
+  }
+}
+```
+
+### Registering Services
+
+The services can be registered using any of the following methods:
+
+```csharp
+public static IHostBuilder UseAzureVmMetadata(this IHostBuilder builder, string sectionName = DefaultSectionName)
+public static IServiceCollection AddAzureVmMetadata(this IServiceCollection services, Action<AzureVmMetadata> configure)
+```
+
+### Consuming Services
+
+The `AzureVmMetadata` can be injected wherever needed. For example:
+
+```csharp
+public class MyClass
+{
+  public MyClass(IOptions<AzureVmMetadata> options) { Metadata = options.Value; }
+
+  private AzureVmMetadata Metadata { get; }
+
+  public void DoWork()
+  {
+    Log.LogEnvironment(Metadata.Location, Metadata.Offer);
+  }
+}
+```
+
+## Feedback & Contributing
+
+We welcome feedback and contributions in [our GitHub repo](https://github.com/dotnet/extensions).

--- a/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataConfigBuilderExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataConfigBuilderExtensionsTests.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.Extensions.AmbientMetadata.Test;
+
+public class AzureVmMetadataConfigBuilderExtensionsTests
+{
+    [Fact]
+    public void GivenNullBuilder_ThrowsArgumentNullException()
+    {
+        // Arrange
+        IConfigurationBuilder? builder = null;
+
+        // Act and Assert
+        Assert.Throws<ArgumentNullException>(() => builder!.AddAzureVmMetadata());
+    }
+
+    [Fact]
+    public void GivenNullSectionName_ThrowsArgumentNullException()
+    {
+        // Arrange
+        ConfigurationBuilder builder = new();
+
+        // Act and Assert
+        Assert.Throws<ArgumentNullException>(() => builder.AddAzureVmMetadata(sectionName: null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void GivenWhitespaceSectionName_ThrowsArgumentException(string sectionName)
+    {
+        // Arrange
+        ConfigurationBuilder builder = new();
+
+        // Act and Assert
+        Assert.Throws<ArgumentException>(() => builder.AddAzureVmMetadata(sectionName: sectionName));
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataHostBuilderExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataHostBuilderExtensionsTests.cs
@@ -1,0 +1,127 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Testing;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Extensions.AmbientMetadata.Test;
+
+public class AzureVmMetadataHostBuilderExtensionsTests
+{
+    [Theory]
+    [InlineData("ambientmetadata:azurevm")]
+    [InlineData("customSection:ambientmetadata:azurevm")]
+    public void GivenMetadata_RegistersOptions_HostBuilder(string? sectionName)
+    {
+        var metadata = new AzureVmMetadata
+        {
+            Location = "eastus",
+            Name = "my-vm",
+            Offer = "WindowsServer",
+            OsType = "Windows",
+            PlatformFaultDomain = "0",
+            PlatformUpdateDomain = "0",
+            Publisher = "MicrosoftWindowsServer",
+            Sku = "2019-Datacenter",
+            SubscriptionId = "12345678-1234-5678-abcd-1234567890ab",
+            Version = "latest",
+            VmId = "abcdefgh-1234-5678-abcd-1234567890ab",
+            VmScaleSetName = "my-vm-scale-set",
+            VmSize = "Standard_DS2_v2"
+        };
+
+        var config = new Dictionary<string, string?>
+        {
+            [$"{sectionName}:{nameof(AzureVmMetadata.Location)}"] = metadata.Location,
+            [$"{sectionName}:{nameof(AzureVmMetadata.Name)}"] = metadata.Name,
+            [$"{sectionName}:{nameof(AzureVmMetadata.Offer)}"] = metadata.Offer,
+            [$"{sectionName}:{nameof(AzureVmMetadata.OsType)}"] = metadata.OsType,
+            [$"{sectionName}:{nameof(AzureVmMetadata.PlatformFaultDomain)}"] = metadata.PlatformFaultDomain,
+            [$"{sectionName}:{nameof(AzureVmMetadata.PlatformUpdateDomain)}"] = metadata.PlatformUpdateDomain,
+            [$"{sectionName}:{nameof(AzureVmMetadata.Publisher)}"] = metadata.Publisher,
+            [$"{sectionName}:{nameof(AzureVmMetadata.Sku)}"] = metadata.Sku,
+            [$"{sectionName}:{nameof(AzureVmMetadata.SubscriptionId)}"] = metadata.SubscriptionId,
+            [$"{sectionName}:{nameof(AzureVmMetadata.Version)}"] = metadata.Version,
+            [$"{sectionName}:{nameof(AzureVmMetadata.VmId)}"] = metadata.VmId,
+            [$"{sectionName}:{nameof(AzureVmMetadata.VmScaleSetName)}"] = metadata.VmScaleSetName,
+            [$"{sectionName}:{nameof(AzureVmMetadata.VmSize)}"] = metadata.VmSize,
+        };
+
+        IHostBuilder hostBuilder = FakeHost.CreateBuilder();
+        if (sectionName is not null)
+        {
+            hostBuilder.UseAzureVmMetadata(sectionName);
+        }
+        else
+        {
+            hostBuilder.UseAzureVmMetadata();
+        }
+
+        using IHost host = hostBuilder
+            .ConfigureHostConfiguration(configBuilder => configBuilder.AddInMemoryCollection(config))
+            .Build();
+
+        host.Services.GetRequiredService<IOptions<AzureVmMetadata>>().Value.Should().BeEquivalentTo(metadata);
+    }
+
+    [Theory]
+    [InlineData("ambientmetadata:azurevm")]
+    [InlineData("customSection:ambientmetadata:azurevm")]
+    public void GivenMetadata_RegistersOptions_HostApplicationBuilder(string? sectionName)
+    {
+        var metadata = new AzureVmMetadata
+        {
+            Location = "eastus",
+            Name = "my-vm",
+            Offer = "WindowsServer",
+            OsType = "Windows",
+            PlatformFaultDomain = "0",
+            PlatformUpdateDomain = "0",
+            Publisher = "MicrosoftWindowsServer",
+            Sku = "2019-Datacenter",
+            SubscriptionId = "12345678-1234-5678-abcd-1234567890ab",
+            Version = "latest",
+            VmId = "abcdefgh-1234-5678-abcd-1234567890ab",
+            VmScaleSetName = "my-vm-scale-set",
+            VmSize = "Standard_DS2_v2"
+        };
+
+        var config = new Dictionary<string, string?>
+        {
+            [$"{sectionName}:{nameof(AzureVmMetadata.Location)}"] = metadata.Location,
+            [$"{sectionName}:{nameof(AzureVmMetadata.Name)}"] = metadata.Name,
+            [$"{sectionName}:{nameof(AzureVmMetadata.Offer)}"] = metadata.Offer,
+            [$"{sectionName}:{nameof(AzureVmMetadata.OsType)}"] = metadata.OsType,
+            [$"{sectionName}:{nameof(AzureVmMetadata.PlatformFaultDomain)}"] = metadata.PlatformFaultDomain,
+            [$"{sectionName}:{nameof(AzureVmMetadata.PlatformUpdateDomain)}"] = metadata.PlatformUpdateDomain,
+            [$"{sectionName}:{nameof(AzureVmMetadata.Publisher)}"] = metadata.Publisher,
+            [$"{sectionName}:{nameof(AzureVmMetadata.Sku)}"] = metadata.Sku,
+            [$"{sectionName}:{nameof(AzureVmMetadata.SubscriptionId)}"] = metadata.SubscriptionId,
+            [$"{sectionName}:{nameof(AzureVmMetadata.Version)}"] = metadata.Version,
+            [$"{sectionName}:{nameof(AzureVmMetadata.VmId)}"] = metadata.VmId,
+            [$"{sectionName}:{nameof(AzureVmMetadata.VmScaleSetName)}"] = metadata.VmScaleSetName,
+            [$"{sectionName}:{nameof(AzureVmMetadata.VmSize)}"] = metadata.VmSize,
+        };
+
+        HostApplicationBuilder hostBuilder = Host.CreateEmptyApplicationBuilder(new());
+        if (sectionName is not null)
+        {
+            hostBuilder.UseAzureVmMetadata(sectionName);
+        }
+        else
+        {
+            hostBuilder.UseAzureVmMetadata();
+        }
+
+        hostBuilder.Configuration.AddInMemoryCollection(config);
+        using IHost host = hostBuilder.Build();
+
+        host.Services.GetRequiredService<IOptions<AzureVmMetadata>>().Value.Should().BeEquivalentTo(metadata);
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataProviderTests.cs
@@ -1,0 +1,142 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.AmbientMetadata.Internal;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Microsoft.Extensions.AmbientMetadata.Test;
+
+public class AzureVmMetadataProviderTests
+{
+    private readonly Mock<HttpMessageHandler> _handlerMock;
+
+    public AzureVmMetadataProviderTests()
+    {
+        _handlerMock = new Mock<HttpMessageHandler>();
+    }
+
+    [Fact]
+    public async Task GetMetadataAsync_WithValidHttpResponse_ReturnsExpectedMetadata()
+    {
+        // Arrange
+        var expectedMetadata = new AzureVmMetadata
+        {
+            Location = "West US",
+            Name = "my-vm",
+            Offer = "UbuntuServer",
+            OsType = "Linux",
+            PlatformFaultDomain = "1",
+            PlatformUpdateDomain = "2",
+            Publisher = "Canonical",
+            Sku = "18.04-LTS",
+            SubscriptionId = "12345678-1234-5678-abcd-1234567890ab",
+            Version = "18.04.202110080",
+            VmId = "12345678-1234-5678-abcd-1234567890ab",
+            VmScaleSetName = null,
+            VmSize = "Standard_D2_v2"
+        };
+        using var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(expectedMetadata, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+        };
+
+        _handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(httpResponseMessage)
+            .Verifiable();
+
+        using var magicHttpClient = new HttpClient(_handlerMock.Object);
+        var metadataProvider = new AzureVmMetadataProvider(magicHttpClient);
+
+        // Act
+        AzureVmMetadata result = await metadataProvider.GetMetadataAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(expectedMetadata);
+    }
+
+    [Fact]
+    public async Task GetMetadataAsync_WithEmptyHttpResponse_ReturnsEmptyMetadata()
+    {
+        // Arrange
+        using var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(string.Empty)
+        };
+        _handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(httpResponseMessage)
+            .Verifiable();
+        using var magicHttpClient = new HttpClient(_handlerMock.Object);
+        var metadataProvider = new AzureVmMetadataProvider(magicHttpClient);
+
+        // Act
+        AzureVmMetadata result = await metadataProvider.GetMetadataAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(new AzureVmMetadata());
+    }
+
+    [Fact]
+    public async Task GetMetadataAsync_WithInvalidHttpResponse_ReturnsEmptyMetadata()
+    {
+        // Arrange
+        using var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        _handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(httpResponseMessage)
+            .Verifiable();
+
+        using var magicHttpClient = new HttpClient(_handlerMock.Object);
+        var metadataProvider = new AzureVmMetadataProvider(magicHttpClient);
+
+        // Act
+        AzureVmMetadata result = await metadataProvider.GetMetadataAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(new AzureVmMetadata());
+    }
+
+    [Fact]
+    public async Task GetMetadataAsync_WithExceptionDuringHttpRequest_ReturnsEmptyMetadata()
+    {
+        // Arrange
+
+        _handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException());
+
+        using var magicHttpClient = new HttpClient(_handlerMock.Object);
+        var metadataProvider = new AzureVmMetadataProvider(magicHttpClient);
+
+        // Act
+        AzureVmMetadata result = await metadataProvider.GetMetadataAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(new AzureVmMetadata());
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataServiceCollectionExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataServiceCollectionExtensionsTests.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Extensions.AmbientMetadata.Test;
+
+public class AzureVmMetadataServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void GivenAnyNullArgument_ShouldThrowArgumentNullException()
+    {
+        var serviceCollection = new ServiceCollection();
+        IConfigurationRoot config = new ConfigurationBuilder().Build();
+
+        serviceCollection.Invoking(x => ((IServiceCollection)null!).AddAzureVmMetadata(config.GetSection(string.Empty)))
+            .Should().Throw<ArgumentNullException>();
+
+        serviceCollection.Invoking(x => x.AddAzureVmMetadata((Action<AzureVmMetadata>)null!))
+            .Should().Throw<ArgumentNullException>();
+
+        serviceCollection.Invoking(x => ((IServiceCollection)null!).AddAzureVmMetadata(_ => { }))
+            .Should().Throw<ArgumentNullException>();
+
+        serviceCollection.Invoking(x => x.AddAzureVmMetadata((IConfigurationSection)null!))
+            .Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenConfigurationSection_ShouldRegisterMetadataFromIt()
+    {
+        // Arrange
+        var testData = new AzureVmMetadata
+        {
+            Location = "eastus",
+            Name = "my-vm",
+            Offer = "WindowsServer",
+            OsType = "Windows",
+            PlatformFaultDomain = "0",
+            PlatformUpdateDomain = "0",
+            Publisher = "MicrosoftWindowsServer",
+            Sku = "2019-Datacenter",
+            SubscriptionId = "12345678-1234-5678-abcd-1234567890ab",
+            Version = "latest",
+            VmId = "abcdefgh-1234-5678-abcd-1234567890ab",
+            VmScaleSetName = "my-vm-scale-set",
+            VmSize = "Standard_DS2_v2"
+        };
+
+        IConfigurationRoot config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.Location)}"] = testData.Location,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.Name)}"] = testData.Name,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.Offer)}"] = testData.Offer,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.OsType)}"] = testData.OsType,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.PlatformFaultDomain)}"] = testData.PlatformFaultDomain,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.PlatformUpdateDomain)}"] = testData.PlatformUpdateDomain,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.Publisher)}"] = testData.Publisher,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.Sku)}"] = testData.Sku,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.SubscriptionId)}"] = testData.SubscriptionId,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.Version)}"] = testData.Version,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.VmId)}"] = testData.VmId,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.VmScaleSetName)}"] = testData.VmScaleSetName,
+                [$"{nameof(AzureVmMetadata)}:{nameof(AzureVmMetadata.VmSize)}"] = testData.VmSize,
+            })
+            .Build();
+
+        IConfigurationSection configurationSection = config
+            .GetSection(nameof(AzureVmMetadata));
+
+        // Act
+        using ServiceProvider provider = new ServiceCollection()
+            .AddAzureVmMetadata(configurationSection)
+            .BuildServiceProvider();
+        AzureVmMetadata metadata = provider
+            .GetRequiredService<IOptions<AzureVmMetadata>>().Value;
+
+        // Assert
+        metadata.Should().BeEquivalentTo(testData);
+    }
+
+    [Fact]
+    public void GivenActionDelegate_ShouldRegisterMetadataFromIt()
+    {
+        // Arrange
+        var testData = new AzureVmMetadata
+        {
+            Location = "eastus",
+            Name = "my-vm",
+            Offer = "WindowsServer",
+            OsType = "Windows",
+            PlatformFaultDomain = "0",
+            PlatformUpdateDomain = "0",
+            Publisher = "MicrosoftWindowsServer",
+            Sku = "2019-Datacenter",
+            SubscriptionId = "12345678-1234-5678-abcd-1234567890ab",
+            Version = "latest",
+            VmId = "abcdefgh-1234-5678-abcd-1234567890ab",
+            VmScaleSetName = "my-vm-scale-set",
+            VmSize = "Standard_DS2_v2"
+        };
+
+        // Act
+        using ServiceProvider provider = new ServiceCollection()
+            .AddAzureVmMetadata(m =>
+            {
+                m.Location = testData.Location;
+                m.Name = testData.Name;
+                m.Offer = testData.Offer;
+                m.OsType = testData.OsType;
+                m.PlatformFaultDomain = testData.PlatformFaultDomain;
+                m.PlatformUpdateDomain = testData.PlatformUpdateDomain;
+                m.Publisher = testData.Publisher;
+                m.Sku = testData.Sku;
+                m.SubscriptionId = testData.SubscriptionId;
+                m.Version = testData.Version;
+                m.VmId = testData.VmId;
+                m.VmScaleSetName = testData.VmScaleSetName;
+                m.VmSize = testData.VmSize;
+            })
+            .BuildServiceProvider();
+        AzureVmMetadata metadata = provider
+            .GetRequiredService<IOptions<AzureVmMetadata>>().Value;
+
+        // Assert
+        metadata.Should().BeEquivalentTo(testData);
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataSourceTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataSourceTests.cs
@@ -1,0 +1,115 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using Microsoft.Extensions.AmbientMetadata.Internal;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Extensions.AmbientMetadata.Test;
+
+public class AzureVmMetadataSourceTests
+{
+    [Fact]
+    public void Constructor_SetsSectionNameProperty_WhenArgumentsAreValid()
+    {
+        // Arrange
+        IAzureVmMetadataProvider metadataProvider = Mock.Of<IAzureVmMetadataProvider>();
+        string sectionName = "AzureMetadata";
+
+        // Act
+        var source = new AzureVmMetadataSource(metadataProvider, sectionName);
+
+        // Assert
+        Assert.Equal(sectionName, source.SectionName);
+    }
+
+    [Fact]
+    public void Build_CallsGetMetadataAsyncOnMetadataProvider()
+    {
+        // Arrange
+        Mock<IAzureVmMetadataProvider> metadataProvider = new Mock<IAzureVmMetadataProvider>();
+        var metadata = new AzureVmMetadata();
+        metadataProvider.Setup(m => m.GetMetadataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(metadata);
+        var source = new AzureVmMetadataSource(metadataProvider.Object, "Azure");
+
+        // Act
+        IConfigurationProvider provider = source.Build(Mock.Of<IConfigurationBuilder>());
+
+        // Assert
+        metadataProvider.Verify(m => m.GetMetadataAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void Build_ConfiguresProviderWithValues()
+    {
+        // Arrange
+        const string TestSectionName = "Azure";
+        IAzureVmMetadataProvider metadataProvider = Mock.Of<IAzureVmMetadataProvider>();
+        var metadata = new AzureVmMetadata
+        {
+            Location = "East US",
+            Name = "TestVM",
+            Offer = "Windows",
+            OsType = "Windows",
+            PlatformFaultDomain = "0",
+            PlatformUpdateDomain = "1",
+            Publisher = "Microsoft",
+            Sku = "2019-Datacenter",
+            SubscriptionId = "12345678-1234-1234-1234-123456789012",
+            Version = "1.0.0",
+            VmId = "12345678-1234-1234-1234-123456789012",
+            VmScaleSetName = "TestScaleSet",
+            VmSize = "Standard_D2_v2"
+        };
+        Mock.Get(metadataProvider).Setup(m => m.GetMetadataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(metadata);
+        var source = new AzureVmMetadataSource(metadataProvider, TestSectionName);
+
+        // Act
+        IConfigurationRoot config = new ConfigurationBuilder().Add(source).Build();
+
+        // Assert
+        Assert.Equal(metadata.Location, config[$"{TestSectionName}:{nameof(AzureVmMetadata.Location)}"]);
+        Assert.Equal(metadata.Name, config[$"{TestSectionName}:{nameof(AzureVmMetadata.Name)}"]);
+        Assert.Equal(metadata.Offer, config[$"{TestSectionName}:{nameof(AzureVmMetadata.Offer)}"]);
+        Assert.Equal(metadata.OsType, config[$"{TestSectionName}:{nameof(AzureVmMetadata.OsType)}"]);
+        Assert.Equal(metadata.PlatformFaultDomain, config[$"{TestSectionName}:{nameof(AzureVmMetadata.PlatformFaultDomain)}"]);
+        Assert.Equal(metadata.PlatformUpdateDomain, config[$"{TestSectionName}:{nameof(AzureVmMetadata.PlatformUpdateDomain)}"]);
+        Assert.Equal(metadata.Publisher, config[$"{TestSectionName}:{nameof(AzureVmMetadata.Publisher)}"]);
+        Assert.Equal(metadata.Sku, config[$"{TestSectionName}:{nameof(AzureVmMetadata.Sku)}"]);
+        Assert.Equal(metadata.SubscriptionId, config[$"{TestSectionName}:{nameof(AzureVmMetadata.SubscriptionId)}"]);
+        Assert.Equal(metadata.Version, config[$"{TestSectionName}:{nameof(AzureVmMetadata.Version)}"]);
+        Assert.Equal(metadata.VmId, config[$"{TestSectionName}:{nameof(AzureVmMetadata.VmId)}"]);
+        Assert.Equal(metadata.VmScaleSetName, config[$"{TestSectionName}:{nameof(AzureVmMetadata.VmScaleSetName)}"]);
+        Assert.Equal(metadata.VmSize, config[$"{TestSectionName}:{nameof(AzureVmMetadata.VmSize)}"]);
+    }
+
+    [Fact]
+    public void Build_ConfiguresProviderWithEmptyValues_WhenMetadataIsEmpty()
+    {
+        // Arrange
+        const string TestSectionName = "Azure";
+        IAzureVmMetadataProvider metadataProvider = Mock.Of<IAzureVmMetadataProvider>();
+        var metadata = new AzureVmMetadata();
+        Mock.Get(metadataProvider).Setup(m => m.GetMetadataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(metadata);
+        var source = new AzureVmMetadataSource(metadataProvider, TestSectionName);
+
+        // Act
+        IConfigurationRoot config = new ConfigurationBuilder().Add(source).Build();
+
+        // Assert
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.Name)}"]);
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.Offer)}"]);
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.OsType)}"]);
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.PlatformFaultDomain)}"]);
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.PlatformUpdateDomain)}"]);
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.Publisher)}"]);
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.Sku)}"]);
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.SubscriptionId)}"]);
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.Version)}"]);
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.VmId)}"]);
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.VmScaleSetName)}"]);
+        Assert.Equal(string.Empty, config[$"{TestSectionName}:{nameof(AzureVmMetadata.VmSize)}"]);
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/AzureVmMetadataTests.cs
@@ -1,0 +1,168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.Extensions.AmbientMetadata.Test;
+
+public class AzureVmMetadataTests
+{
+    [Fact]
+    public void ShouldConstructObject()
+    {
+        var instance = new AzureVmMetadata();
+        Assert.NotNull(instance);
+    }
+
+    [Fact]
+    public void ShouldHaveAllPropertiesNull()
+    {
+        // Arrange
+        var obj = new AzureVmMetadata();
+        object?[] properties = obj.GetType().GetProperties().Select(f => f.GetValue(obj)).ToArray();
+
+        properties.Should().OnlyContain(x => x == null);
+    }
+
+    [Fact]
+    public void LocationProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata
+        {
+            // Act
+            Location = "West US 2"
+        };
+
+        // Assert
+        metadata.Location.Should().Be("West US 2");
+    }
+
+    [Fact]
+    public void NameProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata { Name = "MyVM" };
+
+        // Assert
+        metadata.Name.Should().Be("MyVM");
+    }
+
+    [Fact]
+    public void OfferProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata { Offer = "WindowsServer" };
+
+        // Assert
+        metadata.Offer.Should().Be("WindowsServer");
+    }
+
+    [Fact]
+    public void OsTypeProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata { OsType = "Windows" };
+
+        // Assert
+        metadata.OsType.Should().Be("Windows");
+    }
+
+    [Fact]
+    public void PlatformFaultDomainProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata { PlatformFaultDomain = "0" };
+
+        // Assert
+        metadata.PlatformFaultDomain.Should().Be("0");
+    }
+
+    [Fact]
+    public void PlatformUpdateDomainProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata { PlatformUpdateDomain = "0" };
+
+        // Assert
+        metadata.PlatformUpdateDomain.Should().Be("0");
+    }
+
+    [Fact]
+    public void PublisherProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata { Publisher = "Microsoft" };
+
+        // Assert
+        metadata.Publisher.Should().Be("Microsoft");
+    }
+
+    [Fact]
+    public void SkuProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata { Sku = "Standard_D2_v3" };
+
+        // Assert
+        metadata.Sku.Should().Be("Standard_D2_v3");
+    }
+
+    [Fact]
+    public void SubscriptionIdProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata { SubscriptionId = "01234567-89ab-cdef-0123-456789abcdef" };
+
+        // Assert
+        metadata.SubscriptionId.Should().Be("01234567-89ab-cdef-0123-456789abcdef");
+    }
+
+    [Fact]
+    public void VersionProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata
+        {
+            // Act
+            Version = "1.0.0"
+        };
+
+        // Assert
+        metadata.Version.Should().Be("1.0.0");
+    }
+
+    [Fact]
+    public void VmIdProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata { VmId = "01234567-89ab-cdef-0123-456789abcdef" };
+
+        // Assert
+        metadata.VmId.Should().Be("01234567-89ab-cdef-0123-456789abcdef");
+    }
+
+    [Fact]
+    public void VmScaleSetNameProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata { VmScaleSetName = "scale set name" };
+
+        // Assert
+        metadata.VmScaleSetName.Should().Be("scale set name");
+    }
+
+    [Fact]
+    public void VmSizeProperty_ShouldSetAndGetCorrectly()
+    {
+        // Arrange
+        var metadata = new AzureVmMetadata { VmSize = "1234567" };
+
+        // Assert
+        metadata.VmSize.Should().Be("1234567");
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/Microsoft.Extensions.AmbientMetadata.AzureVM.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.AmbientMetadata.AzureVm.Tests/Microsoft.Extensions.AmbientMetadata.AzureVM.Tests.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Microsoft.Extensions.AmbientMetadata.Test</RootNamespace>
+    <Description>Unit tests for Microsoft.Extensions.AmbientMetadata.AzureVm.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AmbientMetadata.AzureVm\Microsoft.Extensions.AmbientMetadata.AzureVm.csproj" />
+    <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.Hosting.Testing\Microsoft.Extensions.Hosting.Testing.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Adding a brand new component - Azure Virtual Machine metadata, which automatically grabs Azure Virtual Machine instance information from the [Azure IMDS](https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=windows) service endpoint 169.254.169.254, deserializes it into a strong type `AzureVmMetadata` and registers it in Dependency Injection container as `IOptions<AzureVmMetadata>`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6612)