### PR TITLE
Add ChatMessage.CreatedAt

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatMessage.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatMessage.cs
@@ -53,6 +53,7 @@ public class ChatMessage
             AdditionalProperties = AdditionalProperties,
             _authorName = _authorName,
             _contents = _contents,
+            CreatedAt = CreatedAt,
             RawRepresentation = RawRepresentation,
             Role = Role,
             MessageId = MessageId,
@@ -64,6 +65,9 @@ public class ChatMessage
         get => _authorName;
         set => _authorName = string.IsNullOrWhiteSpace(value) ? null : value;
     }
+
+    /// <summary>Gets or sets a timestamp for the chat message.</summary>
+    public DateTimeOffset? CreatedAt { get; set; }
 
     /// <summary>Gets or sets the role of the author of the message.</summary>
     public ChatRole Role { get; set; } = ChatRole.User;

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponse.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponse.cs
@@ -130,19 +130,19 @@ public class ChatResponse
             ChatMessage message = _messages![i];
             updates[i] = new ChatResponseUpdate
             {
-                ConversationId = ConversationId,
-
                 AdditionalProperties = message.AdditionalProperties,
                 AuthorName = message.AuthorName,
                 Contents = message.Contents,
+                MessageId = message.MessageId,
                 RawRepresentation = message.RawRepresentation,
                 Role = message.Role,
 
-                ResponseId = ResponseId,
-                MessageId = message.MessageId,
-                CreatedAt = CreatedAt,
+                ConversationId = ConversationId,
                 FinishReason = FinishReason,
-                ModelId = ModelId
+                ModelId = ModelId,
+                ResponseId = ResponseId,
+
+                CreatedAt = message.CreatedAt ?? CreatedAt,
             };
         }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
@@ -84,9 +84,10 @@ public static class ChatResponseExtensions
         var contentsList = filter is null ? update.Contents : update.Contents.Where(filter).ToList();
         if (contentsList.Count > 0)
         {
-            list.Add(new ChatMessage(update.Role ?? ChatRole.Assistant, contentsList)
+            list.Add(new(update.Role ?? ChatRole.Assistant, contentsList)
             {
                 AuthorName = update.AuthorName,
+                CreatedAt = update.CreatedAt,
                 RawRepresentation = update.RawRepresentation,
                 AdditionalProperties = update.AdditionalProperties,
             });
@@ -268,7 +269,7 @@ public static class ChatResponseExtensions
 
         if (isNewMessage)
         {
-            message = new ChatMessage(ChatRole.Assistant, []);
+            message = new(ChatRole.Assistant, []);
             response.Messages.Add(message);
         }
         else
@@ -280,9 +281,15 @@ public static class ChatResponseExtensions
         // Incorporate those into the latest message; in cases where the message
         // stores a single value, prefer the latest update's value over anything
         // stored in the message.
+
         if (update.AuthorName is not null)
         {
             message.AuthorName = update.AuthorName;
+        }
+
+        if (update.CreatedAt is not null)
+        {
+            message.CreatedAt = update.CreatedAt;
         }
 
         if (update.Role is ChatRole role)

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -884,6 +884,10 @@
           "Stage": "Stable"
         },
         {
+          "Member": "System.DateTimeOffset? Microsoft.Extensions.AI.ChatMessage.CreatedAt { get; set; }",
+          "Stage": "Stable"
+        },
+        {
           "Member": "string? Microsoft.Extensions.AI.ChatMessage.MessageId { get; set; }",
           "Stage": "Stable"
         },

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
@@ -95,6 +95,7 @@ internal sealed class AzureAIInferenceChatClient : IChatClient
         // Create the return message.
         ChatMessage message = new(ToChatRole(response.Role), response.Content)
         {
+            CreatedAt = response.Created,
             MessageId = response.Id, // There is no per-message ID, but there's only one message per response, so use the response ID
             RawRepresentation = response,
         };

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -438,6 +438,7 @@ internal sealed class OpenAIChatClient : IChatClient
         // Create the return message.
         ChatMessage returnMessage = new()
         {
+            CreatedAt = openAICompletion.CreatedAt,
             MessageId = openAICompletion.Id, // There's no per-message ID, so we use the same value as the response ID
             RawRepresentation = openAICompletion,
             Role = FromOpenAIChatRole(openAICompletion.Role),

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -162,6 +162,11 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
             }
         }
 
+        foreach (var message in response.Messages)
+        {
+            message.CreatedAt = openAIResponse.CreatedAt;
+        }
+
         return response;
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatMessageTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatMessageTests.cs
@@ -18,6 +18,7 @@ public class ChatMessageTests
         ChatMessage message = new();
         Assert.Null(message.AuthorName);
         Assert.Empty(message.Contents);
+        Assert.Null(message.CreatedAt);
         Assert.Equal(ChatRole.User, message.Role);
         Assert.Empty(message.Text);
         Assert.NotNull(message.Contents);
@@ -50,6 +51,7 @@ public class ChatMessageTests
         }
 
         Assert.Null(message.AuthorName);
+        Assert.Null(message.CreatedAt);
         Assert.Null(message.RawRepresentation);
         Assert.Null(message.AdditionalProperties);
         Assert.Equal(text ?? string.Empty, message.ToString());
@@ -113,6 +115,7 @@ public class ChatMessageTests
         }
 
         Assert.Null(message.AuthorName);
+        Assert.Null(message.CreatedAt);
         Assert.Null(message.RawRepresentation);
         Assert.Null(message.AdditionalProperties);
     }
@@ -228,6 +231,20 @@ public class ChatMessageTests
 
         message.AdditionalProperties = props;
         Assert.Same(props, message.AdditionalProperties);
+    }
+
+    [Fact]
+    public void CreatedAt_Roundtrips()
+    {
+        ChatMessage message = new();
+        Assert.Null(message.CreatedAt);
+
+        DateTimeOffset now = DateTimeOffset.Now;
+        message.CreatedAt = now;
+        Assert.Equal(now, message.CreatedAt);
+
+        message.CreatedAt = null;
+        Assert.Null(message.CreatedAt);
     }
 
     [Fact]


### PR DESCRIPTION
We currently have it at the ChatResponse{Update} level, but for more agentic scenarios, it's helpful to have a timestamp per message.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6657)