### PR TITLE
Add TextReasoningContent.ProtectedData

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/TextReasoningContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/TextReasoningContent.cs
@@ -38,6 +38,22 @@ public sealed class TextReasoningContent : AIContent
         set => _text = value;
     }
 
+    /// <summary>Gets or sets an optional opaque blob of data associated with this reasoning content.</summary>
+    /// <remarks>
+    /// <para>
+    /// This property is used to store data from a provider that should be roundtripped back to the provider but that is not
+    /// intended for human consumption. It is often encrypted or otherwise redacted information that is only intended to be
+    /// sent back to the provider and not displayed to the user. It's possible for a <see cref="TextReasoningContent"/> to contain
+    /// only <see cref="ProtectedData"/> and have an empty <see cref="Text"/> property. This data also may be associated with
+    /// the corresponding <see cref="Text"/>, acting as a validation signature for it.
+    /// </para>
+    /// <para>
+    /// Note that whereas <see cref="Text"/> can be provider agnostic, <see cref="ProtectedData"/>
+    /// is provider-specific, and is likely to only be understood by the provider that created it.
+    /// </para>
+    /// </remarks>
+    public string? ProtectedData { get; set; }
+
     /// <inheritdoc/>
     public override string ToString() => Text;
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -2422,6 +2422,10 @@
         {
           "Member": "string Microsoft.Extensions.AI.TextReasoningContent.Text { get; set; }",
           "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.TextReasoningContent.ProtectedData { get; set; }",
+          "Stage": "Stable"
         }
       ]
     },

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -17,6 +17,7 @@ using OpenAI.Responses;
 #pragma warning disable S907 // "goto" statement should not be used
 #pragma warning disable S1067 // Expressions should not be too complex
 #pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+#pragma warning disable S3254 // Default parameter values should not be passed as arguments
 #pragma warning disable S3604 // Member initializer values should not be redundant
 #pragma warning disable SA1202 // Elements should be ordered by access
 #pragma warning disable SA1204 // Static elements should appear before instance elements
@@ -149,8 +150,12 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                     ((List<AIContent>)message.Contents).AddRange(ToAIContents(messageItem.Content));
                     break;
 
-                case ReasoningResponseItem reasoningItem when reasoningItem.GetSummaryText() is string summary:
-                    message.Contents.Add(new TextReasoningContent(summary) { RawRepresentation = outputItem });
+                case ReasoningResponseItem reasoningItem:
+                    message.Contents.Add(new TextReasoningContent(reasoningItem.GetSummaryText())
+                    {
+                        ProtectedData = reasoningItem.EncryptedContent,
+                        RawRepresentation = outputItem,
+                    });
                     break;
 
                 case FunctionCallResponseItem functionCall:
@@ -627,7 +632,9 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                             break;
 
                         case TextReasoningContent reasoningContent:
-                            yield return ResponseItem.CreateReasoningItem(reasoningContent.Text);
+                            yield return OpenAIResponsesModelFactory.ReasoningResponseItem(
+                                encryptedContent: reasoningContent.ProtectedData,
+                                summaryText: reasoningContent.Text);
                             break;
 
                         case FunctionCallContent callContent:

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/TextReasoningContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/TextReasoningContentTests.cs
@@ -16,6 +16,7 @@ public class TextReasoningContentTests
         TextReasoningContent c = new(text);
         Assert.Null(c.RawRepresentation);
         Assert.Null(c.AdditionalProperties);
+        Assert.Null(c.ProtectedData);
         Assert.Equal(text ?? string.Empty, c.Text);
     }
 
@@ -46,5 +47,11 @@ public class TextReasoningContentTests
         c.Text = string.Empty;
         Assert.Equal(string.Empty, c.Text);
         Assert.Equal(string.Empty, c.ToString());
+
+        Assert.Null(c.ProtectedData);
+        c.ProtectedData = "protected";
+        Assert.Equal("protected", c.ProtectedData);
+        c.ProtectedData = null;
+        Assert.Null(c.ProtectedData);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/extensions/issues/6510

I considered multiple approaches, including having a separate content type dedicated to encrypted/redacted/protected data, but ended up just extending the existing TextReasoningContent with a new optional ProtectedData property.

Anthropic has thinking content, which is human-readable text that's accompanied by an opaque "signature" blob: that's representable with the thinking as Text and the signature as ProtectedData. It also has redacted thinking content, which is just an opaque data string, which we can represent with empty Text and data as ProtectedData.

OpenAI lets users of the Responses API opt-in to including an encrypted version of the reasoning trace in their output, which is most useful when the developer also opts-out of storing the responses in the service and thus needs to roundtrip the data back. By default, reasoning output only includes human-readable text, but if opted into encrypted reasoning, the output items will typically include both the summary human-readable text and the encrypted data. That can be modeled using Text for the summary (as we do today) and ProtectedData for the encrypted content.

AWS Bedrock exposes reasoning via a ReasoningContentBlock, which has both reasoningText (human readable) and reasoningContent (opaque encrypted content). However, it'll only ever use one of them in each instance, so we can end up with either Text being non-empty or ProtectedData being non-null.

Gemini has a Part that has both a thought (human readable) and thoughtSignature (opaque data), which we can represent as Text and ProtectedData, respectively.

The one thing gnawing at me is that we have Text right now as always returning a non-null string: if you give it null, it gives you back empty. That means the only way we have to distinguish "only ProtectedData" from "Text and ProtectedData" is if Text is empty. Other than bugs, I don't think there are real situations where one of these services sends back empty Text, but if we find that can happen, we might either need to take a (non-binary breaking) change to have Text be nullable, or add some sort of additional property to the instance that specifies what kind of data it carries.