### PR TITLE
Factor ChatMessage.Role into ChatResponseUpdate coalescing logic

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
@@ -303,7 +303,7 @@ public static class ChatResponseExtensions
     private static void ProcessUpdate(ChatResponseUpdate update, ChatResponse response)
     {
         // If there is no message created yet, or if the last update we saw had a different
-        // message ID than the newest update, create a new message.
+        // message ID or role than the newest update, create a new message.
         ChatMessage message;
         var isNewMessage = false;
         if (response.Messages.Count == 0)
@@ -313,6 +313,12 @@ public static class ChatResponseExtensions
         else if (update.MessageId is { Length: > 0 } updateMessageId
             && response.Messages[response.Messages.Count - 1].MessageId is string lastMessageId
             && updateMessageId != lastMessageId)
+        {
+            isNewMessage = true;
+        }
+        else if (update.Role is { } updateRole
+            && response.Messages[response.Messages.Count - 1].Role is { } lastRole
+            && updateRole != lastRole)
         {
             isNewMessage = true;
         }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
@@ -29,7 +29,7 @@ public class ChatResponseUpdateExtensionsTests
         ChatResponseUpdate[] updates =
         [
             new(ChatRole.Assistant, "Hello") { ResponseId = "someResponse", MessageId = "12345", CreatedAt = new DateTimeOffset(1, 2, 3, 4, 5, 6, TimeSpan.Zero), ModelId = "model123" },
-            new(new("human"), ", ") { AuthorName = "Someone", AdditionalProperties = new() { ["a"] = "b" } },
+            new(ChatRole.Assistant, ", ") { AuthorName = "Someone", AdditionalProperties = new() { ["a"] = "b" } },
             new(null, "world!") { CreatedAt = new DateTimeOffset(2, 2, 3, 4, 5, 6, TimeSpan.Zero), ConversationId = "123", AdditionalProperties = new() { ["c"] = "d" } },
 
             new() { Contents = [new UsageContent(new() { InputTokenCount = 1, OutputTokenCount = 2 })] },
@@ -53,7 +53,7 @@ public class ChatResponseUpdateExtensionsTests
 
         ChatMessage message = response.Messages.Single();
         Assert.Equal("12345", message.MessageId);
-        Assert.Equal(new ChatRole("human"), message.Role);
+        Assert.Equal(ChatRole.Assistant, message.Role);
         Assert.Equal("Someone", message.AuthorName);
         Assert.Null(message.AdditionalProperties);
 
@@ -63,6 +63,62 @@ public class ChatResponseUpdateExtensionsTests
         Assert.Equal("d", response.AdditionalProperties["c"]);
 
         Assert.Equal("Hello, world!", response.Text);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ToChatResponse_RoleOrIdChangeDictatesMessageChange(bool useAsync)
+    {
+        ChatResponseUpdate[] updates =
+        [
+            new(null, "!") { MessageId = "1" },
+            new(ChatRole.Assistant, "a") { MessageId = "1" },
+            new(ChatRole.Assistant, "b") { MessageId = "2" },
+            new(ChatRole.User, "c") { MessageId = "2" },
+            new(ChatRole.User, "d") { MessageId = "2" },
+            new(ChatRole.Assistant, "e") { MessageId = "3" },
+            new(ChatRole.Tool, "f") { MessageId = "4" },
+            new(ChatRole.Tool, "g") { MessageId = "4" },
+            new(ChatRole.Tool, "h") { MessageId = "5" },
+            new(new("human"), "i") { MessageId = "6" },
+            new(new("human"), "j") { MessageId = "7" },
+            new(new("human"), "k") { MessageId = "7" },
+            new(null, "l") { MessageId = "7" },
+            new(null, "m") { MessageId = "8" },
+        ];
+
+        ChatResponse response = useAsync ?
+            updates.ToChatResponse() :
+            await YieldAsync(updates).ToChatResponseAsync();
+        Assert.Equal(9, response.Messages.Count);
+
+        Assert.Equal("!a", response.Messages[0].Text);
+        Assert.Equal(ChatRole.Assistant, response.Messages[0].Role);
+
+        Assert.Equal("b", response.Messages[1].Text);
+        Assert.Equal(ChatRole.Assistant, response.Messages[1].Role);
+
+        Assert.Equal("cd", response.Messages[2].Text);
+        Assert.Equal(ChatRole.User, response.Messages[2].Role);
+
+        Assert.Equal("e", response.Messages[3].Text);
+        Assert.Equal(ChatRole.Assistant, response.Messages[3].Role);
+
+        Assert.Equal("fg", response.Messages[4].Text);
+        Assert.Equal(ChatRole.Tool, response.Messages[4].Role);
+
+        Assert.Equal("h", response.Messages[5].Text);
+        Assert.Equal(ChatRole.Tool, response.Messages[5].Role);
+
+        Assert.Equal("i", response.Messages[6].Text);
+        Assert.Equal(new ChatRole("human"), response.Messages[6].Role);
+
+        Assert.Equal("jkl", response.Messages[7].Text);
+        Assert.Equal(new ChatRole("human"), response.Messages[7].Role);
+
+        Assert.Equal("m", response.Messages[8].Text);
+        Assert.Equal(ChatRole.Assistant, response.Messages[8].Role);
     }
 
     [Theory]


### PR DESCRIPTION
If the role changes, consider it a new message.

https://github.com/dotnet/extensions/discussions/6731
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6778)