### PR TITLE
Increase output token limit for EquivalenceEvaluator

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/EquivalenceEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/EquivalenceEvaluator.cs
@@ -52,7 +52,7 @@ public sealed class EquivalenceEvaluator : IEvaluator
         new ChatOptions
         {
             Temperature = 0.0f,
-            MaxOutputTokens = 1,
+            MaxOutputTokens = 5, // See https://github.com/dotnet/extensions/issues/6814.
             TopP = 1.0f,
             PresencePenalty = 0.0f,
             FrequencyPenalty = 0.0f,


### PR DESCRIPTION
EquivalenceEvaluator was specifying MaxOutputTokens = 1 since its prompt instructs the LLM to produce a response (score) that is a single digit (between 1 and 5).

Turns out that while this works for most models (including the OpenAI models that were used to test the prompt), some models require more than one token for this. For example, looks like Claude requires two tokens for this - see https://github.com/dotnet/extensions/issues/6814).

This PR bumps the MaxOutputTokens to 5 to address the above issue.

Fixes #6814