### PR TITLE
Consider using Environment.CpuUsage in ResourceMonitoring

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -117,8 +117,7 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
     internal static long GetCpuTicks()
     {
 #if NET9_0_OR_GREATER
-        var cpuUsage = Environment.CpuUsage;
-        return (cpuUsage.PrivilegedTime + cpuUsage.UserTime).Ticks;
+        return Environment.CpuUsage.TotalTime.Ticks;
 #else
         using var process = Process.GetCurrentProcess();
         return process.TotalProcessorTime.Ticks;


### PR DESCRIPTION
This PR updates the **WindowsSnapshotProvider** to use the new **Environment.CpuUsage** property introduced in .NET 9.0+ for obtaining CPU usage information, providing improved performance compared to the previous approach using **Process.GetCurrentProcess()**.

The **Environment.CpuUsage** property was introduced in .NET 9.0 and provides direct access to the current process's CPU usage information without the overhead of the **Process** class. This change is conditionally compiled using [#if NET9_0_OR_GREATER] to ensure compatibility with earlier .NET versions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6696)
 
 Resolves https://github.com/dotnet/extensions/issues/5893