### PR TITLE
Fix a couple of issues in M.E.AI.OpenAI clients

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Added M.E.AI to OpenAI conversions for response format types.
 - Added `ResponseTool` to `AITool` conversions.
+- Fixed the handling of `HostedCodeInterpreterTool` with Responses when no file IDs were provided.
+- Fixed an issue where requests would fail when AllowMultipleToolCalls was set with no tools provided.
+- Fixed an issue where requests would fail when an AuthorName was provided containing invalid characters.
 
 ## 9.9.0-preview.1.25458.4
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -418,7 +418,6 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
 
         // Handle strongly-typed properties.
         result.MaxOutputTokenCount ??= options.MaxOutputTokens;
-        result.ParallelToolCallsEnabled ??= options.AllowMultipleToolCalls;
         result.PreviousResponseId ??= options.ConversationId;
         result.Temperature ??= options.Temperature;
         result.TopP ??= options.TopP;
@@ -528,6 +527,11 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                         result.Tools.Add(responsesMcpTool);
                         break;
                 }
+            }
+
+            if (result.Tools.Count > 0)
+            {
+                result.ParallelToolCallsEnabled ??= options.AllowMultipleToolCalls;
             }
 
             if (result.ToolChoice is null && result.Tools.Count > 0)

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
@@ -152,6 +152,7 @@ public class OpenAIChatClientTests
 
         var response = await client.GetResponseAsync("hello", new()
         {
+            AllowMultipleToolCalls = false,
             MaxOutputTokens = 10,
             Temperature = 0.5f,
         });
@@ -658,15 +659,46 @@ public class OpenAIChatClientTests
     {
         const string Input = """
             {
-                "messages":[{"role":"user","content":"hello"}],
-                "model":"gpt-4o-mini",
-                "logprobs":true,
-                "top_logprobs":42,
-                "logit_bias":{"12":34},
-                "parallel_tool_calls":false,
-                "user":"12345",
-                "metadata":{"something":"else"},
-                "store":true
+                "metadata": {
+                    "something": "else"
+                },
+                "user": "12345",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "hello"
+                    }
+                ],
+                "model": "gpt-4o-mini",
+                "top_logprobs": 42,
+                "store": true,
+                "logit_bias": {
+                    "12": 34
+                },
+                "logprobs": true,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "description": "",
+                            "name": "GetPersonAge",
+                            "parameters": {
+                                "type": "object",
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                ],
+                "tool_choice": "auto",
+                "parallel_tool_calls": false
             }
             """;
 
@@ -694,6 +726,7 @@ public class OpenAIChatClientTests
         Assert.NotNull(await client.GetResponseAsync("hello", new()
         {
             AllowMultipleToolCalls = false,
+            Tools = [AIFunctionFactory.Create((string name) => 42, "GetPersonAge")],
             RawRepresentationFactory = (c) =>
             {
                 var openAIOptions = new ChatCompletionOptions

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
@@ -159,7 +159,7 @@ public class OpenAIConversionTests
         List<ChatMessage> messages =
         [
             new(ChatRole.System, "You are a helpful assistant."),
-            new(ChatRole.User, "Hello"),
+            new(ChatRole.User, "Hello") { AuthorName = "Jane" },
             new(ChatRole.Assistant,
             [
                 new TextContent("Hi there!"),
@@ -168,9 +168,9 @@ public class OpenAIConversionTests
                     ["param1"] = "value1",
                     ["param2"] = 42
                 }),
-            ]),
+            ]) { AuthorName = "!@#$%John Smith^*)" },
             new(ChatRole.Tool, [new FunctionResultContent("callid123", "theresult")]),
-            new(ChatRole.Assistant, "The answer is 42."),
+            new(ChatRole.Assistant, "The answer is 42.") { AuthorName = "@#$#$@$" },
         ];
 
         ChatOptions? options = withOptions ? new ChatOptions { Instructions = "You talk like a parrot." } : null;
@@ -196,6 +196,7 @@ public class OpenAIConversionTests
 
         UserChatMessage m1 = Assert.IsType<UserChatMessage>(convertedMessages[index + 1], exactMatch: false);
         Assert.Equal("Hello", Assert.Single(m1.Content).Text);
+        Assert.Equal("Jane", m1.ParticipantName);
 
         AssistantChatMessage m2 = Assert.IsType<AssistantChatMessage>(convertedMessages[index + 2], exactMatch: false);
         Assert.Single(m2.Content);
@@ -208,6 +209,7 @@ public class OpenAIConversionTests
             ["param1"] = "value1",
             ["param2"] = 42
         }), JsonSerializer.Deserialize<JsonElement>(tc.FunctionArguments.ToMemory().Span)));
+        Assert.Equal("JohnSmith", m2.ParticipantName);
 
         ToolChatMessage m3 = Assert.IsType<ToolChatMessage>(convertedMessages[index + 3], exactMatch: false);
         Assert.Equal("callid123", m3.ToolCallId);
@@ -215,6 +217,7 @@ public class OpenAIConversionTests
 
         AssistantChatMessage m4 = Assert.IsType<AssistantChatMessage>(convertedMessages[index + 4], exactMatch: false);
         Assert.Equal("The answer is 42.", Assert.Single(m4.Content).Text);
+        Assert.Null(m4.ParticipantName);
     }
 
     [Fact]


### PR DESCRIPTION
1. Setting AllowMultipleToolCalls if there aren't any tools results in failure. Fix it to only set the property if tools have been added.
2. The chat completion service fails if a participant name containing anything other than a constrained set of characters are included. Fix it with a sanitized value.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6827)