### PR TITLE
Fix issue with NetSourceIndexStage1 for dependency conflict versions

### DIFF
--- a/src/Packages/Microsoft.Internal.Extensions.DotNetApiDocs.Transport/Microsoft.Internal.Extensions.DotNetApiDocs.Transport.proj
+++ b/src/Packages/Microsoft.Internal.Extensions.DotNetApiDocs.Transport/Microsoft.Internal.Extensions.DotNetApiDocs.Transport.proj
@@ -31,6 +31,7 @@
     <!-- This is needed in order to avoid a version conflict between some dependencies bringing in the 6.0 version of the assembly
     and some others depending on the 9.0 version. -->
     <PackageReference Include="System.Text.Encodings.Web" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
   <!-- Include the reference assembly and put the documentation file next to it. -->


### PR DESCRIPTION
cc: @stephentoub @sebastienros As you were following on the fix for this after some changes in dependencies to MEAI packages. This promotes the package ref for DiagnosticSource in our api docs transport project, which fixes the version conflict. 

I've tested this in an internal build that runs Source Index step and build passed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6672)