### PR TITLE
[release/9.9.1] Merge updates from main for MEAI Release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,14 +10,14 @@
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <!--
         When DotNetFinalVersionKind is set to 'release' (only for the release branches),
         the build will produce stable outputs for 'Shipping' packages.
 
         This is used by the Arcade SDK (Publish.proj) to determine if the build is a release build or not.
       -->
-    <DotNetFinalVersionKind />
+    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <!-- Enabling this rule will cause build failures on undocumented public APIs. -->
     <SkipArcadeNoWarnCS1591>true</SkipArcadeNoWarnCS1591>
   </PropertyGroup>

--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="$(MicrosoftMLTokenizersVersion)" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OllamaSharp" Version="5.1.9" />
-    <PackageVersion Include="OpenAI" Version="2.4.0" />
+    <PackageVersion Include="OpenAI" Version="2.5.0" />
     <PackageVersion Include="Polly" Version="8.4.2" />
     <PackageVersion Include="Polly.Core" Version="8.4.2" />
     <PackageVersion Include="Polly.Extensions" Version="8.4.2" />

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## NOT YET RELEASED
 
 - Added new `ChatResponseFormat.ForJsonSchema` overloads that export a JSON schema from a .NET type.
+- Added new `AITool.GetService` virtual method.
 - Updated `TextReasoningContent` to include `ProtectedData` for representing encrypted/redacted content.
 - Fixed `MinLength`/`MaxLength`/`Length` attribute mapping in nullable string properties during schema export.
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/DelegatingAIFunction.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/DelegatingAIFunction.cs
@@ -58,4 +58,14 @@ public class DelegatingAIFunction : AIFunction
     /// <inheritdoc />
     protected override ValueTask<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken) =>
         InnerFunction.InvokeAsync(arguments, cancellationToken);
+
+    /// <inheritdoc />
+    public override object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        _ = Throw.IfNull(serviceType);
+
+        return
+            serviceKey is null && serviceType.IsInstanceOfType(this) ? this :
+            InnerFunction.GetService(serviceType, serviceKey);
+    }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/DelegatingAIFunctionDeclaration.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/DelegatingAIFunctionDeclaration.cs
@@ -45,4 +45,14 @@ internal class DelegatingAIFunctionDeclaration : AIFunctionDeclaration // could 
 
     /// <inheritdoc />
     public override string ToString() => InnerFunction.ToString();
+
+    /// <inheritdoc />
+    public override object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        _ = Throw.IfNull(serviceType);
+
+        return
+            serviceKey is null && serviceType.IsInstanceOfType(this) ? this :
+            InnerFunction.GetService(serviceType, serviceKey);
+    }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -686,6 +686,14 @@
           "Stage": "Stable"
         },
         {
+          "Member": "virtual object? Microsoft.Extensions.AI.AITool.GetService(System.Type serviceType, object? serviceKey = null);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "TService? Microsoft.Extensions.AI.AITool.GetService<TService>(object? serviceKey = null);",
+          "Stage": "Stable"
+        },
+        {
           "Member": "override string Microsoft.Extensions.AI.AITool.ToString();",
           "Stage": "Stable"
         }
@@ -1475,6 +1483,10 @@
       "Methods": [
         {
           "Member": "Microsoft.Extensions.AI.DelegatingAIFunction.DelegatingAIFunction(Microsoft.Extensions.AI.AIFunction innerFunction);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override object? Microsoft.Extensions.AI.DelegatingAIFunction.GetService(System.Type serviceType, object? serviceKey = null);",
           "Stage": "Stable"
         },
         {

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/AITool.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/AITool.cs
@@ -1,10 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using Microsoft.Shared.Collections;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
 
@@ -30,6 +32,35 @@ public abstract class AITool
 
     /// <inheritdoc/>
     public override string ToString() => Name;
+
+    /// <summary>Asks the <see cref="AITool"/> for an object of the specified type <paramref name="serviceType"/>.</summary>
+    /// <param name="serviceType">The type of object being requested.</param>
+    /// <param name="serviceKey">An optional key that can be used to help identify the target service.</param>
+    /// <returns>The found object, otherwise <see langword="null"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="serviceType"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// The purpose of this method is to allow for the retrieval of strongly-typed services that might be provided by the <see cref="AITool"/>,
+    /// including itself or any services it might be wrapping.
+    /// </remarks>
+    public virtual object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        _ = Throw.IfNull(serviceType);
+
+        return
+            serviceKey is null && serviceType.IsInstanceOfType(this) ? this :
+            null;
+    }
+
+    /// <summary>Asks the <see cref="AITool"/> for an object of type <typeparamref name="TService"/>.</summary>
+    /// <typeparam name="TService">The type of the object to be retrieved.</typeparam>
+    /// <param name="serviceKey">An optional key that can be used to help identify the target service.</param>
+    /// <returns>The found object, otherwise <see langword="null"/>.</returns>
+    /// <remarks>
+    /// The purpose of this method is to allow for the retrieval of strongly typed services that may be provided by the <see cref="AITool"/>,
+    /// including itself or any services it might be wrapping.
+    /// </remarks>
+    public TService? GetService<TService>(object? serviceKey = null) =>
+        GetService(typeof(TService), serviceKey) is TService service ? service : default;
 
     /// <summary>Gets the string to display in the debugger for this instance.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NOT YET RELEASED
 
+- Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
+
 ## 9.9.0-preview.1.25458.4
 
 - Updated tool mapping to recognize any `AIFunctionDeclaration`.

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## NOT YET RELEASED
 
+- Updated to depend on OpenAI 2.5.0.
 - Added M.E.AI to OpenAI conversions for response format types.
 - Added `ResponseTool` to `AITool` conversions.
+- Fixed the handling of `HostedCodeInterpreterTool` with Responses when no file IDs were provided.
+- Fixed an issue where requests would fail when AllowMultipleToolCalls was set with no tools provided.
+- Fixed an issue where requests would fail when an AuthorName was provided containing invalid characters.
 
 ## 9.9.0-preview.1.25458.4
 
-- Updated to depend on OpenAI 2.4.0
+- Updated to depend on OpenAI 2.4.0.
 - Updated tool mappings to recognize any `AIFunctionDeclaration`.
 - Updated to accommodate the additions in `Microsoft.Extensions.AI.Abstractions`.
 - Fixed handling of annotated but empty content in the `AsIChatClient` for `AssistantClient`.

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIEmbeddingGenerator.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Shared.Diagnostics;
@@ -11,12 +14,25 @@ using OpenAI.Embeddings;
 
 #pragma warning disable S1067 // Expressions should not be too complex
 #pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+#pragma warning disable EA0011 // Consider removing unnecessary conditional access operator (?)
 
 namespace Microsoft.Extensions.AI;
 
 /// <summary>An <see cref="IEmbeddingGenerator{String, Embedding}"/> for an OpenAI <see cref="EmbeddingClient"/>.</summary>
 internal sealed class OpenAIEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
 {
+    // This delegate instance is used to call the internal overload of GenerateEmbeddingsAsync that accepts
+    // a RequestOptions. This should be replaced once a better way to pass RequestOptions is available.
+    private static readonly Func<EmbeddingClient, IEnumerable<string>, OpenAI.Embeddings.EmbeddingGenerationOptions, RequestOptions, Task<ClientResult<OpenAIEmbeddingCollection>>>?
+        _generateEmbeddingsAsync =
+        (Func<EmbeddingClient, IEnumerable<string>, OpenAI.Embeddings.EmbeddingGenerationOptions, RequestOptions, Task<ClientResult<OpenAIEmbeddingCollection>>>?)
+        typeof(EmbeddingClient)
+        .GetMethod(
+            nameof(EmbeddingClient.GenerateEmbeddingsAsync), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            null, [typeof(IEnumerable<string>), typeof(OpenAI.Embeddings.EmbeddingGenerationOptions), typeof(RequestOptions)], null)
+        ?.CreateDelegate(
+            typeof(Func<EmbeddingClient, IEnumerable<string>, OpenAI.Embeddings.EmbeddingGenerationOptions, RequestOptions, Task<ClientResult<OpenAIEmbeddingCollection>>>));
+
     /// <summary>Metadata about the embedding generator.</summary>
     private readonly EmbeddingGeneratorMetadata _metadata;
 
@@ -49,7 +65,10 @@ internal sealed class OpenAIEmbeddingGenerator : IEmbeddingGenerator<string, Emb
     {
         OpenAI.Embeddings.EmbeddingGenerationOptions? openAIOptions = ToOpenAIOptions(options);
 
-        var embeddings = (await _embeddingClient.GenerateEmbeddingsAsync(values, openAIOptions, cancellationToken).ConfigureAwait(false)).Value;
+        var t = _generateEmbeddingsAsync is not null ?
+            _generateEmbeddingsAsync(_embeddingClient, values, openAIOptions, cancellationToken.ToRequestOptions(streaming: false)) :
+            _embeddingClient.GenerateEmbeddingsAsync(values, openAIOptions, cancellationToken);
+        var embeddings = (await t.ConfigureAwait(false)).Value;
 
         return new(embeddings.Select(e =>
                 new Embedding<float>(e.ToFloats())

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -65,12 +65,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
 
         _responseClient = responseClient;
 
-        // https://github.com/openai/openai-dotnet/issues/662
-        // Update to avoid reflection once OpenAIResponseClient.Model is exposed publicly.
-        string? model = typeof(OpenAIResponseClient).GetField("_model", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-            ?.GetValue(responseClient) as string;
-
-        _metadata = new("openai", responseClient.Endpoint, model);
+        _metadata = new("openai", responseClient.Endpoint, responseClient.Model);
     }
 
     /// <inheritdoc />
@@ -418,7 +413,6 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
 
         // Handle strongly-typed properties.
         result.MaxOutputTokenCount ??= options.MaxOutputTokens;
-        result.ParallelToolCallsEnabled ??= options.AllowMultipleToolCalls;
         result.PreviousResponseId ??= options.ConversationId;
         result.Temperature ??= options.Temperature;
         result.TopP ??= options.TopP;
@@ -469,27 +463,19 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                         break;
 
                     case HostedCodeInterpreterTool codeTool:
-                        string json;
-                        if (codeTool.Inputs is { Count: > 0 } inputs)
-                        {
-                            string jsonArray = JsonSerializer.Serialize(
-                                inputs.OfType<HostedFileContent>().Select(c => c.FileId),
-                                OpenAIJsonContext.Default.IEnumerableString);
-                            json = $$"""{"type":"code_interpreter","container":{"type":"auto",files:{{jsonArray}}} }""";
-                        }
-                        else
-                        {
-                            json = """{"type":"code_interpreter","container":{"type":"auto"}}""";
-                        }
-
-                        result.Tools.Add(ModelReaderWriter.Read<ResponseTool>(BinaryData.FromString(json)));
+                        result.Tools.Add(
+                            ResponseTool.CreateCodeInterpreterTool(
+                                new CodeInterpreterToolContainer(codeTool.Inputs?.OfType<HostedFileContent>().Select(f => f.FileId).ToList() is { Count: > 0 } ids ?
+                                    CodeInterpreterToolContainerConfiguration.CreateAutomaticContainerConfiguration(ids) :
+                                    new())));
                         break;
 
                     case HostedMcpServerTool mcpTool:
                         McpTool responsesMcpTool = ResponseTool.CreateMcpTool(
                             mcpTool.ServerName,
                             mcpTool.Url,
-                            mcpTool.Headers);
+                            serverDescription: mcpTool.ServerDescription,
+                            headers: mcpTool.Headers);
 
                         if (mcpTool.AllowedTools is not null)
                         {
@@ -528,6 +514,11 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                         result.Tools.Add(responsesMcpTool);
                         break;
                 }
+            }
+
+            if (result.Tools.Count > 0)
+            {
+                result.ParallelToolCallsEnabled ??= options.AllowMultipleToolCalls;
             }
 
             if (result.ToolChoice is null && result.Tools.Count > 0)
@@ -673,8 +664,8 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                             break;
 
                         case McpServerToolApprovalRequestContent mcpApprovalRequestContent:
-                            // BUG https://github.com/openai/openai-dotnet/issues/664: Needs to be able to set an approvalRequestId
                             yield return ResponseItem.CreateMcpApprovalRequestItem(
+                                mcpApprovalRequestContent.Id,
                                 mcpApprovalRequestContent.ToolCall.ServerName,
                                 mcpApprovalRequestContent.ToolCall.ToolName,
                                 BinaryData.FromBytes(JsonSerializer.SerializeToUtf8Bytes(mcpApprovalRequestContent.ToolCall.Arguments!, OpenAIJsonContext.Default.IReadOnlyDictionaryStringObject)));
@@ -910,5 +901,15 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
     {
         public ResponseTool Tool => tool;
         public override string Name => Tool.GetType().Name;
+
+        /// <inheritdoc />
+        public override object? GetService(Type serviceType, object? serviceKey = null)
+        {
+            _ = Throw.IfNull(serviceType);
+
+            return
+                serviceKey is null && serviceType.IsInstanceOfType(Tool) ? Tool :
+                base.GetService(serviceType, serviceKey);
+        }
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## NOT YET RELEASED
 
-- Updated the EnableSensitiveData properties on OpenTelemetryChatClient/EmbeddingGenerator to respect a OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT environment variable.
-- Added OpenTelemetryImageGenerator to provide OpenTelemetry instrumentation for IImageGenerator implementations.
+- Updated the `EnableSensitiveData` properties on `OpenTelemetryChatClient/EmbeddingGenerator` to respect a `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable.
+- Updated `OpenTelemetryChatClient/EmbeddingGenerator` to emit recent additions to the OpenTelemetry Semantic Conventions for Generative AI systems.
+- Added `OpenTelemetryImageGenerator` to provide OpenTelemetry instrumentation for `IImageGenerator` implementations.
 
 ## 9.9.0
 

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -430,7 +430,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
         List<ChatMessage> originalMessages = [.. messages];
         messages = originalMessages;
 
-        ApprovalRequiredAIFunction[]? approvalRequiredFunctions = null; // available tools that require approval
+        AITool[]? approvalRequiredFunctions = null; // available tools that require approval
         List<ChatMessage>? augmentedHistory = null; // the actual history of messages sent on turns other than the first
         List<FunctionCallContent>? functionCallContents = null; // function call contents that need responding to in the current turn
         List<ChatMessage>? responseMessages = null; // tracked list of messages, across multiple turns, to be used in fallback cases to reconstitute history
@@ -539,7 +539,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
                     approvalRequiredFunctions =
                         (options?.Tools ?? Enumerable.Empty<AITool>())
                         .Concat(AdditionalTools ?? Enumerable.Empty<AITool>())
-                        .OfType<ApprovalRequiredAIFunction>()
+                        .Where(t => t.GetService<ApprovalRequiredAIFunction>() is not null)
                         .ToArray();
                 }
 
@@ -741,7 +741,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
                 for (int i = 0; i < count; i++)
                 {
                     AITool tool = toolList[i];
-                    anyRequireApproval |= tool is ApprovalRequiredAIFunction;
+                    anyRequireApproval |= tool.GetService<ApprovalRequiredAIFunction>() is not null;
                     map[tool.Name] = tool;
                 }
             }
@@ -1475,7 +1475,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
     /// </summary>
     private static (bool hasApprovalRequiringFcc, int lastApprovalCheckedFCCIndex) CheckForApprovalRequiringFCC(
         List<FunctionCallContent>? functionCallContents,
-        ApprovalRequiredAIFunction[] approvalRequiredFunctions,
+        AITool[] approvalRequiredFunctions,
         bool hasApprovalRequiringFcc,
         int lastApprovalCheckedFCCIndex)
     {
@@ -1556,7 +1556,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
                     {
                         foreach (var t in toolMap)
                         {
-                            if (t.Value is ApprovalRequiredAIFunction araf && araf.Name == functionCall.Name)
+                            if (t.Value.GetService<ApprovalRequiredAIFunction>() is { } araf && araf.Name == functionCall.Name)
                             {
                                 anyApprovalRequired = true;
                                 break;

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/.template.config/template.json
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/.template.config/template.json
@@ -499,6 +499,12 @@
       "valueTransform": "vectorStoreIndexNameTransform",
       "replaces": "data-ChatWithCustomData-CSharp.Web-"
     },
+    "aspireClassNameReplacer": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "aspireClassName_ReplaceInvalidChars",
+      "replaces": "ChatWithCustomData_CSharp_Web_AspireClassName"
+    },
     "webProjectNamespaceAdjuster": {
       "type": "generated",
       "generator": "switch",
@@ -524,6 +530,12 @@
     }
   },
   "forms": {
+    "aspireClassName_ReplaceInvalidChars": {
+      "identifier": "replace",
+      "pattern": "(((?<=\\.)|^)(?=\\d)|\\W)",
+      "replacement": "_",
+      "description": "Insert underscore before digits at start, or after a dot, or to replace non-word characters"
+    },
     "vectorStoreIndexNameTransform": {
       "identifier": "chain",
       "steps": [

--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.AppHost/Program.cs
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/src/ChatWithCustomData/ChatWithCustomData-CSharp.AppHost/Program.cs
@@ -51,7 +51,7 @@ var vectorDB = builder.AddQdrant("vectordb")
 #else // UseLocalVectorStore
 #endif
 
-var webApp = builder.AddProject<Projects.ChatWithCustomData_CSharp_Web>("aichatweb-app");
+var webApp = builder.AddProject<Projects.ChatWithCustomData_CSharp_Web_AspireClassName_Web>("aichatweb-app");
 #if (IsOllama) // AI SERVICE PROVIDER REFERENCES
 webApp
     .WithReference(chat)

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Functions/DelegatingAIFunctionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Functions/DelegatingAIFunctionTests.cs
@@ -20,7 +20,7 @@ public class DelegatingAIFunctionTests
     [Fact]
     public void DefaultOverrides_DelegateToInnerFunction()
     {
-        AIFunction expected = AIFunctionFactory.Create(() => 42);
+        AIFunction expected = new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => 42));
         DerivedFunction actual = new(expected);
 
         Assert.Same(expected, actual.InnerFunction);
@@ -32,6 +32,7 @@ public class DelegatingAIFunctionTests
         Assert.Same(expected.UnderlyingMethod, actual.UnderlyingMethod);
         Assert.Same(expected.AdditionalProperties, actual.AdditionalProperties);
         Assert.Equal(expected.ToString(), actual.ToString());
+        Assert.Same(expected, actual.GetService<ApprovalRequiredAIFunction>());
     }
 
     private sealed class DerivedFunction(AIFunction innerFunction) : DelegatingAIFunction(innerFunction)

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/AIToolTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/AIToolTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Xunit;
 
 namespace Microsoft.Extensions.AI;
@@ -15,6 +16,28 @@ public class AIToolTests
         Assert.Equal(nameof(DerivedAITool), tool.ToString());
         Assert.Empty(tool.Description);
         Assert.Empty(tool.AdditionalProperties);
+    }
+
+    [Fact]
+    public void GetService_ReturnsExpectedObject()
+    {
+        DerivedAITool tool = new();
+
+        Assert.Throws<ArgumentNullException>("serviceType", () => tool.GetService(null!));
+
+        Assert.Same(tool, tool.GetService(typeof(object)));
+        Assert.Same(tool, tool.GetService(typeof(AITool)));
+        Assert.Same(tool, tool.GetService(typeof(DerivedAITool)));
+
+        Assert.Same(tool, tool.GetService<object>());
+        Assert.Same(tool, tool.GetService<AITool>());
+        Assert.Same(tool, tool.GetService<DerivedAITool>());
+
+        Assert.Null(tool.GetService(typeof(string)));
+        Assert.Null(tool.GetService<string>());
+        Assert.Null(tool.GetService<object>("key"));
+        Assert.Null(tool.GetService<AITool>("key"));
+        Assert.Null(tool.GetService<DerivedAITool>("key"));
     }
 
     private sealed class DerivedAITool : AITool;

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
@@ -152,6 +152,7 @@ public class OpenAIChatClientTests
 
         var response = await client.GetResponseAsync("hello", new()
         {
+            AllowMultipleToolCalls = false,
             MaxOutputTokens = 10,
             Temperature = 0.5f,
         });
@@ -658,15 +659,46 @@ public class OpenAIChatClientTests
     {
         const string Input = """
             {
-                "messages":[{"role":"user","content":"hello"}],
-                "model":"gpt-4o-mini",
-                "logprobs":true,
-                "top_logprobs":42,
-                "logit_bias":{"12":34},
-                "parallel_tool_calls":false,
-                "user":"12345",
-                "metadata":{"something":"else"},
-                "store":true
+                "metadata": {
+                    "something": "else"
+                },
+                "user": "12345",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "hello"
+                    }
+                ],
+                "model": "gpt-4o-mini",
+                "top_logprobs": 42,
+                "store": true,
+                "logit_bias": {
+                    "12": 34
+                },
+                "logprobs": true,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "description": "",
+                            "name": "GetPersonAge",
+                            "parameters": {
+                                "type": "object",
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                ],
+                "tool_choice": "auto",
+                "parallel_tool_calls": false
             }
             """;
 
@@ -694,6 +726,7 @@ public class OpenAIChatClientTests
         Assert.NotNull(await client.GetResponseAsync("hello", new()
         {
             AllowMultipleToolCalls = false,
+            Tools = [AIFunctionFactory.Create((string name) => 42, "GetPersonAge")],
             RawRepresentationFactory = (c) =>
             {
                 var openAIOptions = new ChatCompletionOptions
@@ -1584,6 +1617,19 @@ public class OpenAIChatClientTests
             { "OutputTokenDetails.AcceptedPredictionTokenCount", 0 },
             { "OutputTokenDetails.RejectedPredictionTokenCount", 0 },
         }, response.Usage.AdditionalCounts);
+    }
+
+    [Fact]
+    public async Task RequestHeaders_UserAgent_ContainsMEAI()
+    {
+        using var handler = new ThrowUserAgentExceptionHandler();
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateChatClient(httpClient, "gpt-4o-mini");
+
+        InvalidOperationException e = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetResponseAsync("hello"));
+
+        Assert.StartsWith("User-Agent header: OpenAI", e.Message);
+        Assert.Contains("MEAI", e.Message);
     }
 
     private static IChatClient CreateChatClient(HttpClient httpClient, string modelId) =>

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/ThrowUserAgentExceptionHandler.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/ThrowUserAgentExceptionHandler.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.AI;
+
+internal sealed class ThrowUserAgentExceptionHandler : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException($"User-Agent header: {request.Headers.UserAgent}");
+}

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Microsoft.Extensions.AI.Templates.Tests.csproj
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Microsoft.Extensions.AI.Templates.Tests.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\TestUtilities\TestUtilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="Snapshots\**\*.*" />
     <None Include="Snapshots\**\*.*" />
 

--- a/test/TestUtilities/XUnit/EnvironmentVariableConditionAttribute.cs
+++ b/test/TestUtilities/XUnit/EnvironmentVariableConditionAttribute.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.TestUtilities;
+
+/// <summary>
+/// Skips a test based on the value of an environment variable.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true)]
+public class EnvironmentVariableConditionAttribute : Attribute, ITestCondition
+{
+    private string? _currentValue;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnvironmentVariableConditionAttribute"/> class.
+    /// </summary>
+    /// <param name="variableName">Name of the environment variable.</param>
+    /// <param name="values">Value(s) of the environment variable to match for the condition.</param>
+    /// <remarks>
+    /// By default, the test will be run if the value of the variable matches any of the supplied values.
+    /// Set <see cref="RunOnMatch"/> to <c>False</c> to run the test only if the value does not match.
+    /// </remarks>
+    public EnvironmentVariableConditionAttribute(string variableName, params string[] values)
+    {
+        if (string.IsNullOrEmpty(variableName))
+        {
+            throw new ArgumentException("Value cannot be null or empty.", nameof(variableName));
+        }
+
+        if (values == null || values.Length == 0)
+        {
+            throw new ArgumentException("You must supply at least one value to match.", nameof(values));
+        }
+
+        VariableName = variableName;
+        Values = values;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the test should run if the value of the variable matches any
+    /// of the supplied values. If <c>False</c>, the test runs only if the value does not match any of the
+    /// supplied values. Default is <c>True</c>.
+    /// </summary>
+    public bool RunOnMatch { get; set; } = true;
+
+    /// <summary>
+    /// Gets the name of the environment variable.
+    /// </summary>
+    public string VariableName { get; }
+
+    /// <summary>
+    /// Gets the value(s) of the environment variable to match for the condition.
+    /// </summary>
+    public string[] Values { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the condition is met for the configured environment variable and values.
+    /// </summary>
+    public bool IsMet
+    {
+        get
+        {
+            _currentValue ??= Environment.GetEnvironmentVariable(VariableName);
+            var hasMatched = Values.Any(value => string.Equals(value, _currentValue, StringComparison.OrdinalIgnoreCase));
+
+            return RunOnMatch ? hasMatched : !hasMatched;
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating the reason the test was skipped.
+    /// </summary>
+    public string SkipReason
+    {
+        get
+        {
+            var value = _currentValue ?? "(null)";
+
+            return $"Test skipped on environment variable with name '{VariableName}' and value '{value}' " +
+                $"for the '{nameof(RunOnMatch)}' value of '{RunOnMatch}'.";
+        }
+    }
+}


### PR DESCRIPTION
This merges everything from main into release/9.9.1 to prepare for a v9.9.1 release of:

* Microsoft.Extensions.AI
* Microsoft.Extensions.AI.Abstractions
* Microsoft.Extensions.AI.OpenAI
* Microsoft.Extensions.AI.AzureAIInference
* Microsoft.Extensions.AI.Templates

The PR also updates `Versions.props` to prepare for shipping the 9.9.1 release with stable packages.

For reference on all of the differences between `release/9.9` and the result of `release/9.9.1` after this PR:
https://github.com/dotnet/extensions/compare/release/9.9...jeffhandley:extensions:jeffhandley/9.9.1-merge#files_bucket
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6844)