### PR TITLE
Couple of fixes for MEAI.Evaluation

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/MetricCard.tsx
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/components/MetricCard.tsx
@@ -242,9 +242,14 @@ export const MetricDisplay = ({ metric }: { metric: MetricWithNoValue | NumericM
     const classes = useCardStyles();
     const { fg, bg } = useCardColors(metric.interpretation);
 
-    const pillClass = mergeClasses(
-        bg,
-        classes.metricPill,
+    const pillClass = mergeClasses(bg, classes.metricPill);
+    const valueClass = mergeClasses(fg, classes.metricValueText);
+
+    return (
+        <Tooltip content={`${metric.name}: ${metricValue}`} relationship="description">
+            <div className={pillClass}>
+                <span className={valueClass}>{metricValue}</span>
+            </div>
+        </Tooltip>
     );
-    return (<div className={pillClass}><span className={fg}>{metricValue}</span></div>);
 };

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyChatClient.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Extensions.AI.Evaluation.Safety;
 
 internal sealed class ContentSafetyChatClient : IChatClient
 {
-    private const string Moniker = "Azure AI Foundry Evaluation";
+    private const string ProviderName = "azure.ai.foundry";
+    private const string ModelId = $"{ProviderName}.evaluation";
 
     private readonly ContentSafetyService _service;
     private readonly IChatClient? _originalChatClient;
@@ -35,38 +36,14 @@ internal sealed class ContentSafetyChatClient : IChatClient
 
         ChatClientMetadata? originalMetadata = _originalChatClient?.GetService<ChatClientMetadata>();
 
-        string providerName;
-        Uri? providerUri = originalMetadata?.ProviderUri;
-
-        if (contentSafetyServiceConfiguration.IsHubBasedProject)
-        {
-            providerName =
-                $"{Moniker} (" +
-                $"Subscription: {contentSafetyServiceConfiguration.SubscriptionId}, " +
-                $"Resource Group: {contentSafetyServiceConfiguration.ResourceGroupName}, " +
-                $"Project: {contentSafetyServiceConfiguration.ProjectName})";
-        }
-        else
-        {
-            providerName = $"{Moniker} (Endpoint: {contentSafetyServiceConfiguration.Endpoint})";
-            providerUri = contentSafetyServiceConfiguration.Endpoint;
-        }
-
+        string providerName = ProviderName;
         if (originalMetadata?.ProviderName is string originalProviderName &&
             !string.IsNullOrWhiteSpace(originalProviderName))
         {
             providerName = $"{providerName}; {originalProviderName}";
         }
 
-        string modelId = Moniker;
-
-        if (originalMetadata?.DefaultModelId is string originalModelId &&
-            !string.IsNullOrWhiteSpace(originalModelId))
-        {
-            modelId = $"{modelId}; {originalModelId}";
-        }
-
-        _metadata = new ChatClientMetadata(providerName, providerUri, modelId);
+        _metadata = new ChatClientMetadata(providerName, defaultModelId: ModelId);
     }
 
     public async Task<ChatResponse> GetResponseAsync(
@@ -88,7 +65,7 @@ internal sealed class ContentSafetyChatClient : IChatClient
 
             return new ChatResponse(new ChatMessage(ChatRole.Assistant, annotationResult))
             {
-                ModelId = Moniker
+                ModelId = ModelId
             };
         }
         else
@@ -121,7 +98,7 @@ internal sealed class ContentSafetyChatClient : IChatClient
 
             yield return new ChatResponseUpdate(ChatRole.Assistant, annotationResult)
             {
-                ModelId = Moniker
+                ModelId = ModelId
             };
         }
         else


### PR DESCRIPTION
1. Truncates long metric values in the trends table -

Before:
<img width="2548" height="884" alt="image" src="https://github.com/user-attachments/assets/2b663e3a-825b-432d-9980-6083d143b4fe" />

After:
<img width="2442" height="864" alt="image" src="https://github.com/user-attachments/assets/adb44baf-8d9b-4b37-8fd0-8e050b29f313" />

2. Also includes a change to simplify how client metadata is constructed for ContentSafetyChatClient
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6673)