### PR TITLE
Expose streaming conversion utility methods

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Extensions.AI;
 using Microsoft.Shared.Diagnostics;
 
@@ -20,10 +21,11 @@ public static class MicrosoftExtensionsAIResponsesExtensions
 
     /// <summary>Creates a sequence of OpenAI <see cref="ResponseItem"/> instances from the specified input messages.</summary>
     /// <param name="messages">The input messages to convert.</param>
+    /// <param name="options">The options employed while processing <paramref name="messages"/>.</param>
     /// <returns>A sequence of OpenAI response items.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="messages"/> is <see langword="null"/>.</exception>
-    public static IEnumerable<ResponseItem> AsOpenAIResponseItems(this IEnumerable<ChatMessage> messages) =>
-        OpenAIResponsesChatClient.ToOpenAIResponseItems(Throw.IfNull(messages));
+    public static IEnumerable<ResponseItem> AsOpenAIResponseItems(this IEnumerable<ChatMessage> messages, ChatOptions? options = null) =>
+        OpenAIResponsesChatClient.ToOpenAIResponseItems(Throw.IfNull(messages), options);
 
     /// <summary>Creates a sequence of <see cref="ChatMessage"/> instances from the specified input items.</summary>
     /// <param name="items">The input messages to convert.</param>
@@ -39,6 +41,19 @@ public static class MicrosoftExtensionsAIResponsesExtensions
     /// <exception cref="ArgumentNullException"><paramref name="response"/> is <see langword="null"/>.</exception>
     public static ChatResponse AsChatResponse(this OpenAIResponse response, ResponseCreationOptions? options = null) =>
         OpenAIResponsesChatClient.FromOpenAIResponse(Throw.IfNull(response), options);
+
+    /// <summary>
+    /// Creates a sequence of Microsoft.Extensions.AI <see cref="ChatResponseUpdate"/> instances from the specified
+    /// sequence of OpenAI <see cref="StreamingResponseUpdate"/> instances.
+    /// </summary>
+    /// <param name="responseUpdates">The update instances.</param>
+    /// <param name="options">The options employed in the creation of the response.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>A sequence of converted <see cref="ChatResponseUpdate"/> instances.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="responseUpdates"/> is <see langword="null"/>.</exception>
+    public static IAsyncEnumerable<ChatResponseUpdate> AsChatResponseUpdatesAsync(
+        this IAsyncEnumerable<StreamingResponseUpdate> responseUpdates, ResponseCreationOptions? options = null, CancellationToken cancellationToken = default) =>
+        OpenAIResponsesChatClient.FromOpenAIStreamingResponseUpdatesAsync(Throw.IfNull(responseUpdates), options, cancellationToken);
 
     /// <summary>Creates an OpenAI <see cref="OpenAIResponse"/> from a <see cref="ChatResponse"/>.</summary>
     /// <param name="response">The response to convert.</param>

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -303,7 +303,7 @@ internal sealed class OpenAIChatClient : IChatClient
         return null;
     }
 
-    private static async IAsyncEnumerable<ChatResponseUpdate> FromOpenAIStreamingChatCompletionAsync(
+    internal static async IAsyncEnumerable<ChatResponseUpdate> FromOpenAIStreamingChatCompletionAsync(
         IAsyncEnumerable<StreamingChatCompletionUpdate> updates,
         ChatCompletionOptions? options,
         [EnumeratorCancellation] CancellationToken cancellationToken)

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using OpenAI.Assistants;
 using OpenAI.Chat;
 using OpenAI.Realtime;
@@ -77,8 +78,10 @@ public class OpenAIConversionTests
         Assert.Equal("The name parameter", nameProperty.GetProperty("description").GetString());
     }
 
-    [Fact]
-    public void AsOpenAIChatMessages_ProducesExpectedOutput()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AsOpenAIChatMessages_ProducesExpectedOutput(bool withOptions)
     {
         Assert.Throws<ArgumentNullException>("messages", () => ((IEnumerable<ChatMessage>)null!).AsOpenAIChatMessages());
 
@@ -99,17 +102,31 @@ public class OpenAIConversionTests
             new(ChatRole.Assistant, "The answer is 42."),
         ];
 
-        var convertedMessages = messages.AsOpenAIChatMessages().ToArray();
+        ChatOptions? options = withOptions ? new ChatOptions { Instructions = "You talk like a parrot." } : null;
 
-        Assert.Equal(5, convertedMessages.Length);
+        var convertedMessages = messages.AsOpenAIChatMessages(options).ToArray();
 
-        SystemChatMessage m0 = Assert.IsType<SystemChatMessage>(convertedMessages[0]);
+        int index = 0;
+        if (withOptions)
+        {
+            Assert.Equal(6, convertedMessages.Length);
+
+            index = 1;
+            SystemChatMessage instructionsMessage = Assert.IsType<SystemChatMessage>(convertedMessages[0]);
+            Assert.Equal("You talk like a parrot.", Assert.Single(instructionsMessage.Content).Text);
+        }
+        else
+        {
+            Assert.Equal(5, convertedMessages.Length);
+        }
+
+        SystemChatMessage m0 = Assert.IsType<SystemChatMessage>(convertedMessages[index]);
         Assert.Equal("You are a helpful assistant.", Assert.Single(m0.Content).Text);
 
-        UserChatMessage m1 = Assert.IsType<UserChatMessage>(convertedMessages[1]);
+        UserChatMessage m1 = Assert.IsType<UserChatMessage>(convertedMessages[index + 1]);
         Assert.Equal("Hello", Assert.Single(m1.Content).Text);
 
-        AssistantChatMessage m2 = Assert.IsType<AssistantChatMessage>(convertedMessages[2]);
+        AssistantChatMessage m2 = Assert.IsType<AssistantChatMessage>(convertedMessages[index + 2]);
         Assert.Single(m2.Content);
         Assert.Equal("Hi there!", m2.Content[0].Text);
         var tc = Assert.Single(m2.ToolCalls);
@@ -121,11 +138,11 @@ public class OpenAIConversionTests
             ["param2"] = 42
         }), JsonSerializer.Deserialize<JsonElement>(tc.FunctionArguments.ToMemory().Span)));
 
-        ToolChatMessage m3 = Assert.IsType<ToolChatMessage>(convertedMessages[3]);
+        ToolChatMessage m3 = Assert.IsType<ToolChatMessage>(convertedMessages[index + 3]);
         Assert.Equal("callid123", m3.ToolCallId);
         Assert.Equal("theresult", Assert.Single(m3.Content).Text);
 
-        AssistantChatMessage m4 = Assert.IsType<AssistantChatMessage>(convertedMessages[4]);
+        AssistantChatMessage m4 = Assert.IsType<AssistantChatMessage>(convertedMessages[index + 4]);
         Assert.Equal("The answer is 42.", Assert.Single(m4.Content).Text);
     }
 
@@ -215,6 +232,70 @@ public class OpenAIConversionTests
         Assert.Equal("Hello, world!", Assert.IsType<TextContent>(message.Contents[0]).Text);
         Assert.Equal("http://example.com/image.png", Assert.IsType<UriContent>(message.Contents[1]).Uri.ToString());
         Assert.Equal("functionName", Assert.IsType<FunctionCallContent>(message.Contents[2]).Name);
+    }
+
+    [Fact]
+    public async Task AsChatResponse_ConvertsOpenAIStreamingChatCompletionUpdates()
+    {
+        Assert.Throws<ArgumentNullException>("chatCompletionUpdates", () => ((IAsyncEnumerable<StreamingChatCompletionUpdate>)null!).AsChatResponseUpdatesAsync());
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (var update in CreateUpdates().AsChatResponseUpdatesAsync())
+        {
+            updates.Add(update);
+        }
+
+        ChatResponse response = updates.ToChatResponse();
+
+        Assert.Equal("id", response.ResponseId);
+        Assert.Equal(ChatFinishReason.ToolCalls, response.FinishReason);
+        Assert.Equal("model123", response.ModelId);
+        Assert.Equal(new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero), response.CreatedAt);
+        Assert.NotNull(response.Usage);
+        Assert.Equal(1, response.Usage.InputTokenCount);
+        Assert.Equal(2, response.Usage.OutputTokenCount);
+        Assert.Equal(3, response.Usage.TotalTokenCount);
+
+        ChatMessage message = Assert.Single(response.Messages);
+        Assert.Equal(ChatRole.Assistant, message.Role);
+
+        Assert.Equal(3, message.Contents.Count);
+        Assert.Equal("Hello, world!", Assert.IsType<TextContent>(message.Contents[0]).Text);
+        Assert.Equal("http://example.com/image.png", Assert.IsType<UriContent>(message.Contents[1]).Uri.ToString());
+        Assert.Equal("functionName", Assert.IsType<FunctionCallContent>(message.Contents[2]).Name);
+
+        static async IAsyncEnumerable<StreamingChatCompletionUpdate> CreateUpdates()
+        {
+            await Task.Yield();
+            yield return OpenAIChatModelFactory.StreamingChatCompletionUpdate(
+                "id",
+                new ChatMessageContent(
+                    ChatMessageContentPart.CreateTextPart("Hello, world!"),
+                    ChatMessageContentPart.CreateImagePart(new Uri("http://example.com/image.png"))),
+                null,
+                [OpenAIChatModelFactory.StreamingChatToolCallUpdate(0, "id", ChatToolCallKind.Function, "functionName", BinaryData.FromString("test"))],
+                ChatMessageRole.Assistant,
+                null, null, null, OpenAI.Chat.ChatFinishReason.ToolCalls, new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                "model123", null, OpenAIChatModelFactory.ChatTokenUsage(2, 1, 3));
+        }
+    }
+
+    [Fact]
+    public void AsChatResponse_ConvertsOpenAIResponse()
+    {
+        Assert.Throws<ArgumentNullException>("response", () => ((OpenAIResponse)null!).AsChatResponse());
+
+        // The OpenAI library currently doesn't provide any way to create an OpenAIResponse instance,
+        // as all constructors/factory methods currently are internal. Update this test when such functionality is available.
+    }
+
+    [Fact]
+    public void AsChatResponseUpdatesAsync_ConvertsOpenAIStreamingResponseUpdates()
+    {
+        Assert.Throws<ArgumentNullException>("responseUpdates", () => ((IAsyncEnumerable<StreamingResponseUpdate>)null!).AsChatResponseUpdatesAsync());
+
+        // The OpenAI library currently doesn't provide any way to create a StreamingResponseUpdate instance,
+        // as all constructors/factory methods currently are internal. Update this test when such functionality is available.
     }
 
     [Fact]
@@ -453,6 +534,325 @@ public class OpenAIConversionTests
             var chatResponse = new ChatResponse(new ChatMessage(inputRole, "Test"));
             var completion = chatResponse.AsOpenAIChatCompletion();
             Assert.Equal(expectedOpenAIRole, completion.Role);
+        }
+    }
+
+    [Fact]
+    public async Task AsOpenAIStreamingChatCompletionUpdatesAsync_WithNullArgument_ThrowsArgumentNullException()
+    {
+        var asyncEnumerable = ((IAsyncEnumerable<ChatResponseUpdate>)null!).AsOpenAIStreamingChatCompletionUpdatesAsync();
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await asyncEnumerable.GetAsyncEnumerator().MoveNextAsync());
+    }
+
+    [Fact]
+    public async Task AsOpenAIStreamingChatCompletionUpdatesAsync_WithEmptyCollection_ReturnsEmptySequence()
+    {
+        var updates = new List<ChatResponseUpdate>();
+        var result = new List<StreamingChatCompletionUpdate>();
+
+        await foreach (var update in CreateAsyncEnumerable(updates).AsOpenAIStreamingChatCompletionUpdatesAsync())
+        {
+            result.Add(update);
+        }
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AsOpenAIStreamingChatCompletionUpdatesAsync_WithRawRepresentation_ReturnsOriginal()
+    {
+        var originalUpdate = OpenAIChatModelFactory.StreamingChatCompletionUpdate(
+            "test-id",
+            new ChatMessageContent(ChatMessageContentPart.CreateTextPart("Hello")),
+            role: ChatMessageRole.Assistant,
+            finishReason: OpenAI.Chat.ChatFinishReason.Stop,
+            createdAt: new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            model: "gpt-3.5-turbo");
+
+        var responseUpdate = new ChatResponseUpdate(ChatRole.Assistant, "Hello")
+        {
+            RawRepresentation = originalUpdate
+        };
+
+        var result = new List<StreamingChatCompletionUpdate>();
+        await foreach (var update in CreateAsyncEnumerable(new[] { responseUpdate }).AsOpenAIStreamingChatCompletionUpdatesAsync())
+        {
+            result.Add(update);
+        }
+
+        Assert.Single(result);
+        Assert.Same(originalUpdate, result[0]);
+    }
+
+    [Fact]
+    public async Task AsOpenAIStreamingChatCompletionUpdatesAsync_WithTextContent_CreatesValidUpdate()
+    {
+        var responseUpdate = new ChatResponseUpdate(ChatRole.Assistant, "Hello, world!")
+        {
+            ResponseId = "response-123",
+            MessageId = "message-456",
+            ModelId = "gpt-4",
+            FinishReason = ChatFinishReason.Stop,
+            CreatedAt = new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero)
+        };
+
+        var result = new List<StreamingChatCompletionUpdate>();
+        await foreach (var update in CreateAsyncEnumerable(new[] { responseUpdate }).AsOpenAIStreamingChatCompletionUpdatesAsync())
+        {
+            result.Add(update);
+        }
+
+        Assert.Single(result);
+        var streamingUpdate = result[0];
+
+        Assert.Equal("response-123", streamingUpdate.CompletionId);
+        Assert.Equal("gpt-4", streamingUpdate.Model);
+        Assert.Equal(OpenAI.Chat.ChatFinishReason.Stop, streamingUpdate.FinishReason);
+        Assert.Equal(new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero), streamingUpdate.CreatedAt);
+        Assert.Equal(ChatMessageRole.Assistant, streamingUpdate.Role);
+        Assert.Equal("Hello, world!", Assert.Single(streamingUpdate.ContentUpdate).Text);
+    }
+
+    [Fact]
+    public async Task AsOpenAIStreamingChatCompletionUpdatesAsync_WithUsageContent_CreatesUpdateWithUsage()
+    {
+        var responseUpdate = new ChatResponseUpdate
+        {
+            ResponseId = "response-123",
+            Contents =
+            [
+                new UsageContent(new UsageDetails
+                {
+                    InputTokenCount = 10,
+                    OutputTokenCount = 20,
+                    TotalTokenCount = 30
+                })
+            ]
+        };
+
+        var result = new List<StreamingChatCompletionUpdate>();
+        await foreach (var update in CreateAsyncEnumerable(new[] { responseUpdate }).AsOpenAIStreamingChatCompletionUpdatesAsync())
+        {
+            result.Add(update);
+        }
+
+        Assert.Single(result);
+        var streamingUpdate = result[0];
+
+        Assert.Equal("response-123", streamingUpdate.CompletionId);
+        Assert.NotNull(streamingUpdate.Usage);
+        Assert.Equal(20, streamingUpdate.Usage.OutputTokenCount);
+        Assert.Equal(10, streamingUpdate.Usage.InputTokenCount);
+        Assert.Equal(30, streamingUpdate.Usage.TotalTokenCount);
+    }
+
+    [Fact]
+    public async Task AsOpenAIStreamingChatCompletionUpdatesAsync_WithFunctionCallContent_CreatesUpdateWithToolCalls()
+    {
+        var functionCallContent = new FunctionCallContent("call-123", "GetWeather", new Dictionary<string, object?>
+        {
+            ["location"] = "Seattle",
+            ["units"] = "celsius"
+        });
+
+        var responseUpdate = new ChatResponseUpdate(ChatRole.Assistant, [functionCallContent])
+        {
+            ResponseId = "response-123"
+        };
+
+        var result = new List<StreamingChatCompletionUpdate>();
+        await foreach (var update in CreateAsyncEnumerable(new[] { responseUpdate }).AsOpenAIStreamingChatCompletionUpdatesAsync())
+        {
+            result.Add(update);
+        }
+
+        Assert.Single(result);
+        var streamingUpdate = result[0];
+
+        Assert.Equal("response-123", streamingUpdate.CompletionId);
+        Assert.Single(streamingUpdate.ToolCallUpdates);
+
+        var toolCallUpdate = streamingUpdate.ToolCallUpdates[0];
+        Assert.Equal(0, toolCallUpdate.Index);
+        Assert.Equal("call-123", toolCallUpdate.ToolCallId);
+        Assert.Equal(ChatToolCallKind.Function, toolCallUpdate.Kind);
+        Assert.Equal("GetWeather", toolCallUpdate.FunctionName);
+
+        var deserializedArgs = JsonSerializer.Deserialize<Dictionary<string, object?>>(
+            toolCallUpdate.FunctionArgumentsUpdate.ToMemory().Span);
+        Assert.Equal("Seattle", deserializedArgs?["location"]?.ToString());
+        Assert.Equal("celsius", deserializedArgs?["units"]?.ToString());
+    }
+
+    [Fact]
+    public async Task AsOpenAIStreamingChatCompletionUpdatesAsync_WithMultipleFunctionCalls_CreatesCorrectIndexes()
+    {
+        var functionCall1 = new FunctionCallContent("call-1", "Function1", new Dictionary<string, object?> { ["param1"] = "value1" });
+        var functionCall2 = new FunctionCallContent("call-2", "Function2", new Dictionary<string, object?> { ["param2"] = "value2" });
+
+        var responseUpdate = new ChatResponseUpdate(ChatRole.Assistant, [functionCall1, functionCall2])
+        {
+            ResponseId = "response-123"
+        };
+
+        var result = new List<StreamingChatCompletionUpdate>();
+        await foreach (var update in CreateAsyncEnumerable(new[] { responseUpdate }).AsOpenAIStreamingChatCompletionUpdatesAsync())
+        {
+            result.Add(update);
+        }
+
+        Assert.Single(result);
+        var streamingUpdate = result[0];
+
+        Assert.Equal(2, streamingUpdate.ToolCallUpdates.Count);
+
+        Assert.Equal(0, streamingUpdate.ToolCallUpdates[0].Index);
+        Assert.Equal("call-1", streamingUpdate.ToolCallUpdates[0].ToolCallId);
+        Assert.Equal("Function1", streamingUpdate.ToolCallUpdates[0].FunctionName);
+
+        Assert.Equal(1, streamingUpdate.ToolCallUpdates[1].Index);
+        Assert.Equal("call-2", streamingUpdate.ToolCallUpdates[1].ToolCallId);
+        Assert.Equal("Function2", streamingUpdate.ToolCallUpdates[1].FunctionName);
+    }
+
+    [Fact]
+    public async Task AsOpenAIStreamingChatCompletionUpdatesAsync_WithMixedContent_IncludesAllContent()
+    {
+        var responseUpdate = new ChatResponseUpdate(ChatRole.Assistant,
+        [
+            new TextContent("Processing your request..."),
+            new FunctionCallContent("call-123", "GetWeather", new Dictionary<string, object?> { ["location"] = "Seattle" }),
+            new UsageContent(new UsageDetails { TotalTokenCount = 50 })
+        ])
+        {
+            ResponseId = "response-123",
+            ModelId = "gpt-4"
+        };
+
+        var result = new List<StreamingChatCompletionUpdate>();
+        await foreach (var update in CreateAsyncEnumerable(new[] { responseUpdate }).AsOpenAIStreamingChatCompletionUpdatesAsync())
+        {
+            result.Add(update);
+        }
+
+        Assert.Single(result);
+        var streamingUpdate = result[0];
+
+        Assert.Equal("response-123", streamingUpdate.CompletionId);
+        Assert.Equal("gpt-4", streamingUpdate.Model);
+
+        // Should have text content
+        Assert.Contains(streamingUpdate.ContentUpdate, c => c.Text == "Processing your request...");
+
+        // Should have tool call
+        Assert.Single(streamingUpdate.ToolCallUpdates);
+        Assert.Equal("call-123", streamingUpdate.ToolCallUpdates[0].ToolCallId);
+
+        // Should have usage
+        Assert.NotNull(streamingUpdate.Usage);
+        Assert.Equal(50, streamingUpdate.Usage.TotalTokenCount);
+    }
+
+    [Fact]
+    public async Task AsOpenAIStreamingChatCompletionUpdatesAsync_WithDifferentRoles_MapsCorrectly()
+    {
+        var testCases = new[]
+        {
+            (ChatRole.Assistant, ChatMessageRole.Assistant),
+            (ChatRole.User, ChatMessageRole.User),
+            (ChatRole.System, ChatMessageRole.System),
+            (ChatRole.Tool, ChatMessageRole.Tool)
+        };
+
+        foreach (var (inputRole, expectedOpenAIRole) in testCases)
+        {
+            var responseUpdate = new ChatResponseUpdate(inputRole, "Test message");
+
+            var result = new List<StreamingChatCompletionUpdate>();
+            await foreach (var update in CreateAsyncEnumerable(new[] { responseUpdate }).AsOpenAIStreamingChatCompletionUpdatesAsync())
+            {
+                result.Add(update);
+            }
+
+            Assert.Single(result);
+            Assert.Equal(expectedOpenAIRole, result[0].Role);
+        }
+    }
+
+    [Fact]
+    public async Task AsOpenAIStreamingChatCompletionUpdatesAsync_WithDifferentFinishReasons_MapsCorrectly()
+    {
+        var testCases = new[]
+        {
+            (ChatFinishReason.Stop, OpenAI.Chat.ChatFinishReason.Stop),
+            (ChatFinishReason.Length, OpenAI.Chat.ChatFinishReason.Length),
+            (ChatFinishReason.ContentFilter, OpenAI.Chat.ChatFinishReason.ContentFilter),
+            (ChatFinishReason.ToolCalls, OpenAI.Chat.ChatFinishReason.ToolCalls)
+        };
+
+        foreach (var (inputFinishReason, expectedOpenAIFinishReason) in testCases)
+        {
+            var responseUpdate = new ChatResponseUpdate(ChatRole.Assistant, "Test")
+            {
+                FinishReason = inputFinishReason
+            };
+
+            var result = new List<StreamingChatCompletionUpdate>();
+            await foreach (var update in CreateAsyncEnumerable(new[] { responseUpdate }).AsOpenAIStreamingChatCompletionUpdatesAsync())
+            {
+                result.Add(update);
+            }
+
+            Assert.Single(result);
+            Assert.Equal(expectedOpenAIFinishReason, result[0].FinishReason);
+        }
+    }
+
+    [Fact]
+    public async Task AsOpenAIStreamingChatCompletionUpdatesAsync_WithMultipleUpdates_ProcessesAllCorrectly()
+    {
+        var updates = new[]
+        {
+            new ChatResponseUpdate(ChatRole.Assistant, "Hello, ")
+            {
+                ResponseId = "response-123",
+                MessageId = "message-1"
+
+                // No FinishReason set - null
+            },
+            new ChatResponseUpdate(ChatRole.Assistant, "world!")
+            {
+                ResponseId = "response-123",
+                MessageId = "message-1",
+                FinishReason = ChatFinishReason.Stop
+            }
+        };
+
+        var result = new List<StreamingChatCompletionUpdate>();
+        await foreach (var update in CreateAsyncEnumerable(updates).AsOpenAIStreamingChatCompletionUpdatesAsync())
+        {
+            result.Add(update);
+        }
+
+        Assert.Equal(2, result.Count);
+
+        Assert.Equal("response-123", result[0].CompletionId);
+        Assert.Equal("Hello, ", Assert.Single(result[0].ContentUpdate).Text);
+
+        // The ToChatFinishReason method defaults null to Stop
+        Assert.Equal(OpenAI.Chat.ChatFinishReason.Stop, result[0].FinishReason);
+
+        Assert.Equal("response-123", result[1].CompletionId);
+        Assert.Equal("world!", Assert.Single(result[1].ContentUpdate).Text);
+        Assert.Equal(OpenAI.Chat.ChatFinishReason.Stop, result[1].FinishReason);
+    }
+
+    private static async IAsyncEnumerable<T> CreateAsyncEnumerable<T>(IEnumerable<T> source)
+    {
+        foreach (var item in source)
+        {
+            await Task.Yield();
+            yield return item;
         }
     }
 }


### PR DESCRIPTION
We're already exposing the non-streaming response conversions. Expose the streaming ones as well.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6636)