### PR TITLE
Add `IList<AITool>.Add(ResponseTool)` / `AsAITool` extension methods

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added new `ChatResponseFormat.ForJsonSchema` overloads that export a JSON schema from a .NET type.
 - Updated `TextReasoningContent` to include `ProtectedData` for representing encrypted/redacted content.
+- Fixed `MinLength`/`MaxLength`/`Length` attribute mapping in nullable string properties during schema export.
 
 ## 9.9.0
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## NOT YET RELEASED
 
-- Added M.E.AI to OpenAI conversions for response format types
+- Added M.E.AI to OpenAI conversions for response format types.
+- Added `ResponseTool` to `AITool` conversions.
 
 ## 9.9.0-preview.1.25458.4
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
@@ -93,4 +93,46 @@ public static class MicrosoftExtensionsAIResponsesExtensions
             previousResponseId: options?.ConversationId,
             instructions: options?.Instructions);
     }
+
+    /// <summary>Adds the <see cref="ResponseTool"/> to the list of <see cref="AITool"/>s.</summary>
+    /// <param name="tools">The list of <see cref="AITool"/>s to which the provided tool should be added.</param>
+    /// <param name="tool">The <see cref="ResponseTool"/> to add.</param>
+    /// <remarks>
+    /// <see cref="ResponseTool"/> does not derive from <see cref="AITool"/>, so it cannot be added directly to a list of <see cref="AITool"/>s.
+    /// Instead, this method wraps the provided <see cref="ResponseTool"/> in an <see cref="AITool"/> and adds that to the list.
+    /// The <see cref="IChatClient"/> returned by <see cref="OpenAIClientExtensions.AsIChatClient(OpenAIResponseClient)"/> will
+    /// be able to unwrap the <see cref="ResponseTool"/> when it processes the list of tools and use the provided <paramref name="tool"/> as-is.
+    /// </remarks>
+    public static void Add(this IList<AITool> tools, ResponseTool tool)
+    {
+        _ = Throw.IfNull(tools);
+
+        tools.Add(AsAITool(tool));
+    }
+
+    /// <summary>Creates an <see cref="AITool"/> to represent a raw <see cref="ResponseTool"/>.</summary>
+    /// <param name="tool">The tool to wrap as an <see cref="AITool"/>.</param>
+    /// <returns>The <paramref name="tool"/> wrapped as an <see cref="AITool"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// The returned tool is only suitable for use with the <see cref="IChatClient"/> returned by
+    /// <see cref="OpenAIClientExtensions.AsIChatClient(OpenAIResponseClient)"/> (or <see cref="IChatClient"/>s that delegate
+    /// to such an instance). It is likely to be ignored by any other <see cref="IChatClient"/> implementation.
+    /// </para>
+    /// <para>
+    /// When a tool has a corresponding <see cref="AITool"/>-derived type already defined in Microsoft.Extensions.AI,
+    /// such as <see cref="AIFunction"/>, <see cref="HostedWebSearchTool"/>, <see cref="HostedMcpServerTool"/>, or
+    /// <see cref="HostedFileSearchTool"/>, those types should be preferred instead of this method, as they are more portable,
+    /// capable of being respected by any <see cref="IChatClient"/> implementation. This method does not attempt to
+    /// map the supplied <see cref="ResponseTool"/> to any of those types, it simply wraps it as-is:
+    /// the <see cref="IChatClient"/> returned by <see cref="OpenAIClientExtensions.AsIChatClient(OpenAIResponseClient)"/> will
+    /// be able to unwrap the <see cref="ResponseTool"/> when it processes the list of tools.
+    /// </para>
+    /// </remarks>
+    public static AITool AsAITool(this ResponseTool tool)
+    {
+        _ = Throw.IfNull(tool);
+
+        return new OpenAIResponsesChatClient.ResponseToolAITool(tool);
+    }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -414,6 +414,10 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
             {
                 switch (tool)
                 {
+                    case ResponseToolAITool rtat:
+                        result.Tools.Add(rtat.Tool);
+                        break;
+
                     case AIFunctionDeclaration aiFunction:
                         result.Tools.Add(ToResponseTool(aiFunction, options));
                         break;
@@ -876,5 +880,12 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
         {
             filter.ToolNames.Add(toolName);
         }
+    }
+
+    /// <summary>Provides an <see cref="AITool"/> wrapper for a <see cref="ResponseTool"/>.</summary>
+    internal sealed class ResponseToolAITool(ResponseTool tool) : AITool
+    {
+        public ResponseTool Tool => tool;
+        public override string Name => Tool.GetType().Name;
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
@@ -316,7 +316,7 @@ public class OpenAIConversionTests
             updates.Add(update);
         }
 
-        ChatResponse response = updates.ToChatResponse();
+        var response = updates.ToChatResponse();
 
         Assert.Equal("id", response.ResponseId);
         Assert.Equal(ChatFinishReason.ToolCalls, response.FinishReason);
@@ -1174,6 +1174,31 @@ public class OpenAIConversionTests
         var openAIResponse = chatResponse.AsOpenAIResponse(options);
 
         Assert.Equal("response-model-id", openAIResponse.Model);
+    }
+
+    [Fact]
+    public void ListAddResponseTool_AddsToolCorrectly()
+    {
+        Assert.Throws<ArgumentNullException>("tools", () => ((IList<AITool>)null!).Add(ResponseTool.CreateWebSearchTool()));
+        Assert.Throws<ArgumentNullException>("tool", () => new List<AITool>().Add((ResponseTool)null!));
+
+        Assert.Throws<ArgumentNullException>("tool", () => ((ResponseTool)null!).AsAITool());
+
+        ChatOptions options;
+
+        options = new()
+        {
+            Tools = new List<AITool> { ResponseTool.CreateWebSearchTool() },
+        };
+        Assert.Single(options.Tools);
+        Assert.NotNull(options.Tools[0]);
+
+        options = new()
+        {
+            Tools = [ResponseTool.CreateWebSearchTool().AsAITool()],
+        };
+        Assert.Single(options.Tools);
+        Assert.NotNull(options.Tools[0]);
     }
 
     private static async IAsyncEnumerable<T> CreateAsyncEnumerable<T>(IEnumerable<T> source)


### PR DESCRIPTION
For someone that knows they're using an OpenAI Responses IChatClient, they can Add a ResponseTool directly into ChatOptions.Tools, rather than needing to go through RawRepresentationFactory.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6813)