### PR TITLE
Add [Description] to DataContent.Uri

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/DataContent.cs
@@ -5,6 +5,7 @@ using System;
 #if NET
 using System.Buffers;
 using System.Buffers.Text;
+using System.ComponentModel;
 #endif
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -142,6 +143,9 @@ public class DataContent : AIContent
     /// or from a <see cref="System.Uri"/>.
     /// </remarks>
     [StringSyntax(StringSyntaxAttribute.Uri)]
+#if NET
+    [Description("A data URI representing the content.")]
+#endif
     public string Uri
     {
         get


### PR DESCRIPTION
So that if a DataContent has schema generated for it, it's obvious in the schema that the "uri" is specifically a data URI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6615)