### PR TITLE
Emit {OriginalFormat} in HttpClient logger 

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/Log.cs
@@ -17,9 +17,12 @@ namespace Microsoft.Extensions.Http.Logging.Internal;
 [SuppressMessage("Major Code Smell", "S109:Magic numbers should not be used", Justification = "Event ID's.")]
 internal static partial class Log
 {
-    internal const string OriginalFormat = "{OriginalFormat}";
+    private const int MinimalPropertyCount = 5;
 
-    private const int MinimalPropertyCount = 4;
+    private const string OriginalFormat = "{OriginalFormat}";
+
+    private const string OriginalFormatValue =
+        $"{{{HttpClientLoggingTagNames.Method}}} {{{HttpClientLoggingTagNames.Host}}}/{{{HttpClientLoggingTagNames.Path}}}";
 
     private const string RequestReadErrorMessage =
         "An error occurred while reading the request data to fill the logger context for request: " +
@@ -133,8 +136,11 @@ internal static partial class Log
 
         if (record.ResponseBody is not null)
         {
-            loggerMessageState.TagArray[index] = new(HttpClientLoggingTagNames.ResponseBody, record.ResponseBody);
+            loggerMessageState.TagArray[index++] = new(HttpClientLoggingTagNames.ResponseBody, record.ResponseBody);
         }
+
+        // "{OriginalFormat}" property needs to be the last tag in the list.
+        loggerMessageState.TagArray[index] = new(OriginalFormat, OriginalFormatValue);
 
         logger.Log(
             level,

--- a/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/AcceptanceTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/AcceptanceTests.cs
@@ -385,14 +385,14 @@ public class AcceptanceTests
         if (parameterRedactionMode == HttpRouteParameterRedactionMode.None)
         {
             loggedPath.Should().Be(httpRequestMessage.RequestUri.AbsolutePath);
-            state.Should().HaveCount(5);
+            state.Should().HaveCount(6);
         }
         else
         {
             loggedPath.Should().Be(RequestRoute);
             state.Should().ContainSingle(kvp => kvp.Key == "userId").Which.Value.Should().Be(expectedUserId);
             state.Should().ContainSingle(kvp => kvp.Key == "unitId").Which.Value.Should().Be(expectedUnitId);
-            state.Should().HaveCount(7);
+            state.Should().HaveCount(8);
         }
     }
 


### PR DESCRIPTION
Adds the `{OriginalFormat}` property to the list of tags of `HttpClient` logs.

Fixes #6364
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6682)