### PR TITLE
Add TextContent.Annotations

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -196,14 +197,16 @@ public static class ChatResponseExtensions
             int start = 0;
             while (start < contents.Count - 1)
             {
-                // We need at least two TextContents in a row to be able to coalesce.
-                if (contents[start] is not TContent firstText)
+                // We need at least two TextContents in a row to be able to coalesce. We also avoid touching contents
+                // that have annotations, as we want to ensure the annotations (and in particular any start/end indices
+                // into the text content) remain accurate.
+                if (!TryAsCoalescable(contents[start], out var firstText))
                 {
                     start++;
                     continue;
                 }
 
-                if (contents[start + 1] is not TContent secondText)
+                if (!TryAsCoalescable(contents[start + 1], out var secondText))
                 {
                     start += 2;
                     continue;
@@ -215,7 +218,7 @@ public static class ChatResponseExtensions
                 _ = coalescedText.Clear().Append(firstText).Append(secondText);
                 contents[start + 1] = null!;
                 int i = start + 2;
-                for (; i < contents.Count && contents[i] is TContent next; i++)
+                for (; i < contents.Count && TryAsCoalescable(contents[i], out TContent? next); i++)
                 {
                     _ = coalescedText.Append(next);
                     contents[i] = null!;
@@ -229,6 +232,18 @@ public static class ChatResponseExtensions
                 newContent.AdditionalProperties = firstText.AdditionalProperties?.Clone();
 
                 start = i;
+
+                static bool TryAsCoalescable(AIContent content, [NotNullWhen(true)] out TContent? coalescable)
+                {
+                    if (content is TContent && (content is not TextContent tc || tc.Annotations is not { Count: > 0 }))
+                    {
+                        coalescable = (TContent)content;
+                        return true;
+                    }
+
+                    coalescable = null!;
+                    return false;
+                }
             }
 
             // Remove all of the null slots left over from the coalescing process.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/AIAnnotation.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/AIAnnotation.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>
+/// Represents an annotation on a span of content.
+/// </summary>
+[JsonDerivedType(typeof(CitationAnnotation), typeDiscriminator: "citation")]
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]
+public class AIAnnotation
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AIAnnotation"/> class.
+    /// </summary>
+    public AIAnnotation()
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the start character index (inclusive) of the annotated span in the <see cref="AIContent"/>.
+    /// </summary>
+    public int? StartIndex { get; set; }
+
+    /// <summary>
+    /// Gets or sets the end character index (exclusive) of the annotated span in the <see cref="AIContent"/>.
+    /// </summary>
+    public int? EndIndex { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional placeholder or marker text that was present in the original content
+    /// to indicate the citation (e.g., "〖4:0+source.json〗" or "[1]").
+    /// </summary>
+    /// <remarks>
+    /// This is useful for UI rendering or when the original content contained inline citation markers
+    /// that need to be preserved or reconstructed.
+    /// </remarks>
+    public string? Placeholder { get; set; }
+
+    /// <summary>Gets or sets the raw representation of the annotation from an underlying implementation.</summary>
+    /// <remarks>
+    /// If an <see cref="AIAnnotation"/> is created to represent some underlying object from another object
+    /// model, this property can be used to store that original object. This can be useful for debugging or
+    /// for enabling a consumer to access the underlying object model, if needed.
+    /// </remarks>
+    [JsonIgnore]
+    public object? RawRepresentation { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional metadata specific to the provider or source type.
+    /// </summary>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/CitationAnnotation.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/CitationAnnotation.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>
+/// Represents an annotation that links content to source references,
+/// such as documents, URLs, files, or tool outputs.
+/// </summary>
+public class CitationAnnotation : AIAnnotation
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CitationAnnotation"/> class.
+    /// </summary>
+    public CitationAnnotation()
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the location within the source that contains the cited content.
+    /// </summary>
+    public CitationSourceLocation? Location { get; set; }
+
+    /// <summary>
+    /// Gets or sets the title or name of the source.
+    /// </summary>
+    /// <remarks>
+    /// This could be the title of a document, a title from a web page, a name of a file, or similarly descriptive text.
+    /// </remarks>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets a URI from which the source material was retrieved.
+    /// </summary>
+    public Uri? Url { get; set; }
+
+    /// <summary>Gets or sets a source identifier associated with the annotation.</summary>
+    /// <remarks>
+    /// This is a provider-specific identifier that can be used to reference the source material by
+    /// an ID. This may be a document ID, or a file ID, or some other identifier for the source material
+    /// that can be used to uniquely identify it with the provider.
+    /// </remarks>
+    public string? FileId { get; set; }
+
+    /// <summary>Gets or sets the name of any tool involved in the production of the associated content.</summary>
+    /// <remarks>
+    /// This might be a function name, such as one from <see cref="AITool.Name"/>, or the name of a built-in tool
+    /// from the provider, such as "code_interpreter" or "file_search".
+    /// </remarks>
+    public string? ToolName { get; set; }
+
+    /// <summary>Gets or sets an associated ID of a tool call that produced the cited content.</summary>
+    public string? ToolCallId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a snippet or excerpt from the source that was cited.
+    /// </summary>
+    public string? Snippet { get; set; }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/CitationSourceLocation.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/CitationSourceLocation.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Represents a location within source material used for an annotation.</summary>
+public class CitationSourceLocation
+{
+    /// <summary>Gets or sets the page at which the cited material begins.</summary>
+    public int? PageStart { get; set; }
+
+    /// <summary>Gets or sets the page at which the cited material ends.</summary>
+    public int? PageEnd { get; set; }
+
+    /// <summary>Gets or sets the block or chunk at which the cited material begins.</summary>
+    public int? BlockStart { get; set; }
+
+    /// <summary>Gets or sets the block or chunk at which the cited material ends.</summary>
+    public int? BlockEnd { get; set; }
+
+    /// <summary>Gets or sets the character at which the cited material begins.</summary>
+    public int? CharacterStart { get; set; }
+
+    /// <summary>Gets or sets the character at which the cited material ends.</summary>
+    public int? CharacterEnd { get; set; }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/TextContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/TextContent.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
@@ -35,6 +36,11 @@ public sealed class TextContent : AIContent
 
     /// <inheritdoc/>
     public override string ToString() => Text;
+
+    /// <summary>
+    /// Gets or sets a list of annotations on this text content.
+    /// </summary>
+    public IList<AIAnnotation>? Annotations { get; set; }
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string DebuggerDisplay => $"Text = \"{Text}\"";

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -124,6 +124,38 @@
       ]
     },
     {
+      "Type": "class Microsoft.Extensions.AI.AIAnnotation",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.AIAnnotation.AIAnnotation();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.AI.AIAnnotation.AdditionalProperties { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "object? Microsoft.Extensions.AI.AIAnnotation.RawRepresentation { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.AIAnnotation.Placeholder { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.AI.AIAnnotation.StartIndex { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.AI.AIAnnotation.EndIndex { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
       "Type": "class Microsoft.Extensions.AI.AIContent",
       "Stage": "Stable",
       "Methods": [
@@ -1320,6 +1352,82 @@
       ]
     },
     {
+      "Type": "class Microsoft.Extensions.AI.CitationAnnotation : Microsoft.Extensions.AI.AIAnnotation",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.CitationAnnotation.CitationAnnotation();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? Microsoft.Extensions.AI.CitationAnnotation.Title { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.CitationAnnotation.ToolName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.CitationAnnotation.ToolCallId { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Uri? Microsoft.Extensions.AI.CitationAnnotation.Url { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.CitationAnnotation.FileId { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.CitationSourceLocation? Microsoft.Extensions.AI.CitationAnnotation.Location { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.CitationAnnotation.Snippet { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.AI.CitationSourceLocation",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.CitationSourceLocation.CitationSourceLocation();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int? Microsoft.Extensions.AI.CitationSourceLocation.PageStart { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.AI.CitationSourceLocation.PageEnd { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.AI.CitationSourceLocation.BlockStart { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.AI.CitationSourceLocation.BlockEnd { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.AI.CitationSourceLocation.CharacterStart { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.AI.CitationSourceLocation.CharacterEnd { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
       "Type": "class Microsoft.Extensions.AI.DataContent : Microsoft.Extensions.AI.AIContent",
       "Stage": "Stable",
       "Methods": [
@@ -2239,6 +2347,10 @@
         }
       ],
       "Properties": [
+        {
+          "Member": "System.Collections.Generic.IList<Microsoft.Extensions.AI.AIAnnotation>? Microsoft.Extensions.AI.TextContent.Annotations { get; set; }",
+          "Stage": "Stable"
+        },
         {
           "Member": "string Microsoft.Extensions.AI.TextContent.Text { get; set; }",
           "Stage": "Stable"

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantChatClient.cs
@@ -203,7 +203,7 @@ internal sealed class OpenAIAssistantChatClient : IChatClient
                     break;
 
                 case MessageContentUpdate mcu:
-                    yield return new(mcu.Role == MessageRole.User ? ChatRole.User : ChatRole.Assistant, mcu.Text)
+                    ChatResponseUpdate textUpdate = new(mcu.Role == MessageRole.User ? ChatRole.User : ChatRole.Assistant, mcu.Text)
                     {
                         AuthorName = _assistantId,
                         ConversationId = threadId,
@@ -211,10 +211,45 @@ internal sealed class OpenAIAssistantChatClient : IChatClient
                         RawRepresentation = mcu,
                         ResponseId = responseId,
                     };
+
+                    // Add any annotations from the text update. The OpenAI Assistants API does not support passing these back
+                    // into the model (MessageContent.FromXx does not support providing annotations), so they end up being one way and are dropped
+                    // on subsequent requests.
+                    if (mcu.TextAnnotation is { } tau)
+                    {
+                        string? fileId = null;
+                        string? toolName = null;
+                        if (!string.IsNullOrWhiteSpace(tau.InputFileId))
+                        {
+                            fileId = tau.InputFileId;
+                            toolName = "file_search";
+                        }
+                        else if (!string.IsNullOrWhiteSpace(tau.OutputFileId))
+                        {
+                            fileId = tau.OutputFileId;
+                            toolName = "code_interpreter";
+                        }
+
+                        if (fileId is not null)
+                        {
+                            (((TextContent)textUpdate.Contents[0]).Annotations ??= []).Add(new CitationAnnotation
+                            {
+                                RawRepresentation = tau,
+                                StartIndex = tau.StartIndex,
+                                EndIndex = tau.EndIndex,
+                                Placeholder = tau.TextToReplace,
+
+                                FileId = fileId,
+                                ToolName = toolName,
+                            });
+                        }
+                    }
+
+                    yield return textUpdate;
                     break;
 
                 default:
-                    yield return new ChatResponseUpdate
+                    yield return new()
                     {
                         AuthorName = _assistantId,
                         ConversationId = threadId,

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -479,6 +480,32 @@ internal sealed class OpenAIChatClient : IChatClient
         if (openAICompletion.Refusal is string refusal)
         {
             returnMessage.Contents.Add(new ErrorContent(refusal) { ErrorCode = nameof(openAICompletion.Refusal) });
+        }
+
+        // And add annotations. OpenAI chat completion specifies annotations at the message level (and as such they can't be
+        // roundtripped back); we store them either on the first text content, assuming there is one, or on a dedicated content
+        // instance if not.
+        if (openAICompletion.Annotations is { Count: > 0 })
+        {
+            TextContent? annotationContent = returnMessage.Contents.OfType<TextContent>().FirstOrDefault();
+            if (annotationContent is null)
+            {
+                annotationContent = new(null);
+                returnMessage.Contents.Add(annotationContent);
+            }
+
+            foreach (var annotation in openAICompletion.Annotations)
+            {
+                (annotationContent.Annotations ??= []).Add(new CitationAnnotation
+                {
+                    RawRepresentation = annotation,
+                    StartIndex = annotation.StartIndex,
+                    EndIndex = annotation.EndIndex,
+
+                    Title = annotation.WebResourceTitle,
+                    Url = annotation.WebResourceUri,
+                });
+            }
         }
 
         // Wrap the content in a ChatResponse to return.

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponseChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponseChatClient.cs
@@ -592,10 +592,29 @@ internal sealed class OpenAIResponseChatClient : IChatClient
             switch (part.Kind)
             {
                 case ResponseContentPartKind.OutputText:
-                    results.Add(new TextContent(part.Text)
+                    TextContent text = new(part.Text)
                     {
                         RawRepresentation = part,
-                    });
+                    };
+
+                    if (part.OutputTextAnnotations is { Count: > 0 })
+                    {
+                        foreach (var ota in part.OutputTextAnnotations)
+                        {
+                            (text.Annotations ??= []).Add(new CitationAnnotation
+                            {
+                                RawRepresentation = ota,
+                                StartIndex = ota.UriCitationStartIndex,
+                                EndIndex = ota.UriCitationEndIndex,
+
+                                Title = ota.UriCitationTitle,
+                                Url = ota.UriCitationUri,
+                                FileId = ota.FileCitationFileId ?? ota.FilePathFileId,
+                            });
+                        }
+                    }
+
+                    results.Add(text);
                     break;
 
                 case ResponseContentPartKind.Refusal:

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
@@ -183,6 +183,48 @@ public class ChatResponseUpdateExtensionsTests
         Assert.Equal("OP", Assert.IsType<TextReasoningContent>(message.Contents[7]).Text);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ToChatResponse_DoesNotCoalesceAnnotatedContent(bool useAsync)
+    {
+        ChatResponseUpdate[] updates =
+        {
+            new(null, "A"),
+            new(null, "B"),
+            new(null, "C"),
+            new() { Contents = [new TextContent("D") { Annotations = [new()] }] },
+            new() { Contents = [new TextContent("E") { Annotations = [new()] }] },
+            new() { Contents = [new TextContent("F") { Annotations = [new()] }] },
+            new() { Contents = [new TextContent("G") { Annotations = [] }] },
+            new() { Contents = [new TextContent("H") { Annotations = [] }] },
+            new() { Contents = [new TextContent("I") { Annotations = [new()] }] },
+            new() { Contents = [new TextContent("J") { Annotations = [new()] }] },
+            new(null, "K"),
+            new() { Contents = [new TextContent("L") { Annotations = [new()] }] },
+            new(null, "M"),
+            new(null, "N"),
+            new() { Contents = [new TextContent("O") { Annotations = [new()] }] },
+            new() { Contents = [new TextContent("P") { Annotations = [new()] }] },
+        };
+
+        ChatResponse response = useAsync ? await YieldAsync(updates).ToChatResponseAsync() : updates.ToChatResponse();
+        ChatMessage message = Assert.Single(response.Messages);
+        Assert.Equal(12, message.Contents.Count);
+        Assert.Equal("ABC", Assert.IsType<TextContent>(message.Contents[0]).Text);
+        Assert.Equal("D", Assert.IsType<TextContent>(message.Contents[1]).Text);
+        Assert.Equal("E", Assert.IsType<TextContent>(message.Contents[2]).Text);
+        Assert.Equal("F", Assert.IsType<TextContent>(message.Contents[3]).Text);
+        Assert.Equal("GH", Assert.IsType<TextContent>(message.Contents[4]).Text);
+        Assert.Equal("I", Assert.IsType<TextContent>(message.Contents[5]).Text);
+        Assert.Equal("J", Assert.IsType<TextContent>(message.Contents[6]).Text);
+        Assert.Equal("K", Assert.IsType<TextContent>(message.Contents[7]).Text);
+        Assert.Equal("L", Assert.IsType<TextContent>(message.Contents[8]).Text);
+        Assert.Equal("MN", Assert.IsType<TextContent>(message.Contents[9]).Text);
+        Assert.Equal("O", Assert.IsType<TextContent>(message.Contents[10]).Text);
+        Assert.Equal("P", Assert.IsType<TextContent>(message.Contents[11]).Text);
+    }
+
     [Fact]
     public async Task ToChatResponse_UsageContentExtractedFromContents()
     {

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/AIAnnotationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/AIAnnotationTests.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text.Json;
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class AIAnnotationTests
+{
+    [Fact]
+    public void Constructor_PropsDefault()
+    {
+        AIAnnotation a = new();
+        Assert.Null(a.AdditionalProperties);
+        Assert.Null(a.EndIndex);
+        Assert.Null(a.Placeholder);
+        Assert.Null(a.RawRepresentation);
+        Assert.Null(a.StartIndex);
+    }
+
+    [Fact]
+    public void Constructor_PropsRoundtrip()
+    {
+        AIAnnotation a = new();
+
+        Assert.Null(a.AdditionalProperties);
+        AdditionalPropertiesDictionary props = new() { { "key", "value" } };
+        a.AdditionalProperties = props;
+        Assert.Same(props, a.AdditionalProperties);
+
+        Assert.Null(a.EndIndex);
+        a.EndIndex = 42;
+        Assert.Equal(42, a.EndIndex);
+
+        Assert.Null(a.Placeholder);
+        a.Placeholder = "placeholder";
+        Assert.Equal("placeholder", a.Placeholder);
+
+        Assert.Null(a.RawRepresentation);
+        object raw = new();
+        a.RawRepresentation = raw;
+        Assert.Same(raw, a.RawRepresentation);
+
+        Assert.Null(a.StartIndex);
+        a.StartIndex = 10;
+        Assert.Equal(10, a.StartIndex);
+    }
+
+    [Fact]
+    public void Serialization_Roundtrips()
+    {
+        AIAnnotation original = new()
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary { { "key", "value" } },
+            EndIndex = 42,
+            Placeholder = "placeholder",
+            RawRepresentation = new object(),
+            StartIndex = 10,
+        };
+
+        string json = JsonSerializer.Serialize(original, AIJsonUtilities.DefaultOptions.GetTypeInfo(typeof(AIAnnotation)));
+        Assert.NotNull(json);
+
+        AIAnnotation? deserialized = (AIAnnotation?)JsonSerializer.Deserialize(json, AIJsonUtilities.DefaultOptions.GetTypeInfo(typeof(AIAnnotation)));
+        Assert.NotNull(deserialized);
+
+        Assert.NotNull(deserialized.AdditionalProperties);
+        Assert.Single(deserialized.AdditionalProperties);
+        Assert.Equal(JsonSerializer.Deserialize<JsonElement>("\"value\"", AIJsonUtilities.DefaultOptions).ToString(), deserialized.AdditionalProperties["key"]!.ToString());
+
+        Assert.Equal(42, deserialized.EndIndex);
+        Assert.Equal("placeholder", deserialized.Placeholder);
+        Assert.Null(deserialized.RawRepresentation);
+        Assert.Equal(10, deserialized.StartIndex);
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/CitationAnnotationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/CitationAnnotationTests.cs
@@ -1,0 +1,132 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text.Json;
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class CitationAnnotationTests
+{
+    [Fact]
+    public void Constructor_PropsDefault()
+    {
+        CitationAnnotation a = new();
+        Assert.Null(a.AdditionalProperties);
+        Assert.Null(a.EndIndex);
+        Assert.Null(a.Location);
+        Assert.Null(a.Placeholder);
+        Assert.Null(a.RawRepresentation);
+        Assert.Null(a.Snippet);
+        Assert.Null(a.StartIndex);
+        Assert.Null(a.Title);
+        Assert.Null(a.ToolName);
+        Assert.Null(a.Url);
+    }
+
+    [Fact]
+    public void Constructor_PropsRoundtrip()
+    {
+        CitationAnnotation a = new();
+
+        Assert.Null(a.AdditionalProperties);
+        AdditionalPropertiesDictionary props = new() { { "key", "value" } };
+        a.AdditionalProperties = props;
+        Assert.Same(props, a.AdditionalProperties);
+
+        Assert.Null(a.EndIndex);
+        a.EndIndex = 42;
+        Assert.Equal(42, a.EndIndex);
+
+        Assert.Null(a.Location);
+        CitationSourceLocation loc = new();
+        a.Location = loc;
+        Assert.Same(loc, a.Location);
+
+        Assert.Null(a.Placeholder);
+        a.Placeholder = "placeholder";
+        Assert.Equal("placeholder", a.Placeholder);
+
+        Assert.Null(a.RawRepresentation);
+        object raw = new();
+        a.RawRepresentation = raw;
+        Assert.Same(raw, a.RawRepresentation);
+
+        Assert.Null(a.Snippet);
+        a.Snippet = "snippet";
+        Assert.Equal("snippet", a.Snippet);
+
+        Assert.Null(a.StartIndex);
+        a.StartIndex = 10;
+        Assert.Equal(10, a.StartIndex);
+
+        Assert.Null(a.Title);
+        a.Title = "title";
+        Assert.Equal("title", a.Title);
+
+        Assert.Null(a.ToolName);
+        a.ToolName = "toolName";
+        Assert.Equal("toolName", a.ToolName);
+
+        Assert.Null(a.Url);
+        Uri url = new("https://example.com");
+        a.Url = url;
+        Assert.Same(url, a.Url);
+    }
+
+    [Fact]
+    public void Serialization_Roundtrips()
+    {
+        CitationAnnotation original = new()
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary { { "key", "value" } },
+            EndIndex = 42,
+            Location = new()
+            {
+                PageStart = 1,
+                PageEnd = 2,
+                BlockStart = 3,
+                BlockEnd = 4,
+                CharacterStart = 5,
+                CharacterEnd = 6
+            },
+            Placeholder = "placeholder",
+            RawRepresentation = new object(),
+            Snippet = "snippet",
+            StartIndex = 10,
+            Title = "title",
+            ToolName = "toolName",
+            Url = new("https://example.com"),
+        };
+
+        string json = JsonSerializer.Serialize(original, AIJsonUtilities.DefaultOptions.GetTypeInfo(typeof(CitationAnnotation)));
+        Assert.NotNull(json);
+
+        CitationAnnotation? deserialized = (CitationAnnotation?)JsonSerializer.Deserialize(json, AIJsonUtilities.DefaultOptions.GetTypeInfo(typeof(CitationAnnotation)));
+        Assert.NotNull(deserialized);
+
+        Assert.NotNull(deserialized.AdditionalProperties);
+        Assert.Single(deserialized.AdditionalProperties);
+        Assert.Equal(JsonSerializer.Deserialize<JsonElement>("\"value\"", AIJsonUtilities.DefaultOptions).ToString(), deserialized.AdditionalProperties["key"]!.ToString());
+
+        Assert.Equal(42, deserialized.EndIndex);
+        Assert.NotNull(deserialized.Location);
+        Assert.Equal(1, deserialized.Location.PageStart);
+        Assert.Equal(2, deserialized.Location.PageEnd);
+        Assert.Equal(3, deserialized.Location.BlockStart);
+        Assert.Equal(4, deserialized.Location.BlockEnd);
+        Assert.Equal(5, deserialized.Location.CharacterStart);
+        Assert.Equal(6, deserialized.Location.CharacterEnd);
+        Assert.Equal("placeholder", deserialized.Placeholder);
+        Assert.Null(deserialized.RawRepresentation);
+        Assert.Equal("snippet", deserialized.Snippet);
+        Assert.Equal(10, deserialized.StartIndex);
+        Assert.Equal("title", deserialized.Title);
+        Assert.Equal("toolName", deserialized.ToolName);
+
+        Assert.NotNull(deserialized.Url);
+        Assert.Equal(original.Url, deserialized.Url);
+
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
@@ -943,13 +943,14 @@ public static partial class AIJsonUtilitiesTests
         JsonSerializerOptions options = new()
         {
             TypeInfoResolver = JsonTypeInfoResolver.Combine(AIJsonUtilities.DefaultOptions.TypeInfoResolver, JsonContext.Default),
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         };
 
         options.AddAIContentType<DerivedAIContent>("derivativeContent");
 
         AIContent c = new DerivedAIContent { DerivedValue = 42 };
         string json = JsonSerializer.Serialize(c, options);
-        Assert.Equal("""{"$type":"derivativeContent","DerivedValue":42,"AdditionalProperties":null}""", json);
+        Assert.Equal("""{"$type":"derivativeContent","DerivedValue":42}""", json);
 
         AIContent? deserialized = JsonSerializer.Deserialize<AIContent>(json, options);
         Assert.IsType<DerivedAIContent>(deserialized);

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
@@ -34,16 +34,16 @@ namespace Microsoft.Extensions.AI;
 
 public abstract class ChatClientIntegrationTests : IDisposable
 {
-    private readonly IChatClient? _chatClient;
-
     protected ChatClientIntegrationTests()
     {
-        _chatClient = CreateChatClient();
+        ChatClient = CreateChatClient();
     }
+
+    protected IChatClient? ChatClient { get; }
 
     public void Dispose()
     {
-        _chatClient?.Dispose();
+        ChatClient?.Dispose();
         GC.SuppressFinalize(this);
     }
 
@@ -54,7 +54,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync("What's the biggest animal?");
+        var response = await ChatClient.GetResponseAsync("What's the biggest animal?");
 
         Assert.Contains("whale", response.Text, StringComparison.OrdinalIgnoreCase);
     }
@@ -64,7 +64,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync(
+        var response = await ChatClient.GetResponseAsync(
         [
             new(ChatRole.User, "Pick a city, any city"),
             new(ChatRole.Assistant, "Seattle"),
@@ -82,7 +82,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync(
+        var response = await ChatClient.GetResponseAsync(
         [
             new(ChatRole.System, []),
             new(ChatRole.User, []),
@@ -104,7 +104,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
         ];
 
         StringBuilder sb = new();
-        await foreach (var chunk in _chatClient.GetStreamingResponseAsync(chatHistory))
+        await foreach (var chunk in ChatClient.GetStreamingResponseAsync(chatHistory))
         {
             sb.Append(chunk.Text);
         }
@@ -119,7 +119,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync("Explain in 10 words how AI works");
+        var response = await ChatClient.GetResponseAsync("Explain in 10 words how AI works");
 
         Assert.True(response.Usage?.InputTokenCount > 1);
         Assert.True(response.Usage?.OutputTokenCount > 1);
@@ -131,7 +131,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = _chatClient.GetStreamingResponseAsync("Explain in 10 words how AI works", new()
+        var response = ChatClient.GetStreamingResponseAsync("Explain in 10 words how AI works", new()
         {
             AdditionalProperties = new()
             {
@@ -160,7 +160,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
 
         List<ChatMessage> history = [new(ChatRole.User, "Explain in 100 words how AI works")];
 
-        var streamingResponse = _chatClient.GetStreamingResponseAsync(history);
+        var streamingResponse = ChatClient.GetStreamingResponseAsync(history);
 
         Assert.Single(history);
         await history.AddMessagesAsync(streamingResponse);
@@ -179,7 +179,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync(
+        var response = await ChatClient.GetResponseAsync(
             [
                 new(ChatRole.User,
                 [
@@ -197,7 +197,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync(
+        var response = await ChatClient.GetResponseAsync(
             [
                 new(ChatRole.User,
                 [
@@ -223,7 +223,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
             .Build();
 
         using var chatClient = new FunctionInvokingChatClient(
-            new OpenTelemetryChatClient(_chatClient, sourceName: sourceName));
+            new OpenTelemetryChatClient(ChatClient, sourceName: sourceName));
 
         int secretNumber = 42;
 
@@ -246,7 +246,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        using var chatClient = new FunctionInvokingChatClient(_chatClient);
+        using var chatClient = new FunctionInvokingChatClient(ChatClient);
 
         var response = await chatClient.GetResponseAsync("What is the result of SecretComputation on 42 and 84?", new()
         {
@@ -261,7 +261,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        using var chatClient = new FunctionInvokingChatClient(_chatClient);
+        using var chatClient = new FunctionInvokingChatClient(ChatClient);
 
         var response = chatClient.GetStreamingResponseAsync("What is the result of SecretComputation on 42 and 84?", new()
         {
@@ -290,7 +290,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
             .Build();
 
         using var chatClient = new FunctionInvokingChatClient(
-            new OpenTelemetryChatClient(_chatClient, sourceName: sourceName));
+            new OpenTelemetryChatClient(ChatClient, sourceName: sourceName));
 
         int secretNumber = 42;
 
@@ -322,7 +322,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
             .Build();
 
         using var chatClient = new FunctionInvokingChatClient(
-            new OpenTelemetryChatClient(_chatClient, sourceName: sourceName));
+            new OpenTelemetryChatClient(ChatClient, sourceName: sourceName));
 
         int secretNumber = 42;
 
@@ -354,7 +354,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
             .Build();
 
         using var chatClient = new FunctionInvokingChatClient(
-            new OpenTelemetryChatClient(_chatClient, sourceName: sourceName));
+            new OpenTelemetryChatClient(ChatClient, sourceName: sourceName));
 
         List<ChatMessage> messages =
         [
@@ -411,7 +411,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
             .Build();
 
         using var chatClient = new FunctionInvokingChatClient(
-            new OpenTelemetryChatClient(_chatClient, sourceName: sourceName));
+            new OpenTelemetryChatClient(ChatClient, sourceName: sourceName));
 
         int methodCount = 1;
         Func<AIFunctionFactoryOptions> createOptions = () =>
@@ -567,7 +567,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
             throw new SkipTestException("Parallel function calling is not supported by this chat client");
         }
 
-        using var chatClient = new FunctionInvokingChatClient(_chatClient);
+        using var chatClient = new FunctionInvokingChatClient(ChatClient);
 
         // The service/model isn't guaranteed to request two calls to GetPersonAge in the same turn, but it's common that it will.
         var response = await chatClient.GetResponseAsync("How much older is Elsa than Anna? Return the age difference as a single number.", new()
@@ -600,7 +600,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
             return 123;
         }, "GetSecretNumber");
 
-        using var chatClient = new FunctionInvokingChatClient(_chatClient);
+        using var chatClient = new FunctionInvokingChatClient(ChatClient);
 
         var response = await chatClient.GetResponseAsync("Are birds real?", new()
         {
@@ -620,7 +620,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
         var getSecretNumberTool = AIFunctionFactory.Create(() => 123, "GetSecretNumber");
         var shieldsUpTool = AIFunctionFactory.Create(() => shieldsUp = true, "ShieldsUp");
 
-        using var chatClient = new FunctionInvokingChatClient(_chatClient);
+        using var chatClient = new FunctionInvokingChatClient(ChatClient);
 
         // Even though the user doesn't ask for the shields to be activated, verify that the tool is invoked
         var response = await chatClient.GetResponseAsync("What's the current secret number?", new()
@@ -638,9 +638,9 @@ public abstract class ChatClientIntegrationTests : IDisposable
         SkipIfNotEnabled();
 
         var message = new ChatMessage(ChatRole.User, "Pick a random number, uniformly distributed between 1 and 1000000");
-        var firstResponse = await _chatClient.GetResponseAsync([message]);
+        var firstResponse = await ChatClient.GetResponseAsync([message]);
 
-        var secondResponse = await _chatClient.GetResponseAsync([message]);
+        var secondResponse = await ChatClient.GetResponseAsync([message]);
         Assert.NotEqual(firstResponse.Text, secondResponse.Text);
     }
 
@@ -650,7 +650,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
         SkipIfNotEnabled();
 
         using var chatClient = new DistributedCachingChatClient(
-            _chatClient,
+            ChatClient,
             new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())));
 
         var message = new ChatMessage(ChatRole.User, "Pick a random number, uniformly distributed between 1 and 1000000");
@@ -675,7 +675,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
         SkipIfNotEnabled();
 
         using var chatClient = new DistributedCachingChatClient(
-            _chatClient,
+            ChatClient,
             new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())));
 
         var message = new ChatMessage(ChatRole.User, "Pick a random number, uniformly distributed between 1 and 1000000");
@@ -957,7 +957,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync<Person>("""
+        var response = await ChatClient.GetResponseAsync<Person>("""
             Who is described in the following sentence?
             Jimbo Smith is a 35-year-old programmer from Cardiff, Wales.
             """);
@@ -973,7 +973,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync<Person[]>("""
+        var response = await ChatClient.GetResponseAsync<Person[]>("""
             Who are described in the following sentence?
             Jimbo Smith is a 35-year-old software developer from Cardiff, Wales.
             Josh Simpson is a 25-year-old software developer from Newport, Wales.
@@ -989,7 +989,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync<int>("""
+        var response = await ChatClient.GetResponseAsync<int>("""
             There were 14 abstractions for AI programming, which was too many.
             To fix this we added another one. How many are there now?
             """);
@@ -1002,7 +1002,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync<string>("""
+        var response = await ChatClient.GetResponseAsync<string>("""
             The software developer, Jimbo Smith, is a 35-year-old from Cardiff, Wales.
             What's his full name?
             """);
@@ -1015,7 +1015,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync<bool>("""
+        var response = await ChatClient.GetResponseAsync<bool>("""
             Jimbo Smith is a 35-year-old software developer from Cardiff, Wales.
             Is there at least one software developer from Cardiff?
             """);
@@ -1028,7 +1028,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync<bool>("""
+        var response = await ChatClient.GetResponseAsync<bool>("""
             Jimbo Smith is a 35-year-old software developer from Cardiff, Wales.
             Reply true if the previous statement indicates that he is a medical doctor, otherwise false.
             """);
@@ -1041,7 +1041,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.GetResponseAsync<JobType>("""
+        var response = await ChatClient.GetResponseAsync<JobType>("""
             Taylor Swift is a famous singer and songwriter. What is her job?
             """);
 
@@ -1061,7 +1061,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
             Job = JobType.Programmer,
         };
 
-        using var chatClient = new FunctionInvokingChatClient(_chatClient);
+        using var chatClient = new FunctionInvokingChatClient(ChatClient);
         var response = await chatClient.GetResponseAsync<Person>(
             "Who is person with ID 123?", new ChatOptions
             {
@@ -1085,7 +1085,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
         SkipIfNotEnabled();
 
         var capturedOptions = new List<ChatOptions?>();
-        var captureOutputChatClient = _chatClient.AsBuilder()
+        var captureOutputChatClient = ChatClient.AsBuilder()
             .Use((messages, options, nextAsync, cancellationToken) =>
             {
                 capturedOptions.Add(options);
@@ -1125,12 +1125,12 @@ public abstract class ChatClientIntegrationTests : IDisposable
         Unknown,
     }
 
-    [MemberNotNull(nameof(_chatClient))]
+    [MemberNotNull(nameof(ChatClient))]
     protected void SkipIfNotEnabled()
     {
         string? skipIntegration = TestRunnerConfiguration.Instance["SkipIntegrationTests"];
 
-        if (skipIntegration is not null || _chatClient is null)
+        if (skipIntegration is not null || ChatClient is null)
         {
             throw new SkipTestException("Client is not enabled.");
         }

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.TestUtilities;
+using Xunit;
 
 namespace Microsoft.Extensions.AI;
 
@@ -16,4 +19,27 @@ public class OpenAIResponseClientIntegrationTests : ChatClientIntegrationTests
 
     // Test structure doesn't make sense with Respones.
     public override Task Caching_AfterFunctionInvocation_FunctionOutputUnchangedAsync() => Task.CompletedTask;
+
+    [ConditionalFact]
+    public async Task UseWebSearch_AnnotationsReflectResults()
+    {
+        SkipIfNotEnabled();
+
+        var response = await ChatClient.GetResponseAsync(
+            "Write a paragraph about the three most recent blog posts on the .NET blog. Cite your sources.",
+            new() { Tools = [new HostedWebSearchTool()] });
+
+        ChatMessage m = Assert.Single(response.Messages);
+        TextContent tc = m.Contents.OfType<TextContent>().First();
+        Assert.NotNull(tc.Annotations);
+        Assert.NotEmpty(tc.Annotations);
+        Assert.All(tc.Annotations, a =>
+        {
+            CitationAnnotation ca = Assert.IsType<CitationAnnotation>(a);
+            Assert.NotNull(ca.StartIndex);
+            Assert.NotNull(ca.EndIndex);
+            Assert.NotNull(ca.Url);
+            Assert.NotNull(ca.Title);
+        });
+    }
 }


### PR DESCRIPTION
Adds support to M.E.AI.Abstractions for annotations.

Some design notes:
- Right now, I have the Annotations property on TextContent. We can push it down to the base later without it being a breaking change.
- Most services only support citations. OpenAI has a broader notion of annotations, and it looks like Anthropic will be adding other kinds of annotations as well. I modeled this by having a base AIAnnotation and a derived CitationAnnotation.
- Different services are very varied on what they support with citations. I went back and forth on whether to have CitationAnnotation just be a flat set of properties, or to try to model it as further derived types, e.g. UrlCitationAnnotation. I've gone with the former, but could be swayed to the latter if y'all think that's more wise. Note that there's a variety of things OpenAI doesn't support or expose that others do, e.g. Google, Anthropic, and AWS all support including snippets of the cited content; I've included such things here, as well.