### PR TITLE
Add support for using ConversationID for AzureOpenAI and OpenAI

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/.template.config/template.json
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/.template.config/template.json
@@ -60,8 +60,15 @@
           "ChatWithCustomData-CSharp.AppHost/**",
           "ChatWithCustomData-CSharp.ServiceDefaults/**",
           "ChatWithCustomData-CSharp.Web/Program.Aspire.cs",
+          "ChatWithCustomData-CSharp.Web/ResponseClientHelper.cs",
           "README.Aspire.md",
           "*.sln"
+        ]
+      },
+      {
+        "condition": "(IsAspire && !IsOpenAI && !IsAzureOpenAI)",
+        "exclude": [
+          "ChatWithCustomData-CSharp.Web/ResponseClientHelper.cs"
         ]
       },
       {

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/ChatWithCustomData-CSharp.Web.csproj.in
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/ChatWithCustomData-CSharp.Web.csproj.in
@@ -5,6 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>d5681fae-b21b-4114-b781-48180f08c0c4</UserSecretsId>
+<!--#if (IsAzureOpenAI || IsOpenAI)
+    <NoWarn>OPENAI001</NoWarn>
+#endif -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Components/Pages/Chat/Chat.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Components/Pages/Chat/Chat.razor
@@ -66,12 +66,22 @@
         var responseText = new TextContent("");
         currentResponseMessage = new ChatMessage(ChatRole.Assistant, [responseText]);
         currentResponseCancellation = new();
+@*#if (IsAzureOpenAI || IsOpenAI)
+        await foreach (var update in ChatClient.GetStreamingResponseAsync([userMessage], chatOptions, currentResponseCancellation.Token))
+        {
+            messages.AddMessages(update, filter: c => c is not TextContent);
+            responseText.Text += update.Text;
+            chatOptions.ConversationId = update.ConversationId; //Update conversation ID from current response
+            ChatMessageItem.NotifyChanged(currentResponseMessage);
+        }
+#else*@
         await foreach (var update in ChatClient.GetStreamingResponseAsync([.. messages], chatOptions, currentResponseCancellation.Token))
         {
             messages.AddMessages(update, filter: c => c is not TextContent);
             responseText.Text += update.Text;
             ChatMessageItem.NotifyChanged(currentResponseMessage);
         }
+@*#endif*@
 
         // Store the final response in the conversation, and begin getting suggestions
         messages.Add(currentResponseMessage!);
@@ -96,6 +106,9 @@
         CancelAnyCurrentResponse();
         messages.Clear();
         messages.Add(new(ChatRole.System, SystemPrompt));
+@*#if (IsAzureOpenAI || IsOpenAI)
+        chatOptions.ConversationId = null;
+#endif*@
         chatSuggestions?.Clear();
         await chatInput!.FocusAsync();
     }

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Program.Aspire.cs
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Program.Aspire.cs
@@ -27,7 +27,7 @@ var openai = builder.AddOpenAIClient("openai");
 #else
 var openai = builder.AddAzureOpenAIClient("openai");
 #endif
-openai.AddChatClient("gpt-4o-mini")
+openai.AddResponsesChatClient("gpt-4o-mini")
     .UseFunctionInvocation()
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Program.cs
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/Program.cs
@@ -47,7 +47,7 @@ IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator = new OllamaApi
 //   dotnet user-secrets set OpenAI:Key YOUR-API-KEY
 var openAIClient = new OpenAIClient(
     new ApiKeyCredential(builder.Configuration["OpenAI:Key"] ?? throw new InvalidOperationException("Missing configuration: OpenAI:Key. See the README for details.")));
-var chatClient = openAIClient.GetChatClient("gpt-4o-mini").AsIChatClient();
+var chatClient = openAIClient.GetOpenAIResponseClient("gpt-4o-mini").AsIChatClient();
 var embeddingGenerator = openAIClient.GetEmbeddingClient("text-embedding-3-small").AsIEmbeddingGenerator();
 #elif (IsAzureAiFoundry)
 
@@ -66,7 +66,7 @@ var azureOpenAi = new AzureOpenAIClient(
 #else
     new ApiKeyCredential(builder.Configuration["AzureOpenAI:Key"] ?? throw new InvalidOperationException("Missing configuration: AzureOpenAi:Key. See the README for details.")));
 #endif
-var chatClient = azureOpenAi.GetChatClient("gpt-4o-mini").AsIChatClient();
+var chatClient = azureOpenAi.GetOpenAIResponseClient("gpt-4o-mini").AsIChatClient();
 var embeddingGenerator = azureOpenAi.GetEmbeddingClient("text-embedding-3-small").AsIEmbeddingGenerator();
 #endif
 

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/ResponseClientHelper.cs
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/ResponseClientHelper.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.AI;
 using Aspire.OpenAI;
 using OpenAI;
 
-//namespace chat.aspire.Web;
 namespace Microsoft.Extensions.Hosting;
 
 public static class ResponseClientHelper

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/ResponseClientHelper.cs
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.Web/ResponseClientHelper.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.AI;
+using Aspire.OpenAI;
+using OpenAI;
+
+//namespace chat.aspire.Web;
+namespace Microsoft.Extensions.Hosting;
+
+public static class ResponseClientHelper
+{
+
+    public static ChatClientBuilder AddResponsesChatClient(this AspireOpenAIClientBuilder builder, string? deploymentName)
+    {
+        ArgumentNullException.ThrowIfNull(builder, "builder");
+
+        return builder.HostBuilder.Services.AddChatClient((IServiceProvider services) => CreateInnerChatClient(services, builder, deploymentName));
+    }
+    private static IChatClient CreateInnerChatClient(IServiceProvider services, AspireOpenAIClientBuilder builder, string? deploymentName)
+    {
+        OpenAIClient openAIClient = builder.ServiceKey is null ? services.GetRequiredService<OpenAIClient>() : services.GetRequiredKeyedService<OpenAIClient>(builder.ServiceKey);
+
+        if (deploymentName is null)
+        {
+            deploymentName = "gpt-4o-mini";
+        }
+
+        IChatClient chatClient = openAIClient.GetOpenAIResponseClient(deploymentName).AsIChatClient();
+
+        if (builder.DisableTracing)
+        {
+            return chatClient;
+        }
+
+        var loggerFactory = services.GetService<ILoggerFactory>();
+        return new OpenTelemetryChatClient(chatClient, loggerFactory?.CreateLogger(typeof(OpenTelemetryChatClient)));
+    }
+}

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.AzureOpenAI_Qdrant_Aspire.verified/aichatweb/aichatweb.Web/Components/Pages/Chat/Chat.razor
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.AzureOpenAI_Qdrant_Aspire.verified/aichatweb/aichatweb.Web/Components/Pages/Chat/Chat.razor
@@ -66,10 +66,11 @@
         var responseText = new TextContent("");
         currentResponseMessage = new ChatMessage(ChatRole.Assistant, [responseText]);
         currentResponseCancellation = new();
-        await foreach (var update in ChatClient.GetStreamingResponseAsync([.. messages], chatOptions, currentResponseCancellation.Token))
+        await foreach (var update in ChatClient.GetStreamingResponseAsync([userMessage], chatOptions, currentResponseCancellation.Token))
         {
             messages.AddMessages(update, filter: c => c is not TextContent);
             responseText.Text += update.Text;
+            chatOptions.ConversationId = update.ConversationId; //Update conversation ID from current response
             ChatMessageItem.NotifyChanged(currentResponseMessage);
         }
 
@@ -96,6 +97,7 @@
         CancelAnyCurrentResponse();
         messages.Clear();
         messages.Add(new(ChatRole.System, SystemPrompt));
+        chatOptions.ConversationId = null;
         chatSuggestions?.Clear();
         await chatInput!.FocusAsync();
     }

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.AzureOpenAI_Qdrant_Aspire.verified/aichatweb/aichatweb.Web/Program.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.AzureOpenAI_Qdrant_Aspire.verified/aichatweb/aichatweb.Web/Program.cs
@@ -4,11 +4,12 @@ using aichatweb.Web.Services;
 using aichatweb.Web.Services.Ingestion;
 
 var builder = WebApplication.CreateBuilder(args);
+
 builder.AddServiceDefaults();
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
 var openai = builder.AddAzureOpenAIClient("openai");
-openai.AddChatClient("gpt-4o-mini")
+openai.AddResponsesChatClient("gpt-4o-mini")
     .UseFunctionInvocation()
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.AzureOpenAI_Qdrant_Aspire.verified/aichatweb/aichatweb.Web/ResponseClientHelper.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.AzureOpenAI_Qdrant_Aspire.verified/aichatweb/aichatweb.Web/ResponseClientHelper.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.AI;
+using Aspire.OpenAI;
+using OpenAI;
+
+//namespace chat.aspire.Web;
+namespace Microsoft.Extensions.Hosting;
+
+public static class ResponseClientHelper
+{
+
+    public static ChatClientBuilder AddResponsesChatClient(this AspireOpenAIClientBuilder builder, string? deploymentName)
+    {
+        ArgumentNullException.ThrowIfNull(builder, "builder");
+
+        return builder.HostBuilder.Services.AddChatClient((IServiceProvider services) => CreateInnerChatClient(services, builder, deploymentName));
+    }
+    private static IChatClient CreateInnerChatClient(IServiceProvider services, AspireOpenAIClientBuilder builder, string? deploymentName)
+    {
+        OpenAIClient openAIClient = builder.ServiceKey is null ? services.GetRequiredService<OpenAIClient>() : services.GetRequiredKeyedService<OpenAIClient>(builder.ServiceKey);
+
+        if (deploymentName is null)
+        {
+            deploymentName = "gpt-4o-mini";
+        }
+
+        IChatClient chatClient = openAIClient.GetOpenAIResponseClient(deploymentName).AsIChatClient();
+
+        if (builder.DisableTracing)
+        {
+            return chatClient;
+        }
+
+        var loggerFactory = services.GetService<ILoggerFactory>();
+        return new OpenTelemetryChatClient(chatClient, loggerFactory?.CreateLogger(typeof(OpenTelemetryChatClient)));
+    }
+}

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.AzureOpenAI_Qdrant_Aspire.verified/aichatweb/aichatweb.Web/aichatweb.Web.csproj
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.AzureOpenAI_Qdrant_Aspire.verified/aichatweb/aichatweb.Web/aichatweb.Web.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>secret</UserSecretsId>
+    <NoWarn>OPENAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.BasicAspire.verified/aichatweb/aichatweb.Web/Program.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.BasicAspire.verified/aichatweb/aichatweb.Web/Program.cs
@@ -9,7 +9,7 @@ builder.AddServiceDefaults();
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
 var openai = builder.AddAzureOpenAIClient("openai");
-openai.AddChatClient("gpt-4o-mini")
+openai.AddResponsesChatClient("gpt-4o-mini")
     .UseFunctionInvocation()
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.OpenAI_AzureAISearch.verified/aichatweb/Components/Pages/Chat/Chat.razor
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.OpenAI_AzureAISearch.verified/aichatweb/Components/Pages/Chat/Chat.razor
@@ -66,10 +66,11 @@
         var responseText = new TextContent("");
         currentResponseMessage = new ChatMessage(ChatRole.Assistant, [responseText]);
         currentResponseCancellation = new();
-        await foreach (var update in ChatClient.GetStreamingResponseAsync([.. messages], chatOptions, currentResponseCancellation.Token))
+        await foreach (var update in ChatClient.GetStreamingResponseAsync([userMessage], chatOptions, currentResponseCancellation.Token))
         {
             messages.AddMessages(update, filter: c => c is not TextContent);
             responseText.Text += update.Text;
+            chatOptions.ConversationId = update.ConversationId; //Update conversation ID from current response
             ChatMessageItem.NotifyChanged(currentResponseMessage);
         }
 
@@ -96,6 +97,7 @@
         CancelAnyCurrentResponse();
         messages.Clear();
         messages.Add(new(ChatRole.System, SystemPrompt));
+        chatOptions.ConversationId = null;
         chatSuggestions?.Clear();
         await chatInput!.FocusAsync();
     }

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.OpenAI_AzureAISearch.verified/aichatweb/Program.cs
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.OpenAI_AzureAISearch.verified/aichatweb/Program.cs
@@ -16,7 +16,7 @@ builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 //   dotnet user-secrets set OpenAI:Key YOUR-API-KEY
 var openAIClient = new OpenAIClient(
     new ApiKeyCredential(builder.Configuration["OpenAI:Key"] ?? throw new InvalidOperationException("Missing configuration: OpenAI:Key. See the README for details.")));
-var chatClient = openAIClient.GetChatClient("gpt-4o-mini").AsIChatClient();
+var chatClient = openAIClient.GetOpenAIResponseClient("gpt-4o-mini").AsIChatClient();
 var embeddingGenerator = openAIClient.GetEmbeddingClient("text-embedding-3-small").AsIEmbeddingGenerator();
 
 // You will need to set the endpoint and key to your own values

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.OpenAI_AzureAISearch.verified/aichatweb/aichatweb.csproj
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/aichatweb.OpenAI_AzureAISearch.verified/aichatweb/aichatweb.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>secret</UserSecretsId>
+    <NoWarn>OPENAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/extensions/issues/6313

Implement support for stateful conversations, enabling the use of conversationID in the Microsoft.Extensions.AI.WebChatTemplate by switching from GetChatClient to GetOpenAIResponseClient. Avoid using the legacy GetChatClient method, as it does not support conversationID.
Use GetOpenAIResponseClient only with providers that support it—namely AzureOpenAI and OpenAI. Avoid using it with Ollama and GitHubModels, which throw runtime errors due to lack of support for the ResponseStreamingChatClient interface.
Work around issue https://github.com/dotnet/aspire/issues/8464, which prevents clean integration of Responses in Aspire-based templates. When using the `--aspire` flag with `dotnet new aichatweb`, create a helper class and modify the endpoint registration in the Aspire builder to route through this helper method. Replace AddChatClient with AddResponsesChatClient to enable Responses while preserving compatibility with Aspire’s composition model.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6770)