### PR TITLE
Fix KeyNotFoundException on HttpRequestLatencyListener.OnEventWritten for uknown event sources

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Latency/Internal/HttpRequestLatencyListener.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Latency/Internal/HttpRequestLatencyListener.cs
@@ -49,7 +49,9 @@ internal sealed class HttpRequestLatencyListener : EventListener
     internal void OnEventWritten(string eventSourceName, string? eventName)
     {
         // If event of interest, add a checkpoint for it.
-        if (eventName != null && _eventToTokenMap[eventSourceName].TryGetValue(eventName, out var token))
+        if (eventName != null
+            && _eventToTokenMap.TryGetValue(eventSourceName, out var tokenMap)
+            && tokenMap.TryGetValue(eventName, out var token))
         {
             LatencyContext.Get()?.AddCheckpoint(token);
         }

--- a/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Latency/Internal/HttpRequestLatencyListenerTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Latency/Internal/HttpRequestLatencyListenerTest.cs
@@ -191,4 +191,19 @@ public class HttpRequestLatencyListenerTest
         lc.Verify(a => a.AddCheckpoint(It.IsAny<CheckpointToken>()),
             Times.Exactly(numHttpEvents + numSocketEvents + numDnsEvents));
     }
+
+    [Fact]
+    public void HttpRequestLatencyListener_OnEventWritten_DoesNotAddCheckpoints_UnknownEvent()
+    {
+        var lcti = HttpMockProvider.GetTokenIssuer();
+        var lc = HttpMockProvider.GetLatencyContext();
+        var context = new HttpClientLatencyContext();
+        context.Set(lc.Object);
+
+        using var listener = HttpMockProvider.GetListener(context, lcti.Object);
+
+        listener.OnEventWritten("System.Runtime", "EventCounters");
+
+        lc.Verify(a => a.AddCheckpoint(It.IsAny<CheckpointToken>()), Times.Never);
+    }
 }


### PR DESCRIPTION
## Description
The current implementation of HttpRequestLatencyListener.OnEventWritten always expects that eventSourceName should be available in the _eventToTokenMap dictionary.
Some events (e.g., EventCounters) bypasses enabled events check causing OnEventWritten to throw KeyNotFoundException.

https://github.com/dotnet/runtime/blob/ac8354e3e94f04fae2d6d942427d025395197f76/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L2187