### PR TITLE
Fix GetResponseAsync<T> to look at the last message only

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## NOT YET RELEASED
+
+- Fixed `GetResponseAsync<T>` to only look at the contents of the last message in the response.
+
 ## 9.8.0
 
 - Added `FunctionInvokingChatClient.AdditionalTools` to allow `FunctionInvokingChatClient` to have access to tools not included in `ChatOptions.Tools` but known to the target service via pre-configuration.

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatResponse{T}.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatResponse{T}.cs
@@ -127,7 +127,7 @@ public class ChatResponse<T> : ChatResponse
             return _deserializedResult;
         }
 
-        var json = Text;
+        var json = Messages.Count > 0 ? Messages[Messages.Count - 1].Text : string.Empty;
         if (string.IsNullOrEmpty(json))
         {
             failureReason = FailureReason.ResultDidNotContainJson;


### PR DESCRIPTION
It was looking at all messages in the whole response rather than just the last, which is where we expect the JSON to be.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6721)