### PR TITLE
Bring back per library CHANGELOGS for M.E.AI

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Release History
 
+## NOT YET RELEASED
+
+- Added `AIAnnotation` and related types to represent citations and other annotations in chat messages.
+- Added `ChatMessage.CreatedAt` so that chat messages can carry their timestamp.
+- Added a `[Description(...)]` attribute to `DataContent.Uri` to clarify its purpose when used in schemas.
+- Added `DataContent.Name` property to associate a name with the binary data, like a filename.
+- Improved handling of function parameter data annotation attributes in `AIJsonUtilities.CreateJsonSchema`.
+- Fixed schema generation to include an items keyword for arrays of objects in `AIJsonUtilities.CreateJsonSchema`.
+
+## 9.7.1
+
+- Fixed schema generation for nullable function parameters in `AIJsonUtilities.CreateJsonSchema`.
+
+## 9.7.0
+
+- Added `ChatOptions.Instructions` property for configuring system instructions separate from chat messages.
+- Added `Usage` property to `SpeechToTextResponse` to provide details about the token usage.
+- Augmented `AIJsonUtilities.CreateJsonSchema` with support for data annotations.
+
+## 9.6.0
+
+- Added `AIFunction.ReturnJsonSchema` to represent the JSON schema of the return value of a function.
+- Removed title and description keywords from root-level schemas in `AIFunctionFactory`.
+
+## 9.5.0
+
+- Moved `AIFunctionFactory` down from `Microsoft.Extensions.AI` to `Microsoft.Extensions.AI.Abstractions`.
+- Added `BinaryEmbedding` type for representing bit embeddings.
+- Added `TextReasoningContent` to represent reasoning content in chat messages.
+- Added `ChatOptions.AllowMultipleToolCalls` for configuring parallel tool calling.
+- Added a public constructor to the base `AIContent`.
+- Added a missing `[DebuggerDisplay]` attribute on `AIFunctionArguments`.
+- Added `ChatOptions.RawRepresentationFactory` to facilitate passing raw options to the underlying service.
+- Added an `AIJsonSchemaTransformOptions` property inside `AIJsonSchemaCreateOptions`.
+- Added `DataContent.Base64Data` property for easier and more efficient handling of base64-encoded data.
+- Added JSON schema transformation functionality to `AIJsonUtilities`.
+- Fixed `AIJsonUtilities.CreateJsonSchema` to handle `JsonSerializerOptions` that do not have a `TypeInfoResolver` configured.
+- Fixed `AIFunctionFactory` handling of default struct arguments.
+- Fixed schema generation to ensure the type keyword is included when generating schemas for nullable enums.
+- Renamed the `GenerateXx` extension methods on `IEmbeddingGenerator<>`.
+- Renamed `ChatThreadId` to `ConversationId` across the libraries.
+- Replaced `Type targetType` parameter in `AIFunctionFactory.Create` with a delegate.
+- Remove `[Obsolete]` members from previews.
+
 ## 9.4.4-preview.1.25259.16
 
 - Added `AIJsonUtilities.TransformSchema` and supporting types.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Release History
+
+## 9.4.4-preview.1.25259.16
+
+- Added `AIJsonUtilities.TransformSchema` and supporting types.
+- Added `BinaryEmbedding` for bit embeddings.
+- Added `ChatOptions.RawRepresentationFactory` to make it easier to pass options to the underlying service.
+- Added `Base64Data` property to `DataContent`.
+- Moved `AIFunctionFactory` to `Microsoft.Extensions.AI.Abstractions`.
+- Fixed `AIFunctionFactory` handling of default struct arguments.
+
+## 9.4.3-preview.1.25230.7
+
+- Renamed `ChatThreadId` to `ConversationId` on `ChatResponse`, `ChatResponseUpdate`, and `ChatOptions`.
+- Renamed `EmbeddingGeneratorExtensions` method `GenerateEmbeddingAsync` to `GenerateAsync` and `GenerateEmbeddingVectorAsync` to `GenerateVectorAsync`.
+- Made `AIContent`'s constructor `public` instead of `protected`.
+- Fixed `AIJsonUtilities.CreateJsonSchema` to tolerate `JsonSerializerOptions` instances that don't have a `TypeInfoResolver` already configured.
+
+## 9.4.0-preview.1.25207.5
+
+- Added `ErrorContent` and `TextReasoningContent`.
+- Added `MessageId` to `ChatMessage` and `ChatResponseUpdate`.
+- Added `AIFunctionArguments`, changing `AIFunction.InvokeAsync` to accept one and to return a `ValueTask`.
+- Updated `AIJsonUtilities`'s schema generation to not use `default` when `RequireAllProperties` is set to `true`.
+- Added `ISpeechToTextClient` and supporting types.
+- Fixed several issues related to Native AOT support.
+
+## 9.3.0-preview.1.25161.3
+
+- Changed `IChatClient.GetResponseAsync` and `IChatClient.GetStreamingResponseAsync` to accept an `IEnumerable<ChatMessage>` rather than an `IList<ChatMessage>`. It is no longer mutated by implementations.
+- Removed `ChatResponse.Choice` and `ChatResponseUpdate.ChoiceIndex`.
+- Replaced `ChatResponse.Message` with `ChatResponse.Messages`. Responses now carry with them all messages generated as part of the operation, rather than all but the last being added to the history and the last returned.
+- Added `GetRequiredService` extension method for `IChatClient`/`IEmbeddingGenerator`.
+- Added non-generic `IEmbeddingGenerator` interface, which is inherited by `IEmbeddingGenerator<TInput, TEmbedding>`. The `GetService` method moves down to the non-generic interface, and the `GetService`/`GetRequiredService` extension methods are now in terms of the non-generic.
+- `AIJsonUtilities.CreateFunctionJsonSchema` now special-cases `CancellationToken` to not include it in the schema.
+- Improved the debugger displays for `ChatMessage` and the `AIContent` types.
+- Added a static `AIJsonUtilities.HashDataToString` method.
+- Split `DataContent`, which handled both in-memory data and URIs to remote data, into `DataContent` (for the former) and `UriContent` (for the latter).
+- Renamed `DataContent.MediaTypeStartsWith` to `DataContent.HasTopLevelMediaType`, and changed semantics accordingly.
+
+## 9.3.0-preview.1.25114.11
+
+- Renamed `IChatClient.Complete{Streaming}Async` to `IChatClient.Get{Streaming}ResponseAsync`. This is to avoid confusion with "Complete" being about stopping an operation, as well as to avoid tying the methods to a particular implementation detail of how responses are generated. Along with this, renamed `ChatCompletion` to `ChatResponse`, `StreamingChatCompletionUpdate` to `ChatResponseUpdate`, `CompletionId` to `ResponseId`, `ToStreamingChatCompletionUpdates` to `ToChatResponseUpdates`, and `ToChatCompletion{Async}` to `ToChatResponse{Async}`.
+- Removed `IChatClient.Metadata` and `IEmbeddingGenerator.Metadata`. The `GetService` method may be used to retrieve `ChatClientMetadata` and `EmbeddingGeneratorMetadata`, respectively.
+- Added overloads of `Get{Streaming}ResponseAsync` that accept a single `ChatMessage` (in addition to the other overloads that accept a `List<ChatMessage>` or a `string`).
+- Added `ChatThreadId` properties to `ChatOptions`, `ChatResponse`, and `ChatResponseUpdate`. `IChatClient` can now be used in both stateful and stateless modes of operation, such as with agents that maintain server-side chat history.
+- Made `ChatOptions.ToolMode` nullable and added a `None` option.
+- Changed `UsageDetails`'s properties from `int?` to `long?`.
+- Removed `DataContent.ContainsData`; `DataContent.Data.HasValue` may be used instead.
+- Removed `ImageContent` and `AudioContent`; the base `DataContent` should now be used instead, with a new `DataContent.MediaTypeStartsWith` helper for routing based on media type.
+- Removed setters on `FunctionCallContent` and `FunctionResultContent` properties where the value is supplied to the constructor.
+- Removed `FunctionResultContent.Name`.
+- Augmented the base `AITool` with `Name`, `Description`, and `AdditionalProperties` virtual properties.
+- Added a `CodeInterpreterTool` for use with services that support server-side code execution.
+- Changed `AIFunction`'s schema representation to be for the whole function rather than per parameter, and exposed corresponding methods on `AIJsonUtilities`, e.g. `CreateFunctionJsonSchema`.
+- Removed `AIFunctionParameterMetadata` and `AIFunctionReturnParameterMetadata` classes and corresponding properties on `AIFunction` and `AIFunctionFactoryCreateOptions`, replacing them with a `MethodInfo?`. All relevant metadata, such as the JSON schema for the function, are moved to properties directly on `AIFunction`.
+- Renamed `AIFunctionFactoryCreateOptions` to `AIFunctionFactoryOptions` and made all its properties nullable.
+- Changed `AIJsonUtilities.DefaultOptions` to use relaxed JSON escaping.
+- Made `IEmbeddingGenerator<TInput, TEmbedding>` contravariant on `TInput`.
+
+## 9.1.0-preview.1.25064.3
+
+- Added `AdditionalPropertiesDictionary<TValue>` and changed `UsageDetails.AdditionalProperties` to be named `AdditionalCounts` and to be of type `AdditionalPropertiesDictionary<long>`.
+- Updated `FunctionCallingChatClient` to sum all `UsageDetails` token counts from all intermediate messages.
+- Fixed JSON schema generation for floating-point types.
+- Added `AddAIContentType` for enabling custom `AIContent`-derived types to participate in polymorphic serialization.
+
+## 9.0.1-preview.1.24570.5
+
+- Changed `IChatClient`/`IEmbeddingGenerator`.`GetService` to be non-generic.
+- Added `ToChatCompletion` / `ToChatCompletionUpdate` extension methods for `IEnumerable<StreamingChatCompletionUpdate>` / `IAsyncEnumerable<StreamingChatCompletionUpdate>`, respectively.
+- Added `ToStreamingChatCompletionUpdates` instance method to `ChatCompletion`.
+- Added `IncludeTypeInEnumSchemas`, `DisallowAdditionalProperties`, `RequireAllProperties`, and `TransformSchemaNode` options to `AIJsonSchemaCreateOptions`.
+- Fixed a Native AOT warning in `AIFunctionFactory.Create`.
+- Fixed a bug in `AIJsonUtilities` in the handling of Boolean schemas.
+- Improved the `ToString` override of `ChatMessage` and `StreamingChatCompletionUpdate` to include all `TextContent`, and of `ChatCompletion` to include all choices.
+- Added `DebuggerDisplay` attributes to `DataContent` and `GeneratedEmbeddings`.
+- Improved the documentation.
+ 
+## 9.0.0-preview.9.24556.5
+
+- Added a strongly-typed `ChatOptions.Seed` property.
+- Improved `AdditionalPropertiesDictionary` with a `TryAdd` method, a strongly-typed `Enumerator`, and debugger-related attributes for improved debuggability.
+- Fixed `AIJsonUtilities` schema generation for Boolean schemas.
+
+## 9.0.0-preview.9.24525.1
+
+- Lowered the required version of System.Text.Json to 8.0.5 when targeting net8.0 or older.
+- Annotated `FunctionCallContent.Exception` and `FunctionResultContent.Exception` as `[JsonIgnore]`, such that they're ignored when serializing instances with `JsonSerializer`. The corresponding constructors accepting an `Exception` were removed.
+- Annotated `ChatCompletion.Message` as `[JsonIgnore]`, such that it's ignored when serializing instances with `JsonSerializer`.
+- Added the `FunctionCallContent.CreateFromParsedArguments` method.
+- Added the `AdditionalPropertiesDictionary.TryGetValue<T>` method.
+- Added the `StreamingChatCompletionUpdate.ModelId` property and removed the `AIContent.ModelId` property.
+- Renamed the `GenerateAsync` extension method on `IEmbeddingGenerator<,>` to `GenerateEmbeddingsAsync` and updated it to return `Embedding<T>` rather than `GeneratedEmbeddings`.
+- Added `GenerateAndZipAsync` and `GenerateEmbeddingVectorAsync` extension methods for `IEmbeddingGenerator<,>`.
+- Added the `EmbeddingGeneratorOptions.Dimensions` property.
+- Added the `ChatOptions.TopK` property.
+- Normalized `null` inputs in `TextContent` to be empty strings.
+
+## 9.0.0-preview.9.24507.7
+
+- Initial Preview

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Release History
+
+## 9.4.4-preview.1.25259.16
+
+- Added an `AsIEmbeddingGenerator` extension method for `ImageEmbeddingsClient`.
+- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.4.3-preview.1.25230.7
+
+- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.4.0-preview.1.25207.5
+
+- Updated to Azure.AI.Inference 1.0.0-beta.4.
+- Renamed `AsChatClient`/`AsEmbeddingGenerator` extension methods to `AsIChatClient`/`AsIEmbeddingGenerator`.
+- Removed the public `AzureAIInferenceChatClient`/`AzureAIInferenceEmbeddingGenerator` types. These are only created now via the extension methods.
+- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.3.0-preview.1.25161.3
+
+- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.3.0-preview.1.25114.11
+
+- Updated to use Azure.AI.Inference 1.0.0-beta.3, adding support for structured output and audio input.
+
+## 9.1.0-preview.1.25064.3
+
+- Fixed handling of text-only user messages.
+
+## 9.0.1-preview.1.24570.5
+
+  - Made the `ToolCallJsonSerializerOptions` property non-nullable.
+
+## 9.0.0-preview.9.24556.5
+
+- Fixed `AzureAIInferenceEmbeddingGenerator` to respect `EmbeddingGenerationOptions.Dimensions`.
+
+## 9.0.0-preview.9.24525.1
+
+- Lowered the required version of System.Text.Json to 8.0.5 when targeting net8.0 or older.
+- Updated to use Azure.AI.Inference 1.0.0-beta.2.
+- Added `AzureAIInferenceEmbeddingGenerator` and corresponding `AsEmbeddingGenerator` extension method.
+- Improved handling of assistant messages that include both text and function call content.
+
+## 9.0.0-preview.9.24507.7
+
+- Initial Preview

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Release History
 
+## NOT YET RELEASED
+
+- Updated to depend on Azure.AI.Inference 1.0.0-beta.5.
+- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.7.0-preview.1.25356.2
+
+- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.6.0-preview.1.25310.2
+
+- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.5.0-preview.1.25265.7
+
+- Added `AsIEmbeddingGenerator` for Azure.AI.Inference `ImageEmbeddingsClient`.
+- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+
 ## 9.4.4-preview.1.25259.16
 
 - Added an `AsIEmbeddingGenerator` extension method for `ImageEmbeddingsClient`.

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/CHANGELOG.md
@@ -3,40 +3,40 @@
 ## NOT YET RELEASED
 
 - Updated to depend on Azure.AI.Inference 1.0.0-beta.5.
-- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.7.0-preview.1.25356.2
 
-- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.6.0-preview.1.25310.2
 
-- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.5.0-preview.1.25265.7
 
 - Added `AsIEmbeddingGenerator` for Azure.AI.Inference `ImageEmbeddingsClient`.
-- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the changes in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.4.4-preview.1.25259.16
 
 - Added an `AsIEmbeddingGenerator` extension method for `ImageEmbeddingsClient`.
-- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the changes in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.4.3-preview.1.25230.7
 
-- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the changes in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.4.0-preview.1.25207.5
 
 - Updated to Azure.AI.Inference 1.0.0-beta.4.
 - Renamed `AsChatClient`/`AsEmbeddingGenerator` extension methods to `AsIChatClient`/`AsIEmbeddingGenerator`.
 - Removed the public `AzureAIInferenceChatClient`/`AzureAIInferenceEmbeddingGenerator` types. These are only created now via the extension methods.
-- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the changes in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.3.0-preview.1.25161.3
 
-- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the changes in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.3.0-preview.1.25114.11
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Release History
 
+## NOT YET RELEASED
+
+- Updated to depend on OpenAI 2.3.0.
+- Added more conversion helpers for converting bidirectionally between Microsoft.Extensions.AI messages and OpenAI messages.
+- Fixed handling of multiple response messages in the Responses `IChatClient`.
+- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.7.1-preview.1.25365.4
+
+- Added some conversion helpers for converting Microsoft.Extensions.AI messages to OpenAI messages.
+
+## 9.7.0-preview.1.25356.2
+
+- Updated to depend on OpenAI 2.2.0.
+- Added conversion helpers from `AIFunction` to various OpenAI tool representations.
+- Added `AsIChatClient` extension method for OpenAI's `AssistantClient`, enabling `IChatClient` to be used with OpenAI Assistants.
+- Tweaked how JSON schemas for functions are transformed for better compatibility with OpenAI `strict` constraints.
+- Improved handling of `RawRepresentation` in `IChatClients` for Responses and Chat Completion APIs.
+- Improved `ISpeechToTextClient` implementation to support streaming transcriptions.
+- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.6.0-preview.1.25310.2
+
+- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.5.0-preview.1.25265.7
+
+- Added PDF support to `IChatClient` implementations.
+- Disabled use of `strict` schema handling by default.
+- Added support for creating `ErrorContent` in `IChatClient` implementations, such as for refusals.
+- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+
 ## 9.4.4-preview.1.25259.16
 
 - Made `IChatClient` implementation more resilient with non-OpenAI services.

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Release History
+
+## 9.4.4-preview.1.25259.16
+
+- Made `IChatClient` implementation more resilient with non-OpenAI services.
+- Added `ErrorContent` to represent refusals.
+- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.4.3-preview.1.25230.7
+
+- Reverted previous change that enabled `strict` schemas by default.
+- Updated `IChatClient` implementations to support `DataContent`s for PDFs.
+- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.4.0-preview.1.25207.5
+
+- Updated to OpenAI 2.2.0-beta-4.
+- Added `AsISpeechToTextClient` extension method for `AudioClient`.
+- Removed `AsChatClient(OpenAIClient)`/`AsEmbeddingGenerator(OpenAIClient)` extension methods, renamed the remaining `AsChatClient` methods to `AsIChatClient`, renamed the remaining `AsEmbeddingGenerator` methods to `AsIEmbeddingGenerator`, and added an `AsIChatClient` for `OpenAIResponseClient`.
+- Removed the public `OpenAIChatClient`/`OpenAIEmbeddingGenerator` types. These are only created now via the extension methods.
+- Removed serialization/deserialization helpers.
+- Updated to support pulling propagating image detail from `AdditionalProperties`.
+- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.3.0-preview.1.25161.3
+
+- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.3.0-preview.1.25114.11
+
+- Updated to depend on OpenAI 2.2.0-beta.1, updating with support for the Developer role, audio input and output, and additional options like output prediction. It is now also compatible with NativeAOT.
+- Added an `AsChatClient` extension method for OpenAI's `AssistantClient`, enabling `IChatClient` to be used with OpenAI Assistants.
+- Improved the OpenAI serialization helpers, including a custom converter for the `OpenAIChatCompletionRequest` envelope type.
+
+## 9.1.0-preview.1.25064.3
+
+- Updated to depend on OpenAI 2.1.0.
+- Updated to propagate `Metadata` and `StoredOutputEnabled` from `ChatOptions.AdditionalProperties`.
+- Added serialization helpers methods for deserializing OpenAI compatible JSON into the Microsoft.Extensions.AI object model, and vice versa serializing the Microsoft.Extensions.AI object model into OpenAI compatible JSON.
+
+## 9.0.1-preview.1.24570.5
+
+  - Upgraded to depend on the 2.1.0-beta.2 version of the OpenAI NuGet package.
+  - Added the `OpenAIRealtimeExtensions` class, with `ToConversationFunctionTool` and `HandleToolCallsAsync` extension methods for using `AIFunction` with the OpenAI Realtime API.
+  - Made the `ToolCallJsonSerializerOptions` property non-nullable.
+
+## 9.0.0-preview.9.24525.1
+
+- Lowered the required version of System.Text.Json to 8.0.5 when targeting net8.0 or older.
+- Improved handling of system messages that include multiple content items.
+- Improved handling of assistant messages that include both text and function call content.
+- Fixed handling of streaming updates containing empty payloads.
+
+## 9.0.0-preview.9.24507.7
+
+- Initial Preview

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Updated to depend on OpenAI 2.3.0.
 - Added more conversion helpers for converting bidirectionally between Microsoft.Extensions.AI messages and OpenAI messages.
 - Fixed handling of multiple response messages in the Responses `IChatClient`.
-- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.7.1-preview.1.25365.4
 
@@ -19,30 +19,30 @@
 - Tweaked how JSON schemas for functions are transformed for better compatibility with OpenAI `strict` constraints.
 - Improved handling of `RawRepresentation` in `IChatClients` for Responses and Chat Completion APIs.
 - Improved `ISpeechToTextClient` implementation to support streaming transcriptions.
-- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.6.0-preview.1.25310.2
 
-- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.5.0-preview.1.25265.7
 
 - Added PDF support to `IChatClient` implementations.
 - Disabled use of `strict` schema handling by default.
 - Added support for creating `ErrorContent` in `IChatClient` implementations, such as for refusals.
-- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the changes in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.4.4-preview.1.25259.16
 
 - Made `IChatClient` implementation more resilient with non-OpenAI services.
 - Added `ErrorContent` to represent refusals.
-- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the changes in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.4.3-preview.1.25230.7
 
 - Reverted previous change that enabled `strict` schemas by default.
 - Updated `IChatClient` implementations to support `DataContent`s for PDFs.
-- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the changes in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.4.0-preview.1.25207.5
 
@@ -52,11 +52,11 @@
 - Removed the public `OpenAIChatClient`/`OpenAIEmbeddingGenerator` types. These are only created now via the extension methods.
 - Removed serialization/deserialization helpers.
 - Updated to support pulling propagating image detail from `AdditionalProperties`.
-- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the changes in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.3.0-preview.1.25161.3
 
-- Updated to accomodate the changes in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the changes in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.3.0-preview.1.25114.11
 

--- a/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Release History
+
+## 9.4.4-preview.1.25259.16
+
+- Fixed `CachingChatClient` to avoid caching when `ConversationId` is set.
+- Renamed `useJsonSchema` parameter in `GetResponseAsync<T>` to `useJsonSchemaResponseFormat`.
+- Updated `OpenTelemetryChatClient` and `OpenTelemetryEmbeddingGenerator` to conform to the latest 1.33.0 draft specification of the Semantic Conventions for Generative AI systems.
+
+## 9.4.3-preview.1.25230.7
+
+- Updated the diagnostic spans emitted by `FunctionInvokingChatClient` to include total input and output token counts.
+- Updated `AIFunctionFactory` to recognize `[FromKeyedServices]` attribute on parameters in order to resolve those parameters from the `IServiceProvider`.
+- Added `AIFunctionFactoryOptions.Services`, and used it with `IServiceProviderIsService` to automatically resolve `IServiceProvider`-based parameters in `AIFunction` methods.
+- Added `ChatOptions.AllowMultipleToolCalls`.
+- Changed `AIJsonSchemaCreateOptions.RequireAllProperties` to default to `false` instead of `true`.
+- Unsealed `AIFunctionArguments`.
+- Added `AIFunctionArguments` constructors accepting `IEqualityComparer<string>` arguments.
+- Unsealed `FunctionInvocationContext`.
+- Added `FunctionInvocationContext.IsStreaming`.
+- Added protected `FunctionInvokingChatClient.FunctionInvocationServices` property to surface the corresponding `IServiceProvider` provided at construction time.
+- Changed protected virtual `FunctionInvokingChatClient.InvokeFunctionAsync` to return `ValueTask<object?>` instead of `Task<object?>`. Diagnostics are now emitted even if the method is overridden.
+- Added `FunctionInvocationResult.Terminate`.
+
+## 9.4.0-preview.1.25207.5
+
+- Updated `GetResponseAsync<T>` to default to using JSON-schema based structured output by default.
+- Updated `AIFunctionFactory` with support for customizable marshaling of function parameters and return values.
+- Updated `AIFunctionFactory` with a new `Create` overload that supports creating a new receiver instance on each invocation, with either Activator.CreateInstance or ActivatorUtilities.CreateInstance.
+- Updated `AIFunctionFactory` to support injecting an `IServiceProvider` as an argument, sourced from the `AIFunctionArguments` passed to `AIFunction.InvokeAsync`.
+- Simplified `FunctionInvokingChatClient` error handling, removing `RetryOnError` and replacing it with `MaximumConsecutiveErrorsPerRequest`.
+- `FunctionInvokingChatClient` will now ensure that it invokes `AIFunction`s in the same `SynchronizationContext` that `GetResponseAsync`/`GetStreamingResponseAsync` was called in.
+- `OpenTelemetryChatClient` now considers `AdditionalProperties` to be sensitive and will only use that data as tags when `EnableSensitiveData` is set to `true`.
+- Updated `OpenTelemetryChatClient`/`OpenTelemetryEmbeddingGenerator` to conform to the latest 1.32 draft specification of the Semantic Conventions for Generative AI systems.
+- Updated the key used by `DistributedCachingChatClient` to employ SHA384 instead of SHA256.
+- Lowered `System.Text.Json` 9.x dependency to 8.x when targeting `net8.0` or older.
+ 
+## 9.3.0-preview.1.25161.3
+
+- Added caching to `AIFunctionFactory.Create` to improve performance of creating the same functions repeatedly. As part of this, `AIJsonSchemaCreateOptions` now implements `IEquatable<AIJsonSchemaCreateOptions>`.
+- Removed the public `AnonymousDelegatingChatClient`/`AnonymousDelegatingEmbeddingGenerator`. Their functionality is still available via the `Use` methods on the builders.
+- Changed those `Use` methods to use `Func<...>` rather than a custom delegate type.
+- `AIFunctionFactory.Create` now supports `CancellationToken` parameters, and the `AIFunctionContext` type that had served to enable that has been removed.
+- Made `FunctionInvokingChatClient.CurrentContext`'s setter `protected`.
+- Renamed `FunctionInvokingChatClient.DetailedErrors` to `IncludeDetailedErrors`.
+- Renamed `FunctionInvokingChatClient.ConcurrentInvocation` to `AllowConcurrentInvocation`.
+- Removed `FunctionInvokingChatClient.KeepFunctionCallingContent`, as it's no longer relevant now that the input messages are an `IEnumerable<ChatMessage>` rather than an `IList<ChatMessage>`.
+- Renamed `FunctionStatus` to `FunctionInvocationStatus`.
+- Renamed `FunctionInvocationStatus.Failed` to `FunctionInvocationStatus.Exception`.
+- Moved the nested `FunctionInvocationContext` type to be a peer of `FunctionInvokingChatClient` rather than nested within it.
+- Made the `serviceKey` parameters to `AddKeyedChatClient`/`AddKeyedEmbeddingGenerator` nullable.
+- Improved `FunctionInvokingChatClient.GetStreamingResponseAsync` to send back to the inner client all content received until that point, and to stream back to the caller messages it generates (e.g. tool responses).
+- Improved `AddEmbeddingGenerator` and `AddKeyedEmbeddingGenerator` to register for both the generic and non-generic interfaces.
+
+## 9.3.0-preview.1.25114.11
+
+- Updated `OpenTelemetryChatClient`/`OpenTelemetryEmbeddingGenerator` to conform to the latest 1.30.0 draft specification of the Semantic Conventions for Generative AI systems.
+
+## 9.1.0-preview.1.25064.3
+
+- Added `FunctionInvokingChatClient.CurrentContext` to give functions access to detailed function invocation information.
+- Updated `OpenTelemetryChatClient`/`OpenTelemetryEmbeddingGenerator` to conform to the latest 1.29.0 draft specification of the Semantic Conventions for Generative AI systems.
+- Updated `FunctionInvokingChatClient` to emit an `Activity`/span around all interactions related to a single chat operation.
+
+## 9.0.1-preview.1.24570.5
+
+- Moved the `AddChatClient`, `AddKeyedChatClient`, `AddEmbeddingGenerator`, and `AddKeyedEmbeddingGenerator` extension methods to the `Microsoft.Extensions.DependencyInjection` namespace, changed them to register singleton instances instead of scoped instances, and changed them to support lambda-less chaining.
+- Renamed `UseChatOptions`/`UseEmbeddingOptions` to `ConfigureOptions`, and changed the behavior to always invoke the delegate with a safely-mutable instance, either a new instance if the caller provided null, or a clone of the provided instance.
+- Renamed the final `Use` method for building a builder to be named `Build`. The inner client instance is passed to the constructor and the `IServiceProvider` is optionally passed to the `Build` method.
+- Added `AsBuilder` extension methods to `IChatClient`/`IEmbeddingGenerator` to create builders from the instances.
+- Changed the `CachingChatClient`/`CachingEmbeddingGenerator`.`GetCacheKey` method to accept a `params ReadOnlySpan<object?>`, included the `ChatOptions`/`EmbeddingGeneratorOptions` as part of the caching key, and reduced memory allocation.
+- Added support for anonymous delegating `IChatClient`/`IEmbeddingGenerator` implementations, with `Use` methods on `ChatClientBuilder`/`EmbeddingGeneratorBuilder` that enable the implementations of the core methods to be supplied as lambdas.
+- Changed `UseLogging` to accept an `ILoggerFactory` rather than `ILogger`.
+- Reversed the order of the `IChatClient`/`IEmbeddingGenerator` and `IServiceProvider` arguments to used by one of the `Use` overloads.
+- Added logging capabilities to `FunctionInvokingChatClient`. `UseFunctionInvocation` now accepts an optional `ILoggerFactory`.
+- Fixed the `FunctionInvokingChatClient` to include usage data for non-streaming completions in the augmented history.
+- Fixed the `FunctionInvokingChatClient` streaming support to appropriately fail for multi-choice completions.
+- Fixed the `FunctionInvokingChatClient` to stop yielding function calling content that was already being handled.
+- Improved the documentation.
+
+## 9.0.0-preview.9.24556.5
+
+- Added `UseEmbeddingGenerationOptions` and corresponding `ConfigureOptionsEmbeddingGenerator`.
+
+## 9.0.0-preview.9.24525.1
+
+- Added new `AIJsonUtilities` and `AIJsonSchemaCreateOptions` classes.
+- Made `AIFunctionFactory.Create` safe for use with Native AOT.
+- Simplified the set of `AIFunctionFactory.Create` overloads.
+- Changed the default for `FunctionInvokingChatClient.ConcurrentInvocation` from `true` to `false`.
+- Improved the readability of JSON generated as part of logging.
+- Fixed handling of generated JSON schema names when using arrays or generic types.
+- Improved `CachingChatClient`'s coalescing of streaming updates, including reduced memory allocation and enhanced metadata propagation.
+- Updated `OpenTelemetryChatClient` and `OpenTelemetryEmbeddingGenerator` to conform to the latest 1.28.0 draft specification of the Semantic Conventions for Generative AI systems.
+- Improved `CompleteAsync<T>`'s structured output support to handle primitive types, enums, and arrays.
+
+## 9.0.0-preview.9.24507.7
+
+- Initial Preview

--- a/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Release History
 
+## NOT YET RELEASED
+
+- Added `FunctionInvokingChatClient.AdditionalTools` to allow `FunctionInvokingChatClient` to have access to tools not included in `ChatOptions.Tools` but known to the target service via pre-configuration.
+- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.7.1
+
+- Increased the default `FunctionInvokingChatClient.MaximumIterationsPerRequest` value from 10 to 40.
+- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.7.0
+
+- Added `DistributedCachingChatClient/EmbeddingGenerator.AdditionalCacheKeyValues` to allow adding additional values to the cache key.
+- Allowed a `CachingChatClient` to control per-request caching.
+- Updated the Open Telemetry instrumentation to conform to the latest 1.35.0 draft specification of the Semantic Conventions for Generative AI systems.
+- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.6.0
+
+- Fixed hashing in `CachingChatClient` and `CachingEmbeddingGenerator` to be stable with respect to indentation settings and property ordering.
+- Updated the Open Telemetry instrumentation to conform to the latest 1.34.0 draft specification of the Semantic Conventions for Generative AI systems.
+- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
+## 9.5.0
+
+- Changed `OpenTelemetryChatClient` and `OpenTelemetryEmbeddingGenerator` to consider `AdditionalProperties` to be "sensitive".
+- Changed `FunctionInvokingChatClient` to respect the `SynchronizationContext` of the caller when invoking functions.
+- Changed hash function algorithm used in `CachingChatClient` and `CachingEmbeddingGenerator` to SHA-384 instead of SHA-256.
+- Updated `FunctionInvokingChatClient` to include token counts on its emitted diagnostic spans.
+- Updated `OpenTelemetryChatClient` and `OpenTelemetryEmbeddingGenerator` to conform to the latest 1.33.0 draft specification of the Semantic Conventions for Generative AI systems.
+- Renamed the `useJsonSchema` paramter of `GetResponseAsync<T>`.
+- Removed debug-level logging of updates in `LoggingChatClient`.
+- Avoided caching in `CachingChatClient` when `ConversationId` is set.
+- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
 ## 9.4.4-preview.1.25259.16
 
 - Fixed `CachingChatClient` to avoid caching when `ConversationId` is set.

--- a/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
@@ -3,25 +3,25 @@
 ## NOT YET RELEASED
 
 - Added `FunctionInvokingChatClient.AdditionalTools` to allow `FunctionInvokingChatClient` to have access to tools not included in `ChatOptions.Tools` but known to the target service via pre-configuration.
-- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.7.1
 
 - Increased the default `FunctionInvokingChatClient.MaximumIterationsPerRequest` value from 10 to 40.
-- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.7.0
 
 - Added `DistributedCachingChatClient/EmbeddingGenerator.AdditionalCacheKeyValues` to allow adding additional values to the cache key.
 - Allowed a `CachingChatClient` to control per-request caching.
 - Updated the Open Telemetry instrumentation to conform to the latest 1.35.0 draft specification of the Semantic Conventions for Generative AI systems.
-- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.6.0
 
 - Fixed hashing in `CachingChatClient` and `CachingEmbeddingGenerator` to be stable with respect to indentation settings and property ordering.
 - Updated the Open Telemetry instrumentation to conform to the latest 1.34.0 draft specification of the Semantic Conventions for Generative AI systems.
-- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.5.0
 
@@ -33,7 +33,7 @@
 - Renamed the `useJsonSchema` paramter of `GetResponseAsync<T>`.
 - Removed debug-level logging of updates in `LoggingChatClient`.
 - Avoided caching in `CachingChatClient` when `ConversationId` is set.
-- Updated to accomodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 
 ## 9.4.4-preview.1.25259.16
 


### PR DESCRIPTION
We've had several requests for this.

I reverted the previous deletion, which had changes up until but not including the 9.5 release, and then backfilled for the releases since then based on commit history.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6697)