### PR TITLE
Fix one more version conflict on the docs transport package

### DIFF
--- a/src/Packages/Microsoft.Internal.Extensions.DotNetApiDocs.Transport/Microsoft.Internal.Extensions.DotNetApiDocs.Transport.proj
+++ b/src/Packages/Microsoft.Internal.Extensions.DotNetApiDocs.Transport/Microsoft.Internal.Extensions.DotNetApiDocs.Transport.proj
@@ -32,6 +32,7 @@
     and some others depending on the 9.0 version. -->
     <PackageReference Include="System.Text.Encodings.Web" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <!-- Include the reference assembly and put the documentation file next to it. -->


### PR DESCRIPTION
Found one more issue in the internal build due to version conflicts. After this change I'm able to build cleanly locally.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6675)