### PR TITLE
Fix GenerateImagesAsync_SingleImageGeneration integration test

### DIFF
--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ImageGeneratorIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ImageGeneratorIntegrationTests.cs
@@ -43,13 +43,23 @@ public abstract class ImageGeneratorIntegrationTests : IDisposable
 
         Assert.NotNull(response);
         Assert.NotEmpty(response.Contents);
-        Assert.Single(response.Contents);
 
-        var content = response.Contents[0];
-        Assert.IsType<DataContent>(content);
-        var dataContent = (DataContent)content;
-        Assert.False(dataContent.Data.IsEmpty);
-        Assert.StartsWith("image/", dataContent.MediaType, StringComparison.Ordinal);
+        var content = Assert.Single(response.Contents);
+        switch (content)
+        {
+            case UriContent uc:
+                Assert.StartsWith("http", uc.Uri.Scheme, StringComparison.Ordinal);
+                break;
+
+            case DataContent dc:
+                Assert.False(dc.Data.IsEmpty);
+                Assert.StartsWith("image/", dc.MediaType, StringComparison.Ordinal);
+                break;
+
+            default:
+                Assert.Fail($"Unexpected content type: {content.GetType()}");
+                break;
+        }
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Both DataContent and UriContent are valid in responses, and from both OpenAI and Azure OpenAI, I get back a UriContent.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6843)