### PR TITLE
[DRAFT] Use runtime specific, self-contained packages, target .NET 9

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/McpServer/McpServer-CSharp/McpServer-CSharp.csproj.in
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/McpServer/McpServer-CSharp/McpServer-CSharp.csproj.in
@@ -1,11 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RollForward>Major</RollForward>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <!-- This RID list supports over 99% of .NET SDK usage. Adjust to your needs. -->
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-musl-x64;linux-arm64;osx-arm64</RuntimeIdentifiers>
+    <PublishSelfContained>true</PublishSelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
 
     <!-- Set up the NuGet package to be an MCP server -->
     <PackAsTool>true</PackAsTool>

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/McpServer/McpServer-CSharp/README.md
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/McpServer/McpServer-CSharp/README.md
@@ -14,7 +14,9 @@ Please note that this template is currently in an early preview stage. If you ha
   - See [configuring inputs](https://aka.ms/nuget/mcp/guide/configuring-inputs) for more details.
 - Pack the project using `dotnet pack`.
 
-The `bin/Release` directory will contain the package file (.nupkg), which can be [published to NuGet.org](https://learn.microsoft.com/nuget/nuget-org/publish-a-package).
+The `bin/Release` directory will contain the package files (*.nupkg), which can be [published to NuGet.org](https://learn.microsoft.com/nuget/nuget-org/publish-a-package).
+
+One .nupkg will be produced for each runtime identifer you selected in the `<RuntimeIdentifiers>` property in the .csproj, plus a "root" .nupkg containing pointers to the others. For more information about runtime identifiers in .NET, see the [.NET RID catalog](https://learn.microsoft.com/dotnet/core/rid-catalog).
 
 ## Developing locally
 

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.Basic.verified/mcpserver/README.md
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.Basic.verified/mcpserver/README.md
@@ -14,7 +14,9 @@ Please note that this template is currently in an early preview stage. If you ha
   - See [configuring inputs](https://aka.ms/nuget/mcp/guide/configuring-inputs) for more details.
 - Pack the project using `dotnet pack`.
 
-The `bin/Release` directory will contain the package file (.nupkg), which can be [published to NuGet.org](https://learn.microsoft.com/nuget/nuget-org/publish-a-package).
+The `bin/Release` directory will contain the package files (*.nupkg), which can be [published to NuGet.org](https://learn.microsoft.com/nuget/nuget-org/publish-a-package).
+
+One .nupkg will be produced for each runtime identifer you selected in the `<RuntimeIdentifiers>` property in the .csproj, plus a "root" .nupkg containing pointers to the others. For more information about runtime identifiers in .NET, see the [.NET RID catalog](https://learn.microsoft.com/dotnet/core/rid-catalog).
 
 ## Developing locally
 

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.Basic.verified/mcpserver/mcpserver.csproj
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.Basic.verified/mcpserver/mcpserver.csproj
@@ -1,11 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RollForward>Major</RollForward>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <!-- This RID list supports over 99% of .NET SDK usage. Adjust to your needs. -->
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-musl-x64;linux-arm64;osx-arm64</RuntimeIdentifiers>
+    <PublishSelfContained>true</PublishSelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
 
     <!-- Set up the NuGet package to be an MCP server -->
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
Resolve https://github.com/dotnet/extensions/issues/6560.

This uses the new RID-specific tool packages feature to reduce runtime compatibility issues to "all you need is `dnx`".

I switched to .NET 9.0 to avoid trimming warnings related to System.Text.Json in .NET 8.

I selected the list of RIDs based on .NET SDK telemetry on the `tool` verb.

