### PR TITLE
M.E.AI.AzureAIInference - Azure.AI.Inference Package Bump

### DIFF
--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -4,7 +4,7 @@
     <PackageVersion Include="Azure.Core" Version="1.45.0" />
     <PackageVersion Include="Azure.Identity" Version="1.13.2" />
     <PackageVersion Include="Azure.Storage.Files.DataLake" Version="12.21.0" />
-    <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.4" />
+    <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.5" />
     <PackageVersion Include="ICSharpCode.Decompiler" Version="9.1.0.7988" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />


### PR DESCRIPTION
This pull request updates the version of the `Azure.AI.Inference` package in the `eng/packages/General.props` file.

* Updated the `Azure.AI.Inference` package version from `1.0.0-beta.4` to `1.0.0-beta.5` to ensure compatibility with the latest features and fixes. (`[eng/packages/General.propsL7-R7](diffhunk://#diff-cf8319c1a9c1d16c6b3fc2655ef79b529be9f7b1c38f84b9d4926a9df05bc8b6L7-R7)`)