### PR TITLE
Add unofficial .yml

### DIFF
--- a/azure-pipelines-unofficial.yml
+++ b/azure-pipelines-unofficial.yml
@@ -233,7 +233,6 @@ extends:
             timeoutInMinutes: 180
 
             pool:
-              ${{ if eq(variables['runAsPublic'], 'true') }}:
               name: NetCore1ESPool-Internal
               image: 1es-mariner-2
               os: linux


### PR DESCRIPTION
Adds a .yml file to be used by the new unofficial dev pipeline. This is a straight copy of `azure-pipelines.yml`, with publishing stripped out, and SignType set to `test`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6756)