### PR TITLE
Expose response format conversions for OpenAI types

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NOT YET RELEASED
 
+- Added M.E.AI to OpenAI conversions for response format types
+
 ## 9.9.0-preview.1.25458.4
 
 - Updated to depend on OpenAI 2.4.0

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIChatExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIChatExtensions.cs
@@ -26,6 +26,15 @@ public static class MicrosoftExtensionsAIChatExtensions
     public static ChatTool AsOpenAIChatTool(this AIFunctionDeclaration function) =>
         OpenAIChatClient.ToOpenAIChatTool(Throw.IfNull(function));
 
+    /// <summary>
+    /// Creates an OpenAI <see cref="ChatResponseFormat"/> from a <see cref="Microsoft.Extensions.AI.ChatResponseFormat"/>.
+    /// </summary>
+    /// <param name="format">The format.</param>
+    /// <param name="options">The options to use when interpreting the format.</param>
+    /// <returns>The converted OpenAI <see cref="ChatResponseFormat"/>.</returns>
+    public static ChatResponseFormat? AsOpenAIChatResponseFormat(this Microsoft.Extensions.AI.ChatResponseFormat? format, ChatOptions? options = null) =>
+        OpenAIChatClient.ToOpenAIChatResponseFormat(format, options);
+
     /// <summary>Creates a sequence of OpenAI <see cref="ChatMessage"/> instances from the specified input messages.</summary>
     /// <param name="messages">The input messages to convert.</param>
     /// <param name="options">The options employed while processing <paramref name="messages"/>.</param>

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
@@ -21,6 +21,15 @@ public static class MicrosoftExtensionsAIResponsesExtensions
     public static FunctionTool AsOpenAIResponseTool(this AIFunctionDeclaration function) =>
         OpenAIResponsesChatClient.ToResponseTool(Throw.IfNull(function));
 
+    /// <summary>
+    /// Creates an OpenAI <see cref="ResponseTextFormat"/> from a <see cref="ChatResponseFormat"/>.
+    /// </summary>
+    /// <param name="format">The format.</param>
+    /// <param name="options">The options to use when interpreting the format.</param>
+    /// <returns>The converted OpenAI <see cref="ResponseTextFormat"/>.</returns>
+    public static ResponseTextFormat? AsOpenAIResponseTextFormat(this ChatResponseFormat? format, ChatOptions? options = null) =>
+        OpenAIResponsesChatClient.ToOpenAIResponseTextFormat(format, options);
+
     /// <summary>Creates a sequence of OpenAI <see cref="ResponseItem"/> instances from the specified input messages.</summary>
     /// <param name="messages">The input messages to convert.</param>
     /// <param name="options">The options employed while processing <paramref name="messages"/>.</param>


### PR DESCRIPTION
Primarily to enable `ChatResponseFormat.ForJsonSchema<T>` to be used with the OpenAI response format properties
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6806)