### PR TITLE
Fix HostedCodeInterpreterTool with Responses

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -456,7 +456,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                         }
                         else
                         {
-                            json = """{"type":"code_interpreter","container":"auto"}""";
+                            json = """{"type":"code_interpreter","container":{"type":"auto"}}""";
                         }
 
                         result.Tools.Add(ModelReaderWriter.Read<ResponseTool>(BinaryData.FromString(json)));

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
@@ -22,6 +22,22 @@ public class OpenAIResponseClientIntegrationTests : ChatClientIntegrationTests
     public override Task Caching_AfterFunctionInvocation_FunctionOutputUnchangedAsync() => Task.CompletedTask;
 
     [ConditionalFact]
+    public async Task UseCodeInterpreter_ProducesCodeExecutionResults()
+    {
+        SkipIfNotEnabled();
+
+        var response = await ChatClient.GetResponseAsync("Use the code interpreter to calculate the square root of 42. Return only the nearest integer value and no other text.", new()
+        {
+            Tools = [new HostedCodeInterpreterTool()],
+        });
+        Assert.NotNull(response);
+
+        ChatMessage message = Assert.Single(response.Messages);
+
+        Assert.Equal("6", message.Text);
+    }
+
+    [ConditionalFact]
     public async Task UseWebSearch_AnnotationsReflectResults()
     {
         SkipIfNotEnabled();


### PR DESCRIPTION
When no file IDs are present, we're outputting the wrong JSON.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6817)