### PR TITLE
Reapply https://github.com/dotnet/extensions/pull/6205

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Components/Pages/Chat/Chat.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Components/Pages/Chat/Chat.razor
@@ -62,15 +62,6 @@
         chatSuggestions?.Clear();
         await chatInput!.FocusAsync();
 
-@*#if (IsOllama)
-        // Display a new response from the IChatClient, streaming responses
-        // aren't supported because Ollama will not support both streaming and using Tools
-        currentResponseCancellation = new();
-        var response = await ChatClient.GetResponseAsync(messages, chatOptions, currentResponseCancellation.Token);
-
-        // Store responses in the conversation, and begin getting suggestions
-        messages.AddMessages(response);
-#else*@
         // Stream and display a new response from the IChatClient
         var responseText = new TextContent("");
         currentResponseMessage = new ChatMessage(ChatRole.Assistant, [responseText]);
@@ -85,7 +76,6 @@
         // Store the final response in the conversation, and begin getting suggestions
         messages.Add(currentResponseMessage!);
         currentResponseMessage = null;
-@*#endif*@
         chatSuggestions?.Update(messages);
     }
 

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Ollama_Qdrant.verified/aichatweb/aichatweb.Web/Components/Pages/Chat/Chat.razor
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.Ollama_Qdrant.verified/aichatweb/aichatweb.Web/Components/Pages/Chat/Chat.razor
@@ -62,13 +62,20 @@
         chatSuggestions?.Clear();
         await chatInput!.FocusAsync();
 
-        // Display a new response from the IChatClient, streaming responses
-        // aren't supported because Ollama will not support both streaming and using Tools
+        // Stream and display a new response from the IChatClient
+        var responseText = new TextContent("");
+        currentResponseMessage = new ChatMessage(ChatRole.Assistant, [responseText]);
         currentResponseCancellation = new();
-        var response = await ChatClient.GetResponseAsync(messages, chatOptions, currentResponseCancellation.Token);
+        await foreach (var update in ChatClient.GetStreamingResponseAsync([.. messages], chatOptions, currentResponseCancellation.Token))
+        {
+            messages.AddMessages(update, filter: c => c is not TextContent);
+            responseText.Text += update.Text;
+            ChatMessageItem.NotifyChanged(currentResponseMessage);
+        }
 
-        // Store responses in the conversation, and begin getting suggestions
-        messages.AddMessages(response);
+        // Store the final response in the conversation, and begin getting suggestions
+        messages.Add(currentResponseMessage!);
+        currentResponseMessage = null;
         chatSuggestions?.Update(messages);
     }
 


### PR DESCRIPTION
It was lost into oblivion because git thought it was renamed to one of the snapshot files.
https://github.com/dotnet/extensions/commit/34cd461d4f4a53341d791dd1105e1eb1ef33ba6c.patch

```
diff --git a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.BasicAspire--aspire.verified/aichatweb/aichatweb.Web/Components/Pages/Chat/Chat.razor
similarity index 96%
rename from src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
rename to test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.BasicAspire--aspire.verified/aichatweb/aichatweb.Web/Components/Pages/Chat/Chat.razor
index 77626e2d565..5e4f8042add 100644
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData.Web-CSharp/Components/Pages/Chat/Chat.razor
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.BasicAspire--aspire.verified/aichatweb/aichatweb.Web/Components/Pages/Chat/Chat.razor
@@ -103,7 +103,7 @@
     [Description("Searches for information using a phrase or keyword")]
     private async Task<IEnumerable<string>> SearchAsync(
         [Description("The phrase to search for.")] string searchPhrase,
-        [Description("Whenever possible, specify the filename to search that file only. If not provided, the search includes all files.")] string? filenameFilter = null)
+        [Description("If possible, specify the filename to search that file only. If not provided or empty, the search includes all files.")] string? filenameFilter = null)
     {
         await InvokeAsync(StateHasChanged);
         var results = await Search.SearchAsync(searchPhrase, filenameFilter, maxResults: 5);
```

I've updated the snapshot code to ensure it doesn't get lost again.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6706)