### PR TITLE
Split AIFunction into a base class

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## NOT YET RELEASED
+
+- Added non-invocable `AIFunctionDeclaration` (base class for `AIFunction`), `AIFunctionFactory.CreateDeclaration`, and `AIFunction.AsDeclarationOnly`.
+
 ## 9.8.0
 
 - Added `AIAnnotation` and related types to represent citations and other annotations in chat messages.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatToolMode.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatToolMode.cs
@@ -55,8 +55,7 @@ public class ChatToolMode
 
     /// <summary>
     /// Instantiates a <see cref="ChatToolMode"/> indicating that tool usage is required,
-    /// and that the specified <see cref="AIFunction"/> must be selected. The function name
-    /// must match an entry in <see cref="ChatOptions.Tools"/>.
+    /// and that the specified function name must be selected.
     /// </summary>
     /// <param name="functionName">The name of the required function.</param>
     /// <returns>An instance of <see cref="RequiredChatToolMode"/> for the specified function name.</returns>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/RequiredChatToolMode.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/RequiredChatToolMode.cs
@@ -15,17 +15,17 @@ namespace Microsoft.Extensions.AI;
 public sealed class RequiredChatToolMode : ChatToolMode
 {
     /// <summary>
-    /// Gets the name of a specific <see cref="AIFunction"/> that must be called.
+    /// Gets the name of a specific tool that must be called.
     /// </summary>
     /// <remarks>
-    /// If the value is <see langword="null"/>, any available function can be selected (but at least one must be).
+    /// If the value is <see langword="null"/>, any available tool can be selected (but at least one must be).
     /// </remarks>
     public string? RequiredFunctionName { get; }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="RequiredChatToolMode"/> class that requires a specific function to be called.
+    /// Initializes a new instance of the <see cref="RequiredChatToolMode"/> class that requires a specific tool to be called.
     /// </summary>
-    /// <param name="requiredFunctionName">The name of the function that must be called.</param>
+    /// <param name="requiredFunctionName">The name of the tool that must be called.</param>
     /// <exception cref="ArgumentException"><paramref name="requiredFunctionName"/> is empty or composed entirely of whitespace.</exception>
     /// <remarks>
     /// <paramref name="requiredFunctionName"/> can be <see langword="null"/>. However, it's preferable to use

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionDeclaration.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionDeclaration.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Threading.Tasks;
+
+#pragma warning disable S1694 // An abstract class should have both abstract and concrete methods
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Represents a function that can be described to an AI service.</summary>
+/// <remarks>
+/// <see cref="AIFunctionDeclaration"/> is the base class for <see cref="AIFunction"/>, which
+/// adds the ability to invoke the function. Components may type test <see cref="AITool"/> instances
+/// for <see cref="AIFunctionDeclaration"/> to determine whether they can be described as functions,
+/// and may type test for <see cref="AIFunction"/> to determine whether they can be invoked.
+/// </remarks>
+public abstract class AIFunctionDeclaration : AITool
+{
+    /// <summary>Initializes a new instance of the <see cref="AIFunctionDeclaration"/> class.</summary>
+    protected AIFunctionDeclaration()
+    {
+    }
+
+    /// <summary>Gets a JSON Schema describing the function and its input parameters.</summary>
+    /// <remarks>
+    /// <para>
+    /// When specified, declares a self-contained JSON schema document that describes the function and its input parameters.
+    /// A simple example of a JSON schema for a function that adds two numbers together is shown below:
+    /// </para>
+    /// <code>
+    /// {
+    ///   "title" : "addNumbers",
+    ///   "description": "A simple function that adds two numbers together.",
+    ///   "type": "object",
+    ///   "properties": {
+    ///     "a" : { "type": "number" },
+    ///     "b" : { "type": "number", "default": 1 }
+    ///   }, 
+    ///   "required" : ["a"]
+    /// }
+    /// </code>
+    /// <para>
+    /// The metadata present in the schema document plays an important role in guiding AI function invocation.
+    /// </para>
+    /// <para>
+    /// When no schema is specified, consuming chat clients should assume the "{}" or "true" schema, indicating that any JSON input is admissible.
+    /// </para>
+    /// </remarks>
+    public virtual JsonElement JsonSchema => AIJsonUtilities.DefaultJsonSchema;
+
+    /// <summary>Gets a JSON Schema describing the function's return value.</summary>
+    /// <remarks>
+    /// A <see langword="null"/> typically reflects a function that doesn't specify a return schema
+    /// or a function that returns <see cref="void"/>, <see cref="Task"/>, or <see cref="ValueTask"/>.
+    /// </remarks>
+    public virtual JsonElement? ReturnJsonSchema => null;
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -49,7 +49,7 @@ public static partial class AIFunctionFactory
     /// <para>
     /// By default, any parameters to <paramref name="method"/> are sourced from the <see cref="AIFunctionArguments"/>'s dictionary
     /// of key/value pairs and are represented in the JSON schema for the function, as exposed in the returned <see cref="AIFunction"/>'s
-    /// <see cref="AIFunction.JsonSchema"/>. There are a few exceptions to this:
+    /// <see cref="AIFunctionDeclaration.JsonSchema"/>. There are a few exceptions to this:
     /// <list type="bullet">
     ///   <item>
     ///     <description>
@@ -131,7 +131,7 @@ public static partial class AIFunctionFactory
     /// <para>
     /// Any parameters to <paramref name="method"/> are sourced from the <see cref="AIFunctionArguments"/>'s dictionary
     /// of key/value pairs and are represented in the JSON schema for the function, as exposed in the returned <see cref="AIFunction"/>'s
-    /// <see cref="AIFunction.JsonSchema"/>. There are a few exceptions to this:
+    /// <see cref="AIFunctionDeclaration.JsonSchema"/>. There are a few exceptions to this:
     /// <list type="bullet">
     ///   <item>
     ///     <description>
@@ -212,7 +212,7 @@ public static partial class AIFunctionFactory
     /// <para>
     /// By default, any parameters to <paramref name="method"/> are sourced from the <see cref="AIFunctionArguments"/>'s dictionary
     /// of key/value pairs and are represented in the JSON schema for the function, as exposed in the returned <see cref="AIFunction"/>'s
-    /// <see cref="AIFunction.JsonSchema"/>. There are a few exceptions to this:
+    /// <see cref="AIFunctionDeclaration.JsonSchema"/>. There are a few exceptions to this:
     /// <list type="bullet">
     ///   <item>
     ///     <description>
@@ -304,7 +304,7 @@ public static partial class AIFunctionFactory
     /// <para>
     /// Any parameters to <paramref name="method"/> are sourced from the <see cref="AIFunctionArguments"/>'s dictionary
     /// of key/value pairs and are represented in the JSON schema for the function, as exposed in the returned <see cref="AIFunction"/>'s
-    /// <see cref="AIFunction.JsonSchema"/>. There are a few exceptions to this:
+    /// <see cref="AIFunctionDeclaration.JsonSchema"/>. There are a few exceptions to this:
     /// <list type="bullet">
     ///   <item>
     ///     <description>
@@ -398,7 +398,7 @@ public static partial class AIFunctionFactory
     /// <para>
     /// By default, any parameters to <paramref name="method"/> are sourced from the <see cref="AIFunctionArguments"/>'s dictionary
     /// of key/value pairs and are represented in the JSON schema for the function, as exposed in the returned <see cref="AIFunction"/>'s
-    /// <see cref="AIFunction.JsonSchema"/>. There are a few exceptions to this:
+    /// <see cref="AIFunctionDeclaration.JsonSchema"/>. There are a few exceptions to this:
     /// <list type="bullet">
     ///   <item>
     ///     <description>
@@ -466,6 +466,39 @@ public static partial class AIFunctionFactory
         Func<AIFunctionArguments, object> createInstanceFunc,
         AIFunctionFactoryOptions? options = null) =>
         ReflectionAIFunction.Build(method, createInstanceFunc, options ?? _defaultOptions);
+
+    /// <summary>Creates an <see cref="AIFunctionDeclaration"/> using the specified parameters as the implementation of its corresponding properties.</summary>
+    /// <param name="name">The name of the function.</param>
+    /// <param name="description">A description of the function, suitable for use in describing the purpose to a model.</param>
+    /// <param name="jsonSchema">A JSON schema describing the function and its input parameters.</param>
+    /// <param name="returnJsonSchema">A JSON schema describing the function's return value.</param>
+    /// <returns>The created <see cref="AIFunctionDeclaration"/> that describes a function.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <see cref="CreateDeclaration"/> creates an <see cref="AIFunctionDeclaration"/> that can be used to describe a function
+    /// but not invoke it. To create an invocable <see cref="AIFunction"/>, use Create. A non-invocable <see cref="AIFunctionDeclaration"/>
+    /// may also be created from an invocable <see cref="AIFunction"/> using that function's <see cref="AIFunction.AsDeclarationOnly"/> method.
+    /// </remarks>
+    public static AIFunctionDeclaration CreateDeclaration(
+        string name,
+        string? description,
+        JsonElement jsonSchema,
+        JsonElement? returnJsonSchema = null) =>
+        new DefaultAIFunctionDeclaration(
+            Throw.IfNullOrEmpty(name),
+            description ?? string.Empty,
+            jsonSchema,
+            returnJsonSchema);
+
+    private sealed class DefaultAIFunctionDeclaration(
+        string name, string description, JsonElement jsonSchema, JsonElement? returnJsonSchema) :
+        AIFunctionDeclaration
+    {
+        public override string Name => name;
+        public override string Description => description;
+        public override JsonElement JsonSchema => jsonSchema;
+        public override JsonElement? ReturnJsonSchema => returnJsonSchema;
+    }
 
     private sealed class ReflectionAIFunction : AIFunction
     {

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactoryOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactoryOptions.cs
@@ -107,14 +107,14 @@ public sealed class AIFunctionFactoryOptions
     public Func<object?, Type?, CancellationToken, ValueTask<object?>>? MarshalResult { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether a schema should be created for the function's result type, if possible, and included as <see cref="AIFunction.ReturnJsonSchema" />.
+    /// Gets or sets a value indicating whether a schema should be created for the function's result type, if possible, and included as <see cref="AIFunctionDeclaration.ReturnJsonSchema" />.
     /// </summary>
     /// <remarks>
     /// <para>
     /// The default value is <see langword="false"/>.
     /// </para>
     /// <para>
-    /// When set to <see langword="true"/>, results in the produced <see cref="AIFunction.ReturnJsonSchema"/> to always be <see langword="null"/>.
+    /// When set to <see langword="true"/>, results in the produced <see cref="AIFunctionDeclaration.ReturnJsonSchema"/> to always be <see langword="null"/>.
     /// </para>
     /// </remarks>
     public bool ExcludeResultSchema { get; set; }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/DelegatingAIFunctionDeclaration.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/DelegatingAIFunctionDeclaration.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.Shared.Diagnostics;
+
+#pragma warning disable SA1202 // Elements should be ordered by access
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>
+/// Provides an optional base class for an <see cref="AIFunctionDeclaration"/> that passes through calls to another instance.
+/// </summary>
+internal class DelegatingAIFunctionDeclaration : AIFunctionDeclaration // could be made public in the future if there's demand
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegatingAIFunctionDeclaration"/> class as a wrapper around <paramref name="innerFunction"/>.
+    /// </summary>
+    /// <param name="innerFunction">The inner AI function to which all calls are delegated by default.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="innerFunction"/> is <see langword="null"/>.</exception>
+    protected DelegatingAIFunctionDeclaration(AIFunctionDeclaration innerFunction)
+    {
+        InnerFunction = Throw.IfNull(innerFunction);
+    }
+
+    /// <summary>Gets the inner <see cref="AIFunctionDeclaration" />.</summary>
+    protected AIFunctionDeclaration InnerFunction { get; }
+
+    /// <inheritdoc />
+    public override string Name => InnerFunction.Name;
+
+    /// <inheritdoc />
+    public override string Description => InnerFunction.Description;
+
+    /// <inheritdoc />
+    public override JsonElement JsonSchema => InnerFunction.JsonSchema;
+
+    /// <inheritdoc />
+    public override JsonElement? ReturnJsonSchema => InnerFunction.ReturnJsonSchema;
+
+    /// <inheritdoc />
+    public override IReadOnlyDictionary<string, object?> AdditionalProperties => InnerFunction.AdditionalProperties;
+
+    /// <inheritdoc />
+    public override string ToString() => InnerFunction.ToString();
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -172,7 +172,7 @@
       ]
     },
     {
-      "Type": "abstract class Microsoft.Extensions.AI.AIFunction : Microsoft.Extensions.AI.AITool",
+      "Type": "abstract class Microsoft.Extensions.AI.AIFunction : Microsoft.Extensions.AI.AIFunctionDeclaration",
       "Stage": "Stable",
       "Methods": [
         {
@@ -186,23 +186,39 @@
         {
           "Member": "abstract System.Threading.Tasks.ValueTask<object?> Microsoft.Extensions.AI.AIFunction.InvokeCoreAsync(Microsoft.Extensions.AI.AIFunctionArguments arguments, System.Threading.CancellationToken cancellationToken);",
           "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.AIFunctionDeclaration Microsoft.Extensions.AI.AIFunction.AsDeclarationOnly();",
+          "Stage": "Stable"
         }
       ],
       "Properties": [
-        {
-          "Member": "virtual System.Text.Json.JsonElement Microsoft.Extensions.AI.AIFunction.JsonSchema { get; }",
-          "Stage": "Stable"
-        },
         {
           "Member": "virtual System.Text.Json.JsonSerializerOptions Microsoft.Extensions.AI.AIFunction.JsonSerializerOptions { get; }",
           "Stage": "Stable"
         },
         {
-          "Member": "virtual System.Text.Json.JsonElement? Microsoft.Extensions.AI.AIFunction.ReturnJsonSchema { get; }",
+          "Member": "virtual System.Reflection.MethodInfo? Microsoft.Extensions.AI.AIFunction.UnderlyingMethod { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "abstract class Microsoft.Extensions.AI.AIFunctionDeclaration : Microsoft.Extensions.AI.AITool",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.AIFunctionDeclaration.AIFunctionDeclaration();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "virtual System.Text.Json.JsonElement Microsoft.Extensions.AI.AIFunctionDeclaration.JsonSchema { get; }",
           "Stage": "Stable"
         },
         {
-          "Member": "virtual System.Reflection.MethodInfo? Microsoft.Extensions.AI.AIFunction.UnderlyingMethod { get; }",
+          "Member": "virtual System.Text.Json.JsonElement? Microsoft.Extensions.AI.AIFunctionDeclaration.ReturnJsonSchema { get; }",
           "Stage": "Stable"
         }
       ]
@@ -305,6 +321,10 @@
         },
         {
           "Member": "static Microsoft.Extensions.AI.AIFunction Microsoft.Extensions.AI.AIFunctionFactory.Create(System.Reflection.MethodInfo method, System.Func<Microsoft.Extensions.AI.AIFunctionArguments, object> createInstanceFunc, Microsoft.Extensions.AI.AIFunctionFactoryOptions? options = null);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.AI.AIFunctionDeclaration Microsoft.Extensions.AI.AIFunctionFactory.CreateDeclaration(string name, string? description, System.Text.Json.JsonElement jsonSchema, System.Text.Json.JsonElement? returnJsonSchema = null);",
           "Stage": "Stable"
         }
       ]
@@ -511,6 +531,10 @@
         },
         {
           "Member": "System.Text.Json.JsonElement Microsoft.Extensions.AI.AIJsonSchemaTransformCache.GetOrCreateTransformedSchema(Microsoft.Extensions.AI.AIFunction function);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Text.Json.JsonElement Microsoft.Extensions.AI.AIJsonSchemaTransformCache.GetOrCreateTransformedSchema(Microsoft.Extensions.AI.AIFunctionDeclaration function);",
           "Stage": "Stable"
         },
         {

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaTransformCache.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaTransformCache.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Microsoft.Shared.Diagnostics;
@@ -23,10 +24,10 @@ namespace Microsoft.Extensions.AI;
 /// </remarks>
 public sealed class AIJsonSchemaTransformCache
 {
-    private readonly ConditionalWeakTable<AIFunction, object> _functionSchemaCache = new();
+    private readonly ConditionalWeakTable<AIFunctionDeclaration, object> _functionSchemaCache = new();
     private readonly ConditionalWeakTable<ChatResponseFormatJson, object> _responseFormatCache = new();
 
-    private readonly ConditionalWeakTable<AIFunction, object>.CreateValueCallback _functionSchemaCreateValueCallback;
+    private readonly ConditionalWeakTable<AIFunctionDeclaration, object>.CreateValueCallback _functionSchemaCreateValueCallback;
     private readonly ConditionalWeakTable<ChatResponseFormatJson, object>.CreateValueCallback _responseFormatCreateValueCallback;
 
     /// <summary>
@@ -57,7 +58,16 @@ public sealed class AIJsonSchemaTransformCache
     /// </summary>
     /// <param name="function">The function whose JSON schema we want to transform.</param>
     /// <returns>The transformed JSON schema corresponding to <see cref="TransformOptions"/>.</returns>
-    public JsonElement GetOrCreateTransformedSchema(AIFunction function)
+    [EditorBrowsable(EditorBrowsableState.Never)] // maintained for binary compat; functionality for AIFunction is satisfied by AIFunctionDeclaration overload
+    public JsonElement GetOrCreateTransformedSchema(AIFunction function) =>
+        GetOrCreateTransformedSchema((AIFunctionDeclaration)function);
+
+    /// <summary>
+    /// Gets or creates a transformed JSON schema for the specified <see cref="AIFunctionDeclaration"/> instance.
+    /// </summary>
+    /// <param name="function">The function whose JSON schema we want to transform.</param>
+    /// <returns>The transformed JSON schema corresponding to <see cref="TransformOptions"/>.</returns>
+    public JsonElement GetOrCreateTransformedSchema(AIFunctionDeclaration function)
     {
         _ = Throw.IfNull(function);
         return (JsonElement)_functionSchemaCache.GetValue(function, _functionSchemaCreateValueCallback);

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
@@ -343,7 +343,7 @@ internal sealed class AzureAIInferenceChatClient : IChatClient
         {
             foreach (AITool tool in tools)
             {
-                if (tool is AIFunction af)
+                if (tool is AIFunctionDeclaration af)
                 {
                     result.Tools.Add(ToAzureAIChatTool(af));
                 }
@@ -410,7 +410,7 @@ internal sealed class AzureAIInferenceChatClient : IChatClient
     private static readonly BinaryData _falseString = BinaryData.FromString("false");
 
     /// <summary>Converts an Extensions function to an AzureAI chat tool.</summary>
-    private static ChatCompletionsToolDefinition ToAzureAIChatTool(AIFunction aiFunction)
+    private static ChatCompletionsToolDefinition ToAzureAIChatTool(AIFunctionDeclaration aiFunction)
     {
         // Map to an intermediate model so that redundant properties are skipped.
         var tool = JsonSerializer.Deserialize(SchemaTransformCache.GetOrCreateTransformedSchema(aiFunction), JsonContext.Default.AzureAIChatToolJson)!;

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## NOT YET RELEASED
+
+- Updated tool mapping to recognize any `AIFunctionDeclaration`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
 ## 9.8.0-preview.1.25412.6
 
 - Updated to depend on Azure.AI.Inference 1.0.0-beta.5.

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/AIToolExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/AIToolExtensions.cs
@@ -19,7 +19,7 @@ internal static class AIToolExtensions
 
         var toolDefinitionsJsonArray = new JsonArray();
 
-        foreach (AIFunction function in toolDefinitions.OfType<AIFunction>())
+        foreach (AIFunctionDeclaration function in toolDefinitions.OfType<AIFunctionDeclaration>())
         {
             JsonNode functionJsonNode =
                 new JsonObject

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/IntentResolutionEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/IntentResolutionEvaluator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.AI.Evaluation.Quality;
 /// </para>
 /// <para>
 /// Note that at the moment, <see cref="IntentResolutionEvaluator"/> only supports evaluating calls to tools that are
-/// defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions that are supplied via
+/// defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions that are supplied via
 /// <see cref="IntentResolutionEvaluatorContext.ToolDefinitions"/> will be ignored.
 /// </para>
 /// <para>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/IntentResolutionEvaluatorContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/IntentResolutionEvaluatorContext.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.AI.Evaluation.Quality;
 /// </para>
 /// <para>
 /// Note that at the moment, <see cref="IntentResolutionEvaluator"/> only supports evaluating calls to tools that are
-/// defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions that are supplied via
+/// defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions that are supplied via
 /// <see cref="ToolDefinitions"/> will be ignored.
 /// </para>
 /// </remarks>
@@ -36,7 +36,7 @@ public sealed class IntentResolutionEvaluatorContext : EvaluationContext
     /// </para>
     /// <para>
     /// Note that at the moment, <see cref="IntentResolutionEvaluator"/> only supports evaluating calls to tools that
-    /// are defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions will be ignored.
+    /// are defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions will be ignored.
     /// </para>
     /// </param>
     public IntentResolutionEvaluatorContext(params AITool[] toolDefinitions)
@@ -55,7 +55,7 @@ public sealed class IntentResolutionEvaluatorContext : EvaluationContext
     /// </para>
     /// <para>
     /// Note that at the moment, <see cref="IntentResolutionEvaluator"/> only supports evaluating calls to tools that
-    /// are defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions will be ignored.
+    /// are defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions will be ignored.
     /// </para>
     /// </param>
     public IntentResolutionEvaluatorContext(IEnumerable<AITool> toolDefinitions)
@@ -81,7 +81,7 @@ public sealed class IntentResolutionEvaluatorContext : EvaluationContext
     /// </para>
     /// <para>
     /// Note that at the moment, <see cref="IntentResolutionEvaluator"/> only supports evaluating calls to tools that
-    /// are defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions that are supplied via
+    /// are defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions that are supplied via
     /// <see cref="ToolDefinitions"/> will be ignored.
     /// </para>
     /// </remarks>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/TaskAdherenceEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/TaskAdherenceEvaluator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.AI.Evaluation.Quality;
 /// </para>
 /// <para>
 /// Note that at the moment, <see cref="TaskAdherenceEvaluator"/> only supports evaluating calls to tools that are
-/// defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions that are supplied via
+/// defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions that are supplied via
 /// <see cref="TaskAdherenceEvaluatorContext.ToolDefinitions"/> will be ignored.
 /// </para>
 /// <para>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/TaskAdherenceEvaluatorContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/TaskAdherenceEvaluatorContext.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.AI.Evaluation.Quality;
 /// </para>
 /// <para>
 /// Note that at the moment, <see cref="TaskAdherenceEvaluator"/> only supports evaluating calls to tools that are
-/// defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions that are supplied via
+/// defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions that are supplied via
 /// <see cref="ToolDefinitions"/> will be ignored.
 /// </para>
 /// </remarks>
@@ -37,7 +37,7 @@ public sealed class TaskAdherenceEvaluatorContext : EvaluationContext
     /// </para>
     /// <para>
     /// Note that at the moment, <see cref="TaskAdherenceEvaluator"/> only supports evaluating calls to tools that
-    /// are defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions will be ignored.
+    /// are defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions will be ignored.
     /// </para>
     /// </param>
     public TaskAdherenceEvaluatorContext(params AITool[] toolDefinitions)
@@ -56,7 +56,7 @@ public sealed class TaskAdherenceEvaluatorContext : EvaluationContext
     /// </para>
     /// <para>
     /// Note that at the moment, <see cref="TaskAdherenceEvaluator"/> only supports evaluating calls to tools that
-    /// are defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions will be ignored.
+    /// are defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions will be ignored.
     /// </para>
     /// </param>
     public TaskAdherenceEvaluatorContext(IEnumerable<AITool> toolDefinitions)
@@ -83,7 +83,7 @@ public sealed class TaskAdherenceEvaluatorContext : EvaluationContext
     /// </para>
     /// <para>
     /// Note that at the moment, <see cref="TaskAdherenceEvaluator"/> only supports evaluating calls to tools that are
-    /// defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions that are supplied via
+    /// defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions that are supplied via
     /// <see cref="ToolDefinitions"/> will be ignored.
     /// </para>
     /// </remarks>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/ToolCallAccuracyEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/ToolCallAccuracyEvaluator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.AI.Evaluation.Quality;
 /// </para>
 /// <para>
 /// Note that at the moment, <see cref="ToolCallAccuracyEvaluator"/> only supports evaluating calls to tools that are
-/// defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions that are supplied via
+/// defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions that are supplied via
 /// <see cref="ToolCallAccuracyEvaluatorContext.ToolDefinitions"/> will be ignored.
 /// </para>
 /// <para>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/ToolCallAccuracyEvaluatorContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/ToolCallAccuracyEvaluatorContext.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.AI.Evaluation.Quality;
 /// </para>
 /// <para>
 /// Note that at the moment, <see cref="ToolCallAccuracyEvaluator"/> only supports evaluating calls to tools that are
-/// defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions that are supplied via
+/// defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions that are supplied via
 /// <see cref="ToolDefinitions"/> will be ignored.
 /// </para>
 /// </remarks>
@@ -38,7 +38,7 @@ public sealed class ToolCallAccuracyEvaluatorContext : EvaluationContext
     /// </para>
     /// <para>
     /// Note that at the moment, <see cref="ToolCallAccuracyEvaluator"/> only supports evaluating calls to tools that
-    /// are defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions will be ignored.
+    /// are defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions will be ignored.
     /// </para>
     /// </param>
     public ToolCallAccuracyEvaluatorContext(params AITool[] toolDefinitions)
@@ -57,7 +57,7 @@ public sealed class ToolCallAccuracyEvaluatorContext : EvaluationContext
     /// </para>
     /// <para>
     /// Note that at the moment, <see cref="ToolCallAccuracyEvaluator"/> only supports evaluating calls to tools that
-    /// are defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions will be ignored.
+    /// are defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions will be ignored.
     /// </para>
     /// </param>
     public ToolCallAccuracyEvaluatorContext(IEnumerable<AITool> toolDefinitions)
@@ -85,7 +85,7 @@ public sealed class ToolCallAccuracyEvaluatorContext : EvaluationContext
     /// </para>
     /// <para>
     /// Note that at the moment, <see cref="ToolCallAccuracyEvaluator"/> only supports evaluating calls to tools that
-    /// are defined as <see cref="AIFunction"/>s. Any other <see cref="AITool"/> definitions that are supplied via
+    /// are defined as <see cref="AIFunctionDeclaration"/>s. Any other <see cref="AITool"/> definitions that are supplied via
     /// <see cref="ToolDefinitions"/> will be ignored.
     /// </para>
     /// </remarks>

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## NOT YET RELEASED
+
+- Updated tool mappings to recognize any `AIFunctionDeclaration`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
 ## 9.8.0-preview.1.25412.6
 
 - Updated to depend on OpenAI 2.3.0.

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIAssistantsExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIAssistantsExtensions.cs
@@ -10,10 +10,10 @@ namespace OpenAI.Assistants;
 /// <summary>Provides extension methods for working with content associated with OpenAI.Assistants.</summary>
 public static class MicrosoftExtensionsAIAssistantsExtensions
 {
-    /// <summary>Creates an OpenAI <see cref="FunctionToolDefinition"/> from an <see cref="AIFunction"/>.</summary>
+    /// <summary>Creates an OpenAI <see cref="FunctionToolDefinition"/> from an <see cref="AIFunctionDeclaration"/>.</summary>
     /// <param name="function">The function to convert.</param>
     /// <returns>An OpenAI <see cref="FunctionToolDefinition"/> representing <paramref name="function"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="function"/> is <see langword="null"/>.</exception>
-    public static FunctionToolDefinition AsOpenAIAssistantsFunctionToolDefinition(this AIFunction function) =>
+    public static FunctionToolDefinition AsOpenAIAssistantsFunctionToolDefinition(this AIFunctionDeclaration function) =>
         OpenAIAssistantsChatClient.ToOpenAIAssistantsFunctionToolDefinition(Throw.IfNull(function));
 }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIChatExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIChatExtensions.cs
@@ -19,11 +19,11 @@ namespace OpenAI.Chat;
 /// <summary>Provides extension methods for working with content associated with OpenAI.Chat.</summary>
 public static class MicrosoftExtensionsAIChatExtensions
 {
-    /// <summary>Creates an OpenAI <see cref="ChatTool"/> from an <see cref="AIFunction"/>.</summary>
+    /// <summary>Creates an OpenAI <see cref="ChatTool"/> from an <see cref="AIFunctionDeclaration"/>.</summary>
     /// <param name="function">The function to convert.</param>
     /// <returns>An OpenAI <see cref="ChatTool"/> representing <paramref name="function"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="function"/> is <see langword="null"/>.</exception>
-    public static ChatTool AsOpenAIChatTool(this AIFunction function) =>
+    public static ChatTool AsOpenAIChatTool(this AIFunctionDeclaration function) =>
         OpenAIChatClient.ToOpenAIChatTool(Throw.IfNull(function));
 
     /// <summary>Creates a sequence of OpenAI <see cref="ChatMessage"/> instances from the specified input messages.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIRealtimeExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIRealtimeExtensions.cs
@@ -10,10 +10,10 @@ namespace OpenAI.Realtime;
 /// <summary>Provides extension methods for working with content associated with OpenAI.Realtime.</summary>
 public static class MicrosoftExtensionsAIRealtimeExtensions
 {
-    /// <summary>Creates an OpenAI <see cref="ConversationFunctionTool"/> from an <see cref="AIFunction"/>.</summary>
+    /// <summary>Creates an OpenAI <see cref="ConversationFunctionTool"/> from an <see cref="AIFunctionDeclaration"/>.</summary>
     /// <param name="function">The function to convert.</param>
     /// <returns>An OpenAI <see cref="ConversationFunctionTool"/> representing <paramref name="function"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="function"/> is <see langword="null"/>.</exception>
-    public static ConversationFunctionTool AsOpenAIConversationFunctionTool(this AIFunction function) =>
+    public static ConversationFunctionTool AsOpenAIConversationFunctionTool(this AIFunctionDeclaration function) =>
         OpenAIRealtimeConversationClient.ToOpenAIConversationFunctionTool(Throw.IfNull(function));
 }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
@@ -14,11 +14,11 @@ namespace OpenAI.Responses;
 /// <summary>Provides extension methods for working with content associated with OpenAI.Responses.</summary>
 public static class MicrosoftExtensionsAIResponsesExtensions
 {
-    /// <summary>Creates an OpenAI <see cref="ResponseTool"/> from an <see cref="AIFunction"/>.</summary>
+    /// <summary>Creates an OpenAI <see cref="ResponseTool"/> from an <see cref="AIFunctionDeclaration"/>.</summary>
     /// <param name="function">The function to convert.</param>
     /// <returns>An OpenAI <see cref="ResponseTool"/> representing <paramref name="function"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="function"/> is <see langword="null"/>.</exception>
-    public static ResponseTool AsOpenAIResponseTool(this AIFunction function) =>
+    public static ResponseTool AsOpenAIResponseTool(this AIFunctionDeclaration function) =>
         OpenAIResponsesChatClient.ToResponseTool(Throw.IfNull(function));
 
     /// <summary>Creates a sequence of OpenAI <see cref="ResponseItem"/> instances from the specified input messages.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantsChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantsChatClient.cs
@@ -286,7 +286,7 @@ internal sealed class OpenAIAssistantsChatClient : IChatClient
     }
 
     /// <summary>Converts an Extensions function to an OpenAI assistants function tool.</summary>
-    internal static FunctionToolDefinition ToOpenAIAssistantsFunctionToolDefinition(AIFunction aiFunction, ChatOptions? options = null)
+    internal static FunctionToolDefinition ToOpenAIAssistantsFunctionToolDefinition(AIFunctionDeclaration aiFunction, ChatOptions? options = null)
     {
         bool? strict =
             OpenAIClientExtensions.HasStrict(aiFunction.AdditionalProperties) ??
@@ -348,7 +348,7 @@ internal sealed class OpenAIAssistantsChatClient : IChatClient
                 {
                     switch (tool)
                     {
-                        case AIFunction aiFunction:
+                        case AIFunctionDeclaration aiFunction:
                             runOptions.ToolsOverride.Add(ToOpenAIAssistantsFunctionToolDefinition(aiFunction, options));
                             break;
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -101,7 +101,7 @@ internal sealed class OpenAIChatClient : IChatClient
     }
 
     /// <summary>Converts an Extensions function to an OpenAI chat tool.</summary>
-    internal static ChatTool ToOpenAIChatTool(AIFunction aiFunction, ChatOptions? options = null)
+    internal static ChatTool ToOpenAIChatTool(AIFunctionDeclaration aiFunction, ChatOptions? options = null)
     {
         bool? strict =
             OpenAIClientExtensions.HasStrict(aiFunction.AdditionalProperties) ??
@@ -564,7 +564,7 @@ internal sealed class OpenAIChatClient : IChatClient
         {
             foreach (AITool tool in tools)
             {
-                if (tool is AIFunction af)
+                if (tool is AIFunctionDeclaration af)
                 {
                     result.Tools.Add(ToOpenAIChatTool(af, options));
                 }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIClientExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIClientExtensions.cs
@@ -177,8 +177,8 @@ public static class OpenAIClientExtensions
         strictObj is bool strictValue ?
         strictValue : null;
 
-    /// <summary>Extracts from an <see cref="AIFunction"/> the parameters and strictness setting for use with OpenAI's APIs.</summary>
-    internal static BinaryData ToOpenAIFunctionParameters(AIFunction aiFunction, bool? strict)
+    /// <summary>Extracts from an <see cref="AIFunctionDeclaration"/> the parameters and strictness setting for use with OpenAI's APIs.</summary>
+    internal static BinaryData ToOpenAIFunctionParameters(AIFunctionDeclaration aiFunction, bool? strict)
     {
         // Perform any desirable transformations on the function's JSON schema, if it'll be used in a strict setting.
         JsonElement jsonSchema = strict is true ?

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIRealtimeConversationClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIRealtimeConversationClient.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.AI;
 /// <summary>Provides helpers for interacting with OpenAI Realtime.</summary>
 internal sealed class OpenAIRealtimeConversationClient
 {
-    public static ConversationFunctionTool ToOpenAIConversationFunctionTool(AIFunction aiFunction, ChatOptions? options = null)
+    public static ConversationFunctionTool ToOpenAIConversationFunctionTool(AIFunctionDeclaration aiFunction, ChatOptions? options = null)
     {
         bool? strict =
             OpenAIClientExtensions.HasStrict(aiFunction.AdditionalProperties) ??

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -336,7 +336,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
         // Nothing to dispose. Implementation required for the IChatClient interface.
     }
 
-    internal static ResponseTool ToResponseTool(AIFunction aiFunction, ChatOptions? options = null)
+    internal static ResponseTool ToResponseTool(AIFunctionDeclaration aiFunction, ChatOptions? options = null)
     {
         bool? strict =
             OpenAIClientExtensions.HasStrict(aiFunction.AdditionalProperties) ??
@@ -399,7 +399,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
             {
                 switch (tool)
                 {
-                    case AIFunction aiFunction:
+                    case AIFunctionDeclaration aiFunction:
                         result.Tools.Add(ToResponseTool(aiFunction, options));
                         break;
 

--- a/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## NOT YET RELEASED
 
+- Added `FunctionInvokingChatClient` support for non-invocable tools and `TerminateOnUnknownCalls` property.
 - Fixed `GetResponseAsync<T>` to only look at the contents of the last message in the response.
 
 ## 9.8.0

--- a/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.json
+++ b/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.json
@@ -546,6 +546,10 @@
         {
           "Member": "int Microsoft.Extensions.AI.FunctionInvokingChatClient.MaximumIterationsPerRequest { get; set; }",
           "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.AI.FunctionInvokingChatClient.TerminateOnUnknownCalls { get; set; }",
+          "Stage": "Stable"
         }
       ]
     },

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
@@ -931,6 +931,26 @@ public partial class AIFunctionFactoryTest
         static int Add(int a, int b) => a + b;
     }
 
+    [Fact]
+    public void CreateDeclaration_Roundtrips()
+    {
+        JsonElement schema = AIJsonUtilities.CreateJsonSchema(typeof(int), serializerOptions: AIJsonUtilities.DefaultOptions);
+
+        AIFunctionDeclaration f = AIFunctionFactory.CreateDeclaration("something", "amazing", schema);
+        Assert.Equal("something", f.Name);
+        Assert.Equal("amazing", f.Description);
+        Assert.Equal("""{"type":"integer"}""", f.JsonSchema.ToString());
+        Assert.Null(f.ReturnJsonSchema);
+
+        f = AIFunctionFactory.CreateDeclaration("other", null, default, schema);
+        Assert.Equal("other", f.Name);
+        Assert.Empty(f.Description);
+        Assert.Equal(default, f.JsonSchema);
+        Assert.Equal("""{"type":"integer"}""", f.ReturnJsonSchema.ToString());
+
+        Assert.Throws<ArgumentNullException>("name", () => AIFunctionFactory.CreateDeclaration(null!, "description", default));
+    }
+
     private sealed class MyService(int value)
     {
         public int Value => value;


### PR DESCRIPTION
- Adds `AIFunctionDefinition` as a base class for `AIFunction`, where `AIFunction` layers on invocability over the metadata exposed by the base.
- Added `AIFunctionFactory.CreateDefinition` and `AIFunction.AsDefinitionOnly` for creating `AIFunctionDefinition`s that aren't invocable.
- Updated `FunctionInvokingChatClient` to allow non-`AIFunction` call requests to pass through.
- Added `FunctionInvokingChatClient.TerminateOnUnknownCalls` to control behavior when requests are made to unknown functions.

Closes https://github.com/dotnet/extensions/issues/6688

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6695)