### PR TITLE
add support for background responses

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/BackgroundResponsesOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/BackgroundResponsesOptions.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Options for configuring background responses.</summary>
+[Experimental("MEAI001")]
+public sealed class BackgroundResponsesOptions
+{
+    /// <summary>Initializes a new instance of the <see cref="BackgroundResponsesOptions"/> class.</summary>
+    public BackgroundResponsesOptions()
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="BackgroundResponsesOptions"/> class.</summary>
+    /// <param name="options">The options to initialize from.</param>
+    public BackgroundResponsesOptions(BackgroundResponsesOptions options)
+    {
+        _ = Throw.IfNull(options);
+
+        Allow = options.Allow;
+    }
+
+    /// <summary>Gets or sets a value indicating whether the background responses are allowed.</summary>
+    /// <remarks>
+    /// This property only takes effect if the API it's used with supports background responses.
+    /// If the API does not support background responses, this property will be ignored.
+    /// </remarks>
+    public bool? Allow { get; set; }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Added new `AITool.GetService` virtual method.
 - Updated `TextReasoningContent` to include `ProtectedData` for representing encrypted/redacted content.
 - Fixed `MinLength`/`MaxLength`/`Length` attribute mapping in nullable string properties during schema export.
+- Added `[Experimental]` `ResumptionToken` to represent a base class for continuation tokens.
+- Added `[Experimental]` `BackgroundResponsesOptions` to represent options for background responses.
+- Added `[Experimental]` `ChatOptions.BackgroundResponsesOptions` and `ChatOptions.ContinuationToken` properties specify continuation token and options for background responses.
+- Added `[Experimental]` `ChatResponse.ContinuationToken` and `ChatResponseUpdate.ContinuationToken` to return continuation token for background responses.
+- Added `[Experimental]` `GetResponseAsync` and `GetStreamingResponseAsync` extension methods for `IChatClient` to continue background responses.
 
 ## 9.9.0
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatClientExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatClientExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Shared.Diagnostics;
@@ -120,6 +121,30 @@ public static class ChatClientExtensions
         return client.GetResponseAsync([chatMessage], options, cancellationToken);
     }
 
+    /// <summary>Gets a background response identified by the specified continuation token.</summary>
+    /// <param name="client">The chat client.</param>
+    /// <param name="continuationToken">The continuation token.</param>
+    /// <param name="options">The chat options to configure the request.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The background response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="continuationToken"/> is <see langword="null"/>.</exception>
+    [Experimental("MEAI001")]
+    public static Task<ChatResponse> GetResponseAsync(
+        this IChatClient client,
+        ResumptionToken continuationToken,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(client);
+        _ = Throw.IfNull(continuationToken);
+
+        ChatOptions chatOptions = options ?? new();
+        chatOptions.ContinuationToken = continuationToken;
+
+        return client.GetResponseAsync([], chatOptions, cancellationToken);
+    }
+
     /// <summary>Sends a user chat text message and streams the response messages.</summary>
     /// <param name="client">The chat client.</param>
     /// <param name="chatMessage">The text content for the chat message to send.</param>
@@ -158,5 +183,29 @@ public static class ChatClientExtensions
         _ = Throw.IfNull(chatMessage);
 
         return client.GetStreamingResponseAsync([chatMessage], options, cancellationToken);
+    }
+
+    /// <summary>Gets a background streamed response identified by the specified continuation token and streams its messages.</summary>
+    /// <param name="client">The chat client.</param>
+    /// <param name="continuationToken">The continuation token.</param>
+    /// <param name="options">The chat options to configure the request.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The background response messages.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="continuationToken"/> is <see langword="null"/>.</exception>
+    [Experimental("MEAI001")]
+    public static IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        this IChatClient client,
+        ResumptionToken continuationToken,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(client);
+        _ = Throw.IfNull(continuationToken);
+
+        ChatOptions chatOptions = options ?? new();
+        chatOptions.ContinuationToken = continuationToken;
+
+        return client.GetStreamingResponseAsync([], chatOptions, cancellationToken);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponse.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponse.cs
@@ -88,6 +88,20 @@ public class ChatResponse
     /// <summary>Gets or sets usage details for the chat response.</summary>
     public UsageDetails? Usage { get; set; }
 
+    /// <summary>Gets or sets the continuation token for getting result of the background chat response.</summary>
+    /// <remarks>
+    /// <see cref="IChatClient"/> implementations that support background responses will return
+    /// a continuation token if background responses are enabled in <see cref="ChatOptions.BackgroundResponsesOptions"/>
+    /// and the result of the response has not been obtained yet. Otherwise, the token will be <see langword="null"/>.
+    /// <para>
+    /// This property should be used in conjunction with <see cref="ChatOptions.ContinuationToken"/> to 
+    /// continue or polling for the completion the response. Pass this token to
+    /// <see cref="ChatOptions.ContinuationToken"/> on subsequent calls to <see cref="IChatClient.GetResponseAsync"/>
+    /// to poll for completion.
+    /// </para>
+    /// </remarks>
+    public ResumptionToken? ContinuationToken { get; set; }
+
     /// <summary>Gets or sets the raw representation of the chat response from an underlying implementation.</summary>
     /// <remarks>
     /// If a <see cref="ChatResponse"/> is created to represent some underlying object from another object
@@ -143,6 +157,7 @@ public class ChatResponse
                 ResponseId = ResponseId,
 
                 CreatedAt = message.CreatedAt ?? CreatedAt,
+                ContinuationToken = ContinuationToken,
             };
         }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseUpdate.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseUpdate.cs
@@ -141,6 +141,19 @@ public class ChatResponseUpdate
     /// <inheritdoc/>
     public override string ToString() => Text;
 
+    /// <summary>Gets or sets the continuation token for resuming the streamed chat response of which this update is a part.</summary>
+    /// <remarks>
+    /// <see cref="IChatClient"/> implementations that support background responses will return
+    /// a continuation token on each update if background responses are enabled in <see cref="ChatOptions.BackgroundResponsesOptions"/>
+    /// and not all updates for the response have been streamed yet. Otherwise, the token will be <see langword="null"/>.
+    /// <para>
+    /// This property should be used for stream resumption, where the continuation token of the latest received update should be
+    /// passed to <see cref="ChatOptions.ContinuationToken"/> on subsequent calls to <see cref="IChatClient.GetStreamingResponseAsync"/>
+    /// to resume streaming from the point of interruption.
+    /// </para>
+    /// </remarks>
+    public ResumptionToken? ContinuationToken { get; set; }
+
     /// <summary>Gets a <see cref="AIContent"/> object to display in the debugger display.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private AIContent? ContentForDebuggerDisplay

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -1,5 +1,5 @@
 {
-  "Name": "Microsoft.Extensions.AI.Abstractions, Version=9.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Name": "Microsoft.Extensions.AI.Abstractions, Version=9.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
   "Types": [
     {
       "Type": "sealed class Microsoft.Extensions.AI.AdditionalPropertiesDictionary : Microsoft.Extensions.AI.AdditionalPropertiesDictionary<object?>",
@@ -134,11 +134,11 @@
       ],
       "Properties": [
         {
-          "Member": "System.Collections.Generic.IList<Microsoft.Extensions.AI.AnnotatedRegion>? Microsoft.Extensions.AI.AIAnnotation.AnnotatedRegions { get; set; }",
+          "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.AI.AIAnnotation.AdditionalProperties { get; set; }",
           "Stage": "Stable"
         },
         {
-          "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.AI.AIAnnotation.AdditionalProperties { get; set; }",
+          "Member": "System.Collections.Generic.IList<Microsoft.Extensions.AI.AnnotatedRegion>? Microsoft.Extensions.AI.AIAnnotation.AnnotatedRegions { get; set; }",
           "Stage": "Stable"
         },
         {
@@ -180,15 +180,15 @@
           "Stage": "Stable"
         },
         {
+          "Member": "Microsoft.Extensions.AI.AIFunctionDeclaration Microsoft.Extensions.AI.AIFunction.AsDeclarationOnly();",
+          "Stage": "Stable"
+        },
+        {
           "Member": "System.Threading.Tasks.ValueTask<object?> Microsoft.Extensions.AI.AIFunction.InvokeAsync(Microsoft.Extensions.AI.AIFunctionArguments? arguments = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
           "Stage": "Stable"
         },
         {
           "Member": "abstract System.Threading.Tasks.ValueTask<object?> Microsoft.Extensions.AI.AIFunction.InvokeCoreAsync(Microsoft.Extensions.AI.AIFunctionArguments arguments, System.Threading.CancellationToken cancellationToken);",
-          "Stage": "Stable"
-        },
-        {
-          "Member": "Microsoft.Extensions.AI.AIFunctionDeclaration Microsoft.Extensions.AI.AIFunction.AsDeclarationOnly();",
           "Stage": "Stable"
         }
       ],
@@ -199,26 +199,6 @@
         },
         {
           "Member": "virtual System.Reflection.MethodInfo? Microsoft.Extensions.AI.AIFunction.UnderlyingMethod { get; }",
-          "Stage": "Stable"
-        }
-      ]
-    },
-    {
-      "Type": "abstract class Microsoft.Extensions.AI.AIFunctionDeclaration : Microsoft.Extensions.AI.AITool",
-      "Stage": "Stable",
-      "Methods": [
-        {
-          "Member": "Microsoft.Extensions.AI.AIFunctionDeclaration.AIFunctionDeclaration();",
-          "Stage": "Stable"
-        }
-      ],
-      "Properties": [
-        {
-          "Member": "virtual System.Text.Json.JsonElement Microsoft.Extensions.AI.AIFunctionDeclaration.JsonSchema { get; }",
-          "Stage": "Stable"
-        },
-        {
-          "Member": "virtual System.Text.Json.JsonElement? Microsoft.Extensions.AI.AIFunctionDeclaration.ReturnJsonSchema { get; }",
           "Stage": "Stable"
         }
       ]
@@ -295,6 +275,26 @@
         },
         {
           "Member": "System.Collections.Generic.ICollection<object?> Microsoft.Extensions.AI.AIFunctionArguments.Values { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "abstract class Microsoft.Extensions.AI.AIFunctionDeclaration : Microsoft.Extensions.AI.AITool",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.AIFunctionDeclaration.AIFunctionDeclaration();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "virtual System.Text.Json.JsonElement Microsoft.Extensions.AI.AIFunctionDeclaration.JsonSchema { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "virtual System.Text.Json.JsonElement? Microsoft.Extensions.AI.AIFunctionDeclaration.ReturnJsonSchema { get; }",
           "Stage": "Stable"
         }
       ]
@@ -724,6 +724,16 @@
       ]
     },
     {
+      "Type": "sealed class Microsoft.Extensions.AI.ApprovalRequiredAIFunction : Microsoft.Extensions.AI.DelegatingAIFunction",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.ApprovalRequiredAIFunction.ApprovalRequiredAIFunction(Microsoft.Extensions.AI.AIFunction innerFunction);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
       "Type": "sealed class Microsoft.Extensions.AI.AutoChatToolMode : Microsoft.Extensions.AI.ChatToolMode",
       "Stage": "Stable",
       "Methods": [
@@ -738,6 +748,26 @@
         {
           "Member": "override int Microsoft.Extensions.AI.AutoChatToolMode.GetHashCode();",
           "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.AI.BackgroundResponsesOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.BackgroundResponsesOptions.BackgroundResponsesOptions();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.BackgroundResponsesOptions.BackgroundResponsesOptions(Microsoft.Extensions.AI.BackgroundResponsesOptions options);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool? Microsoft.Extensions.AI.BackgroundResponsesOptions.Allow { get; set; }",
+          "Stage": "Experimental"
         }
       ]
     },
@@ -800,6 +830,10 @@
           "Stage": "Stable"
         },
         {
+          "Member": "static System.Threading.Tasks.Task<Microsoft.Extensions.AI.ChatResponse> Microsoft.Extensions.AI.ChatClientExtensions.GetResponseAsync(this Microsoft.Extensions.AI.IChatClient client, Microsoft.Extensions.AI.ResumptionToken continuationToken, Microsoft.Extensions.AI.BackgroundResponsesOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
           "Member": "static TService? Microsoft.Extensions.AI.ChatClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IChatClient client, object? serviceKey = null);",
           "Stage": "Stable"
         },
@@ -810,6 +844,10 @@
         {
           "Member": "static System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.AI.ChatResponseUpdate> Microsoft.Extensions.AI.ChatClientExtensions.GetStreamingResponseAsync(this Microsoft.Extensions.AI.IChatClient client, Microsoft.Extensions.AI.ChatMessage chatMessage, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
           "Stage": "Stable"
+        },
+        {
+          "Member": "static System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.AI.ChatResponseUpdate> Microsoft.Extensions.AI.ChatClientExtensions.GetStreamingResponseAsync(this Microsoft.Extensions.AI.IChatClient client, Microsoft.Extensions.AI.ResumptionToken continuationToken, Microsoft.Extensions.AI.BackgroundResponsesOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
         }
       ]
     },
@@ -998,15 +1036,23 @@
           "Stage": "Stable"
         },
         {
+          "Member": "Microsoft.Extensions.AI.BackgroundResponsesOptions? Microsoft.Extensions.AI.ChatOptions.BackgroundResponsesOptions { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.ResumptionToken? Microsoft.Extensions.AI.ChatOptions.ContinuationToken { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
           "Member": "string? Microsoft.Extensions.AI.ChatOptions.ConversationId { get; set; }",
           "Stage": "Stable"
         },
         {
-          "Member": "string? Microsoft.Extensions.AI.ChatOptions.Instructions { get; set; }",
+          "Member": "float? Microsoft.Extensions.AI.ChatOptions.FrequencyPenalty { get; set; }",
           "Stage": "Stable"
         },
         {
-          "Member": "float? Microsoft.Extensions.AI.ChatOptions.FrequencyPenalty { get; set; }",
+          "Member": "string? Microsoft.Extensions.AI.ChatOptions.Instructions { get; set; }",
           "Stage": "Stable"
         },
         {
@@ -1087,6 +1133,10 @@
       "Properties": [
         {
           "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.AI.ChatResponse.AdditionalProperties { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.ResumptionToken? Microsoft.Extensions.AI.ChatResponse.ContinuationToken { get; set; }",
           "Stage": "Stable"
         },
         {
@@ -1262,6 +1312,10 @@
           "Stage": "Stable"
         },
         {
+          "Member": "Microsoft.Extensions.AI.ResumptionToken? Microsoft.Extensions.AI.ChatResponseUpdate.ContinuationToken { get; set; }",
+          "Stage": "Stable"
+        },
+        {
           "Member": "string? Microsoft.Extensions.AI.ChatResponseUpdate.ConversationId { get; set; }",
           "Stage": "Stable"
         },
@@ -1412,6 +1466,14 @@
       ],
       "Properties": [
         {
+          "Member": "string? Microsoft.Extensions.AI.CitationAnnotation.FileId { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.CitationAnnotation.Snippet { get; set; }",
+          "Stage": "Stable"
+        },
+        {
           "Member": "string? Microsoft.Extensions.AI.CitationAnnotation.Title { get; set; }",
           "Stage": "Stable"
         },
@@ -1421,14 +1483,6 @@
         },
         {
           "Member": "System.Uri? Microsoft.Extensions.AI.CitationAnnotation.Url { get; set; }",
-          "Stage": "Stable"
-        },
-        {
-          "Member": "string? Microsoft.Extensions.AI.CitationAnnotation.FileId { get; set; }",
-          "Stage": "Stable"
-        },
-        {
-          "Member": "string? Microsoft.Extensions.AI.CitationAnnotation.Snippet { get; set; }",
           "Stage": "Stable"
         }
       ]
@@ -1464,11 +1518,11 @@
           "Stage": "Stable"
         },
         {
-          "Member": "string? Microsoft.Extensions.AI.DataContent.Name { get; set; }",
+          "Member": "string Microsoft.Extensions.AI.DataContent.MediaType { get; }",
           "Stage": "Stable"
         },
         {
-          "Member": "string Microsoft.Extensions.AI.DataContent.MediaType { get; }",
+          "Member": "string? Microsoft.Extensions.AI.DataContent.Name { get; set; }",
           "Stage": "Stable"
         },
         {
@@ -1495,20 +1549,20 @@
         },
         {
           "Member": "override string Microsoft.Extensions.AI.DelegatingAIFunction.ToString();",
-          "Stage": "Experimental"
+          "Stage": "Stable"
         }
       ],
       "Properties": [
-        {
-          "Member": "Microsoft.Extensions.AI.AIFunction Microsoft.Extensions.AI.DelegatingAIFunction.InnerFunction { get; }",
-          "Stage": "Stable"
-        },
         {
           "Member": "override System.Collections.Generic.IReadOnlyDictionary<string, object?> Microsoft.Extensions.AI.DelegatingAIFunction.AdditionalProperties { get; }",
           "Stage": "Stable"
         },
         {
           "Member": "override string Microsoft.Extensions.AI.DelegatingAIFunction.Description { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.AIFunction Microsoft.Extensions.AI.DelegatingAIFunction.InnerFunction { get; }",
           "Stage": "Stable"
         },
         {
@@ -1598,6 +1652,38 @@
         {
           "Member": "Microsoft.Extensions.AI.IEmbeddingGenerator<TInput, TEmbedding> Microsoft.Extensions.AI.DelegatingEmbeddingGenerator<TInput, TEmbedding>.InnerGenerator { get; }",
           "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.AI.DelegatingImageGenerator : Microsoft.Extensions.AI.IImageGenerator, System.IDisposable",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.DelegatingImageGenerator.DelegatingImageGenerator(Microsoft.Extensions.AI.IImageGenerator innerGenerator);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void Microsoft.Extensions.AI.DelegatingImageGenerator.Dispose();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual void Microsoft.Extensions.AI.DelegatingImageGenerator.Dispose(bool disposing);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageGenerationResponse> Microsoft.Extensions.AI.DelegatingImageGenerator.GenerateAsync(Microsoft.Extensions.AI.ImageGenerationRequest request, Microsoft.Extensions.AI.ImageGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual object? Microsoft.Extensions.AI.DelegatingImageGenerator.GetService(System.Type serviceType, object? serviceKey = null);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.IImageGenerator Microsoft.Extensions.AI.DelegatingImageGenerator.InnerGenerator { get; }",
+          "Stage": "Experimental"
         }
       ]
     },
@@ -1800,6 +1886,46 @@
       ]
     },
     {
+      "Type": "sealed class Microsoft.Extensions.AI.FunctionApprovalRequestContent : Microsoft.Extensions.AI.UserInputRequestContent",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.FunctionApprovalRequestContent.FunctionApprovalRequestContent(string id, Microsoft.Extensions.AI.FunctionCallContent functionCall);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.FunctionApprovalResponseContent Microsoft.Extensions.AI.FunctionApprovalRequestContent.CreateResponse(bool approved);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.FunctionCallContent Microsoft.Extensions.AI.FunctionApprovalRequestContent.FunctionCall { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.AI.FunctionApprovalResponseContent : Microsoft.Extensions.AI.UserInputResponseContent",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.FunctionApprovalResponseContent.FunctionApprovalResponseContent(string id, bool approved, Microsoft.Extensions.AI.FunctionCallContent functionCall);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.AI.FunctionApprovalResponseContent.Approved { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.FunctionCallContent Microsoft.Extensions.AI.FunctionApprovalResponseContent.FunctionCall { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
       "Type": "sealed class Microsoft.Extensions.AI.FunctionCallContent : Microsoft.Extensions.AI.AIContent",
       "Stage": "Stable",
       "Methods": [
@@ -1948,6 +2074,22 @@
       ]
     },
     {
+      "Type": "sealed class Microsoft.Extensions.AI.HostedFileContent : Microsoft.Extensions.AI.AIContent",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.HostedFileContent.HostedFileContent(string fileId);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.AI.HostedFileContent.FileId { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
       "Type": "class Microsoft.Extensions.AI.HostedFileSearchTool : Microsoft.Extensions.AI.AITool",
       "Stage": "Stable",
       "Methods": [
@@ -1968,28 +2110,126 @@
       ]
     },
     {
-      "Type": "class Microsoft.Extensions.AI.HostedWebSearchTool : Microsoft.Extensions.AI.AITool",
-      "Stage": "Stable",
+      "Type": "class Microsoft.Extensions.AI.HostedMcpServerTool : Microsoft.Extensions.AI.AITool",
+      "Stage": "Experimental",
       "Methods": [
         {
-          "Member": "Microsoft.Extensions.AI.HostedWebSearchTool.HostedWebSearchTool();",
-          "Stage": "Stable"
-        }
-      ]
-    },
-    {
-      "Type": "sealed class Microsoft.Extensions.AI.HostedFileContent : Microsoft.Extensions.AI.AIContent",
-      "Stage": "Stable",
-      "Methods": [
+          "Member": "Microsoft.Extensions.AI.HostedMcpServerTool.HostedMcpServerTool(string serverName, string url);",
+          "Stage": "Experimental"
+        },
         {
-          "Member": "Microsoft.Extensions.AI.HostedFileContent.HostedFileContent(string fileId);",
-          "Stage": "Stable"
+          "Member": "Microsoft.Extensions.AI.HostedMcpServerTool.HostedMcpServerTool(string serverName, System.Uri url);",
+          "Stage": "Experimental"
         }
       ],
       "Properties": [
         {
-          "Member": "string Microsoft.Extensions.AI.HostedFileContent.FileId { get; set; }",
-          "Stage": "Stable"
+          "Member": "System.Collections.Generic.IList<string>? Microsoft.Extensions.AI.HostedMcpServerTool.AllowedTools { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.HostedMcpServerToolApprovalMode? Microsoft.Extensions.AI.HostedMcpServerTool.ApprovalMode { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, string>? Microsoft.Extensions.AI.HostedMcpServerTool.Headers { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.HostedMcpServerTool.ServerDescription { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.AI.HostedMcpServerTool.ServerName { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Uri Microsoft.Extensions.AI.HostedMcpServerTool.Url { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.AI.HostedMcpServerToolAlwaysRequireApprovalMode : Microsoft.Extensions.AI.HostedMcpServerToolApprovalMode",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.HostedMcpServerToolAlwaysRequireApprovalMode.HostedMcpServerToolAlwaysRequireApprovalMode();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.AI.HostedMcpServerToolAlwaysRequireApprovalMode.Equals(object? obj);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.AI.HostedMcpServerToolAlwaysRequireApprovalMode.GetHashCode();",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.AI.HostedMcpServerToolApprovalMode",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.AI.HostedMcpServerToolRequireSpecificApprovalMode Microsoft.Extensions.AI.HostedMcpServerToolApprovalMode.RequireSpecific(System.Collections.Generic.IList<string>? alwaysRequireApprovalToolNames, System.Collections.Generic.IList<string>? neverRequireApprovalToolNames);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static Microsoft.Extensions.AI.HostedMcpServerToolAlwaysRequireApprovalMode Microsoft.Extensions.AI.HostedMcpServerToolApprovalMode.AlwaysRequire { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.AI.HostedMcpServerToolNeverRequireApprovalMode Microsoft.Extensions.AI.HostedMcpServerToolApprovalMode.NeverRequire { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.AI.HostedMcpServerToolNeverRequireApprovalMode : Microsoft.Extensions.AI.HostedMcpServerToolApprovalMode",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.HostedMcpServerToolNeverRequireApprovalMode.HostedMcpServerToolNeverRequireApprovalMode();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.AI.HostedMcpServerToolNeverRequireApprovalMode.Equals(object? obj);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.AI.HostedMcpServerToolNeverRequireApprovalMode.GetHashCode();",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.AI.HostedMcpServerToolRequireSpecificApprovalMode : Microsoft.Extensions.AI.HostedMcpServerToolApprovalMode",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.HostedMcpServerToolRequireSpecificApprovalMode.HostedMcpServerToolRequireSpecificApprovalMode(System.Collections.Generic.IList<string>? alwaysRequireApprovalToolNames, System.Collections.Generic.IList<string>? neverRequireApprovalToolNames);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.AI.HostedMcpServerToolRequireSpecificApprovalMode.Equals(object? obj);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.AI.HostedMcpServerToolRequireSpecificApprovalMode.GetHashCode();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IList<string>? Microsoft.Extensions.AI.HostedMcpServerToolRequireSpecificApprovalMode.AlwaysRequireApprovalToolNames { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IList<string>? Microsoft.Extensions.AI.HostedMcpServerToolRequireSpecificApprovalMode.NeverRequireApprovalToolNames { get; set; }",
+          "Stage": "Experimental"
         }
       ]
     },
@@ -2010,6 +2250,16 @@
       ]
     },
     {
+      "Type": "class Microsoft.Extensions.AI.HostedWebSearchTool : Microsoft.Extensions.AI.AITool",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.HostedWebSearchTool.HostedWebSearchTool();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
       "Type": "interface Microsoft.Extensions.AI.IChatClient : System.IDisposable",
       "Stage": "Stable",
       "Methods": [
@@ -2024,6 +2274,16 @@
         {
           "Member": "System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.AI.ChatResponseUpdate> Microsoft.Extensions.AI.IChatClient.GetStreamingResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
           "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.AI.IChatReducer",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage>> Microsoft.Extensions.AI.IChatReducer.ReduceAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
         }
       ]
     },
@@ -2048,6 +2308,205 @@
       ]
     },
     {
+      "Type": "interface Microsoft.Extensions.AI.IImageGenerator : System.IDisposable",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageGenerationResponse> Microsoft.Extensions.AI.IImageGenerator.GenerateAsync(Microsoft.Extensions.AI.ImageGenerationRequest request, Microsoft.Extensions.AI.ImageGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "object? Microsoft.Extensions.AI.IImageGenerator.GetService(System.Type serviceType, object? serviceKey = null);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.AI.ImageGenerationOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.ImageGenerationOptions.ImageGenerationOptions();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual Microsoft.Extensions.AI.ImageGenerationOptions Microsoft.Extensions.AI.ImageGenerationOptions.Clone();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.AI.ImageGenerationOptions.AdditionalProperties { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.AI.ImageGenerationOptions.Count { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Drawing.Size? Microsoft.Extensions.AI.ImageGenerationOptions.ImageSize { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.ImageGenerationOptions.MediaType { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.ImageGenerationOptions.ModelId { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Func<Microsoft.Extensions.AI.IImageGenerator, object?>? Microsoft.Extensions.AI.ImageGenerationOptions.RawRepresentationFactory { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.ImageGenerationResponseFormat? Microsoft.Extensions.AI.ImageGenerationOptions.ResponseFormat { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.AI.ImageGenerationRequest",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.ImageGenerationRequest.ImageGenerationRequest();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.ImageGenerationRequest.ImageGenerationRequest(string prompt);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.ImageGenerationRequest.ImageGenerationRequest(string prompt, System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.AIContent>? originalImages);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.AIContent>? Microsoft.Extensions.AI.ImageGenerationRequest.OriginalImages { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.ImageGenerationRequest.Prompt { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.AI.ImageGenerationResponse",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.ImageGenerationResponse.ImageGenerationResponse();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.ImageGenerationResponse.ImageGenerationResponse(System.Collections.Generic.IList<Microsoft.Extensions.AI.AIContent>? contents);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IList<Microsoft.Extensions.AI.AIContent> Microsoft.Extensions.AI.ImageGenerationResponse.Contents { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "object? Microsoft.Extensions.AI.ImageGenerationResponse.RawRepresentation { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.UsageDetails? Microsoft.Extensions.AI.ImageGenerationResponse.Usage { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.Extensions.AI.ImageGenerationResponseFormat",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.ImageGenerationResponseFormat.ImageGenerationResponseFormat();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.AI.ImageGenerationResponseFormat Microsoft.Extensions.AI.ImageGenerationResponseFormat.Data",
+          "Stage": "Experimental",
+          "Value": "1"
+        },
+        {
+          "Member": "const Microsoft.Extensions.AI.ImageGenerationResponseFormat Microsoft.Extensions.AI.ImageGenerationResponseFormat.Hosted",
+          "Stage": "Experimental",
+          "Value": "2"
+        },
+        {
+          "Member": "const Microsoft.Extensions.AI.ImageGenerationResponseFormat Microsoft.Extensions.AI.ImageGenerationResponseFormat.Uri",
+          "Stage": "Experimental",
+          "Value": "0"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.AI.ImageGeneratorExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageGenerationResponse> Microsoft.Extensions.AI.ImageGeneratorExtensions.EditImageAsync(this Microsoft.Extensions.AI.IImageGenerator generator, Microsoft.Extensions.AI.DataContent originalImage, string prompt, Microsoft.Extensions.AI.ImageGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageGenerationResponse> Microsoft.Extensions.AI.ImageGeneratorExtensions.EditImageAsync(this Microsoft.Extensions.AI.IImageGenerator generator, System.ReadOnlyMemory<byte> originalImageData, string fileName, string prompt, Microsoft.Extensions.AI.ImageGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageGenerationResponse> Microsoft.Extensions.AI.ImageGeneratorExtensions.EditImagesAsync(this Microsoft.Extensions.AI.IImageGenerator generator, System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.AIContent> originalImages, string prompt, Microsoft.Extensions.AI.ImageGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageGenerationResponse> Microsoft.Extensions.AI.ImageGeneratorExtensions.GenerateImagesAsync(this Microsoft.Extensions.AI.IImageGenerator generator, string prompt, Microsoft.Extensions.AI.ImageGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static object Microsoft.Extensions.AI.ImageGeneratorExtensions.GetRequiredService(this Microsoft.Extensions.AI.IImageGenerator generator, System.Type serviceType, object? serviceKey = null);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static TService Microsoft.Extensions.AI.ImageGeneratorExtensions.GetRequiredService<TService>(this Microsoft.Extensions.AI.IImageGenerator generator, object? serviceKey = null);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static TService? Microsoft.Extensions.AI.ImageGeneratorExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageGenerator generator, object? serviceKey = null);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.AI.ImageGeneratorMetadata",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.ImageGeneratorMetadata.ImageGeneratorMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? Microsoft.Extensions.AI.ImageGeneratorMetadata.DefaultModelId { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.ImageGeneratorMetadata.ProviderName { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Uri? Microsoft.Extensions.AI.ImageGeneratorMetadata.ProviderUri { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
       "Type": "interface Microsoft.Extensions.AI.ISpeechToTextClient : System.IDisposable",
       "Stage": "Experimental",
       "Methods": [
@@ -2061,6 +2520,90 @@
         },
         {
           "Member": "System.Threading.Tasks.Task<Microsoft.Extensions.AI.SpeechToTextResponse> Microsoft.Extensions.AI.ISpeechToTextClient.GetTextAsync(System.IO.Stream audioSpeechStream, Microsoft.Extensions.AI.SpeechToTextOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.AI.McpServerToolApprovalRequestContent : Microsoft.Extensions.AI.UserInputRequestContent",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.McpServerToolApprovalRequestContent.McpServerToolApprovalRequestContent(string id, Microsoft.Extensions.AI.McpServerToolCallContent toolCall);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.McpServerToolApprovalResponseContent Microsoft.Extensions.AI.McpServerToolApprovalRequestContent.CreateResponse(bool approved);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.McpServerToolCallContent Microsoft.Extensions.AI.McpServerToolApprovalRequestContent.ToolCall { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.AI.McpServerToolApprovalResponseContent : Microsoft.Extensions.AI.UserInputResponseContent",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.McpServerToolApprovalResponseContent.McpServerToolApprovalResponseContent(string id, bool approved);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.AI.McpServerToolApprovalResponseContent.Approved { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.AI.McpServerToolCallContent : Microsoft.Extensions.AI.AIContent",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.McpServerToolCallContent.McpServerToolCallContent(string callId, string toolName, string serverName);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IReadOnlyDictionary<string, object?>? Microsoft.Extensions.AI.McpServerToolCallContent.Arguments { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.AI.McpServerToolCallContent.CallId { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.AI.McpServerToolCallContent.ServerName { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.AI.McpServerToolCallContent.ToolName { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.AI.McpServerToolResultContent : Microsoft.Extensions.AI.AIContent",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.McpServerToolResultContent.McpServerToolResultContent(string callId);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.AI.McpServerToolResultContent.CallId { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IList<Microsoft.Extensions.AI.AIContent>? Microsoft.Extensions.AI.McpServerToolResultContent.Output { get; set; }",
           "Stage": "Experimental"
         }
       ]
@@ -2103,6 +2646,46 @@
       "Properties": [
         {
           "Member": "string? Microsoft.Extensions.AI.RequiredChatToolMode.RequiredFunctionName { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.AI.ResumptionToken",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.ResumptionToken.ResumptionToken();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.ResumptionToken.ResumptionToken(byte[] bytes);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.AI.ResumptionToken Microsoft.Extensions.AI.ResumptionToken.FromBytes(byte[] bytes);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "virtual byte[] Microsoft.Extensions.AI.ResumptionToken.ToBytes();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.AI.ResumptionToken.Converter",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.ResumptionToken.Converter.Converter();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override Microsoft.Extensions.AI.ResumptionToken Microsoft.Extensions.AI.ResumptionToken.Converter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override void Microsoft.Extensions.AI.ResumptionToken.Converter.Write(System.Text.Json.Utf8JsonWriter writer, Microsoft.Extensions.AI.ResumptionToken value, System.Text.Json.JsonSerializerOptions options);",
           "Stage": "Stable"
         }
       ]
@@ -2245,6 +2828,10 @@
         },
         {
           "Member": "string Microsoft.Extensions.AI.SpeechToTextResponse.Text { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.UsageDetails? Microsoft.Extensions.AI.SpeechToTextResponse.Usage { get; set; }",
           "Stage": "Experimental"
         }
       ]
@@ -2440,11 +3027,11 @@
       ],
       "Properties": [
         {
-          "Member": "string Microsoft.Extensions.AI.TextReasoningContent.Text { get; set; }",
+          "Member": "string? Microsoft.Extensions.AI.TextReasoningContent.ProtectedData { get; set; }",
           "Stage": "Stable"
         },
         {
-          "Member": "string? Microsoft.Extensions.AI.TextReasoningContent.ProtectedData { get; set; }",
+          "Member": "string Microsoft.Extensions.AI.TextReasoningContent.Text { get; set; }",
           "Stage": "Stable"
         }
       ]
@@ -2460,11 +3047,11 @@
       ],
       "Properties": [
         {
-          "Member": "int? Microsoft.Extensions.AI.TextSpanAnnotatedRegion.StartIndex { get; set; }",
+          "Member": "int? Microsoft.Extensions.AI.TextSpanAnnotatedRegion.EndIndex { get; set; }",
           "Stage": "Stable"
         },
         {
-          "Member": "int? Microsoft.Extensions.AI.TextSpanAnnotatedRegion.EndIndex { get; set; }",
+          "Member": "int? Microsoft.Extensions.AI.TextSpanAnnotatedRegion.StartIndex { get; set; }",
           "Stage": "Stable"
         }
       ]
@@ -2546,6 +3133,38 @@
         {
           "Member": "long? Microsoft.Extensions.AI.UsageDetails.TotalTokenCount { get; set; }",
           "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.AI.UserInputRequestContent : Microsoft.Extensions.AI.AIContent",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.UserInputRequestContent.UserInputRequestContent(string id);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.AI.UserInputRequestContent.Id { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.AI.UserInputResponseContent : Microsoft.Extensions.AI.AIContent",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.UserInputResponseContent.UserInputResponseContent(string id);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.AI.UserInputResponseContent.Id { get; }",
+          "Stage": "Experimental"
         }
       ]
     }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ResumptionToken.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ResumptionToken.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>
+/// Represents a token used to resume, continue, or rehydrate an operation across multiple scenarios/calls,
+/// such as resuming a streamed response from a specific point or retrieving the result of a background operation.
+/// Subclasses of this class encapsulate all necessary information within the token to facilitate these actions.
+/// </summary>
+[JsonConverter(typeof(Converter))]
+public class ResumptionToken
+{
+    /// <summary>Bytes representing this token.</summary>
+    private readonly byte[]? _bytes;
+
+    /// <summary>Initializes a new instance of the <see cref="ResumptionToken"/> class.</summary>
+    protected ResumptionToken()
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ResumptionToken"/> class.</summary>
+    /// <param name="bytes">Bytes to create the token from.</param>
+    protected ResumptionToken(byte[] bytes)
+    {
+        _ = Throw.IfNull(bytes);
+
+        _bytes = bytes;
+    }
+
+    /// <summary>Create a new instance of <see cref="ResumptionToken"/> from the provided <paramref name="bytes"/>.
+    /// </summary>
+    /// <param name="bytes">Bytes obtained from calling <see cref="ToBytes"/> on a <see cref="ResumptionToken"/>.</param>
+    /// <returns>A <see cref="ResumptionToken"/> equivalent to the one from which
+    /// the original<see cref="ResumptionToken"/> bytes were obtained.</returns>
+    public static ResumptionToken FromBytes(byte[] bytes) => new(bytes);
+
+    /// <summary>Gets the bytes representing this <see cref="ResumptionToken"/>.</summary>
+    /// <returns>The bytes of this <see cref="ResumptionToken"/>.</returns>
+    public virtual byte[] ToBytes() => _bytes ?? throw new InvalidOperationException("Unable to obtain this token's bytes.");
+
+    /// <summary>Provides a <see cref="JsonConverter{ResumptionToken}"/> for serializing <see cref="ResumptionToken"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ResumptionToken>
+    {
+        /// <inheritdoc/>
+        public override ResumptionToken Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return ResumptionToken.FromBytes(reader.GetBytesFromBase64());
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, ResumptionToken value, JsonSerializerOptions options)
+        {
+            _ = Throw.IfNull(writer);
+            _ = Throw.IfNull(value);
+
+            writer.WriteBase64StringValue(value.ToBytes());
+        }
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
@@ -64,7 +64,7 @@ public static class MicrosoftExtensionsAIResponsesExtensions
     /// <exception cref="ArgumentNullException"><paramref name="responseUpdates"/> is <see langword="null"/>.</exception>
     public static IAsyncEnumerable<ChatResponseUpdate> AsChatResponseUpdatesAsync(
         this IAsyncEnumerable<StreamingResponseUpdate> responseUpdates, ResponseCreationOptions? options = null, CancellationToken cancellationToken = default) =>
-        OpenAIResponsesChatClient.FromOpenAIStreamingResponseUpdatesAsync(Throw.IfNull(responseUpdates), options, cancellationToken);
+        OpenAIResponsesChatClient.FromOpenAIStreamingResponseUpdatesAsync(Throw.IfNull(responseUpdates), options, cancellationToken: cancellationToken);
 
     /// <summary>Creates an OpenAI <see cref="OpenAIResponse"/> from a <see cref="ChatResponse"/>.</summary>
     /// <param name="response">The response to convert.</param>

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesContinuationToken.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesContinuationToken.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Represents a continuation token for OpenAI responses.</summary>
+/// <remarks>
+/// The token is used for resuming streamed background responses and continuing
+/// non-streamed background responses until completion.
+/// </remarks>
+internal sealed class OpenAIResponsesContinuationToken : ResumptionToken
+{
+    /// <summary>Initializes a new instance of the <see cref="OpenAIResponsesContinuationToken"/> class.</summary>
+    internal OpenAIResponsesContinuationToken(string responseId)
+    {
+        ResponseId = responseId;
+    }
+
+    /// <summary>Gets or sets the Id of the response.</summary>
+    internal string ResponseId { get; set; }
+
+    /// <summary>Gets or sets the sequence number of a streamed update.</summary>
+    internal int? SequenceNumber { get; set; }
+
+    /// <inheritdoc/>
+    public override byte[] ToBytes()
+    {
+        using MemoryStream stream = new();
+        using Utf8JsonWriter writer = new(stream);
+
+        writer.WriteStartObject();
+
+        writer.WriteString("responseId", ResponseId);
+
+        if (SequenceNumber.HasValue)
+        {
+            writer.WriteNumber("sequenceNumber", SequenceNumber.Value);
+        }
+
+        writer.WriteEndObject();
+
+        writer.Flush();
+        stream.Position = 0;
+
+        return stream.ToArray();
+    }
+
+    /// <summary>Create a new instance of <see cref="OpenAIResponsesContinuationToken"/> from the provided <paramref name="token"/>.
+    /// </summary>
+    /// <param name="token">The token to create the <see cref="OpenAIResponsesContinuationToken"/> from.</param>
+    /// <returns>A <see cref="OpenAIResponsesContinuationToken"/> equivalent of the provided <paramref name="token"/>.</returns>
+    internal static OpenAIResponsesContinuationToken FromToken(ResumptionToken token)
+    {
+        if (token is OpenAIResponsesContinuationToken longRunResumptionToken)
+        {
+            return longRunResumptionToken;
+        }
+
+        byte[] data = token.ToBytes();
+
+        if (data.Length == 0)
+        {
+            throw new InvalidOperationException("Failed to create OpenAIResponsesResumptionToken from provided token because it does not contain any data.");
+        }
+
+        Utf8JsonReader reader = new(data);
+
+        string responseId = null!;
+        int? startAfter = null;
+
+        _ = reader.Read();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            string propertyName = reader.GetString()!;
+
+            switch (propertyName)
+            {
+                case "responseId":
+                    _ = reader.Read();
+                    responseId = reader.GetString()!;
+                    break;
+                case "sequenceNumber":
+                    _ = reader.Read();
+                    startAfter = reader.GetInt32();
+                    break;
+                default:
+                    throw new JsonException($"Unrecognized property '{propertyName}'.");
+            }
+        }
+
+        return new(responseId)
+        {
+            SequenceNumber = startAfter
+        };
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -812,6 +812,19 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
             options = options.Clone();
             options.ConversationId = conversationId;
         }
+        else if (options.ContinuationToken is not null)
+        {
+            // Clone options before resetting the continuation token below.
+            options = options.Clone();
+        }
+
+        // Reset the continuation token of a background response operation
+        // to signal the inner client to handle function call result rather
+        // than getting the result of the operation.
+        if (options?.ContinuationToken is not null)
+        {
+            options.ContinuationToken = null;
+        }
     }
 
     /// <summary>Gets whether the function calling loop should exit based on the function call requests.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworks);netstandard2.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);CA2227;CA1034;SA1316;S1067;S1121;S1994;S3253;MEAI001</NoWarn>
+    <NoWarn>$(NoWarn);CA2227;CA1034;SA1316;S1067;S1121;S1994;S3253;MEAI001;S104</NoWarn>
 
     <!-- CA2007 requires use of ConfigureAwait. While in general we strive to use ConfigureAwait in all our libraries,
          the exemption is when user code that might care about SynchronizationContext is invoked as part of operation.

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/BackgroundResponsesOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/BackgroundResponsesOptionsTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class BackgroundResponsesOptionsTests
+{
+    [Fact]
+    public void Constructor_Parameterless_PropsDefaulted()
+    {
+        BackgroundResponsesOptions options = new();
+        Assert.Null(options.Allow);
+    }
+
+    [Fact]
+    public void Constructor_Copy_PropsRoundtrip()
+    {
+        BackgroundResponsesOptions original = new()
+        {
+            Allow = true
+        };
+
+        BackgroundResponsesOptions copy = new(original);
+
+        Assert.True(copy.Allow);
+        Assert.NotSame(original, copy);
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatOptionsTests.cs
@@ -50,6 +50,8 @@ public class ChatOptionsTests
         Assert.Null(clone.Tools);
         Assert.Null(clone.AdditionalProperties);
         Assert.Null(clone.RawRepresentationFactory);
+        Assert.Null(clone.ContinuationToken);
+        Assert.Null(clone.BackgroundResponsesOptions);
     }
 
     [Fact]
@@ -76,6 +78,13 @@ public class ChatOptionsTests
 
         Func<IChatClient, object?> rawRepresentationFactory = (c) => null;
 
+        ResumptionToken continuationToken = ResumptionToken.FromBytes(new byte[] { 1, 2, 3, 4 });
+
+        BackgroundResponsesOptions backgroundResponsesOptions = new()
+        {
+            Allow = true
+        };
+
         options.ConversationId = "12345";
         options.Instructions = "Some instructions";
         options.Temperature = 0.1f;
@@ -93,6 +102,8 @@ public class ChatOptionsTests
         options.Tools = tools;
         options.RawRepresentationFactory = rawRepresentationFactory;
         options.AdditionalProperties = additionalProps;
+        options.ContinuationToken = continuationToken;
+        options.BackgroundResponsesOptions = backgroundResponsesOptions;
 
         Assert.Equal("12345", options.ConversationId);
         Assert.Equal("Some instructions", options.Instructions);
@@ -111,6 +122,8 @@ public class ChatOptionsTests
         Assert.Same(tools, options.Tools);
         Assert.Same(rawRepresentationFactory, options.RawRepresentationFactory);
         Assert.Same(additionalProps, options.AdditionalProperties);
+        Assert.Same(continuationToken, options.ContinuationToken);
+        Assert.Same(backgroundResponsesOptions, options.BackgroundResponsesOptions);
 
         ChatOptions clone = options.Clone();
         Assert.Equal("12345", clone.ConversationId);
@@ -129,6 +142,9 @@ public class ChatOptionsTests
         Assert.Equal(tools, clone.Tools);
         Assert.Same(rawRepresentationFactory, clone.RawRepresentationFactory);
         Assert.Equal(additionalProps, clone.AdditionalProperties);
+        Assert.Same(continuationToken, clone.ContinuationToken);
+        Assert.NotSame(backgroundResponsesOptions, clone.BackgroundResponsesOptions);
+        Assert.Equal(backgroundResponsesOptions.Allow, clone.BackgroundResponsesOptions?.Allow);
     }
 
     [Fact]
@@ -145,6 +161,13 @@ public class ChatOptionsTests
         AdditionalPropertiesDictionary additionalProps = new()
         {
             ["key"] = "value",
+        };
+
+        ResumptionToken continuationToken = ResumptionToken.FromBytes(new byte[] { 1, 2, 3, 4 });
+
+        BackgroundResponsesOptions backgroundResponsesOptions = new()
+        {
+            Allow = true
         };
 
         options.ConversationId = "12345";
@@ -168,6 +191,8 @@ public class ChatOptionsTests
         ];
         options.RawRepresentationFactory = (c) => null;
         options.AdditionalProperties = additionalProps;
+        options.ContinuationToken = continuationToken;
+        options.BackgroundResponsesOptions = backgroundResponsesOptions;
 
         string json = JsonSerializer.Serialize(options, TestJsonSerializerContext.Default.ChatOptions);
 
@@ -191,6 +216,9 @@ public class ChatOptionsTests
         Assert.Equal(ChatToolMode.RequireAny, deserialized.ToolMode);
         Assert.Null(deserialized.Tools);
         Assert.Null(deserialized.RawRepresentationFactory);
+        Assert.Equal(continuationToken.ToBytes(), deserialized.ContinuationToken?.ToBytes());
+        Assert.NotSame(backgroundResponsesOptions, deserialized.BackgroundResponsesOptions);
+        Assert.Equal(backgroundResponsesOptions.Allow, deserialized.BackgroundResponsesOptions?.Allow);
 
         Assert.NotNull(deserialized.AdditionalProperties);
         Assert.Single(deserialized.AdditionalProperties);

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ResumptionTokenTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ResumptionTokenTests.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class ResumptionTokenTests
+{
+    [Fact]
+    public void Bytes_Roundtrip()
+    {
+        byte[] testBytes = [1, 2, 3, 4, 5];
+
+        ResumptionToken token = ResumptionToken.FromBytes(testBytes);
+
+        Assert.NotNull(token);
+        Assert.Equal(testBytes, token.ToBytes());
+    }
+
+    [Fact]
+    public void JsonSerialization_Roundtrips()
+    {
+        ResumptionToken originalToken = ResumptionToken.FromBytes([1, 2, 3, 4, 5]);
+
+        // Act
+        string json = JsonSerializer.Serialize(originalToken, TestJsonSerializerContext.Default.ResumptionToken);
+
+        ResumptionToken? deserializedToken = JsonSerializer.Deserialize(json, TestJsonSerializerContext.Default.ResumptionToken);
+
+        // Assert
+        Assert.NotNull(deserializedToken);
+        Assert.Equal(originalToken.ToBytes(), deserializedToken.ToBytes());
+        Assert.NotSame(originalToken, deserializedToken);
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/TestJsonSerializerContext.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/TestJsonSerializerContext.cs
@@ -37,4 +37,5 @@ namespace Microsoft.Extensions.AI;
 [JsonSerializable(typeof(decimal))] // Used in Content tests
 [JsonSerializable(typeof(HostedMcpServerToolApprovalMode))]
 [JsonSerializable(typeof(ChatResponseFormatTests.SomeType))]
+[JsonSerializable(typeof(ResumptionToken))]
 internal sealed partial class TestJsonSerializerContext : JsonSerializerContext;

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/HttpHandlerExpectedInput.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/HttpHandlerExpectedInput.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Http;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Model for expected input to an HTTP handler.</summary>
+public sealed class HttpHandlerExpectedInput
+{
+    /// <summary>Gets or sets the expected request URI.</summary>
+    public Uri? Uri { get; set; }
+
+    /// <summary>Gets or sets the expected request body.</summary>
+    public string? Body { get; set; }
+
+    /// <summary>
+    /// Gets or sets the expected HTTP method.
+    /// </summary>
+    public HttpMethod? Method { get; set; }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -188,5 +189,143 @@ public class OpenAIResponseClientIntegrationTests : ChatClientIntegrationTests
             Assert.Equal(2, approvalsCount);
             Assert.Contains("src/Libraries/Microsoft.Extensions.AI.Abstractions/README.md", response.Text);
         }
+    }
+
+    [ConditionalFact]
+    public async Task GetResponseAsync_BackgroundResponses()
+    {
+        SkipIfNotEnabled();
+
+        var chatOptions = new ChatOptions
+        {
+            BackgroundResponsesOptions = new() { Allow = true }
+        };
+
+        // Get initial response with continuation token
+        var response = await ChatClient.GetResponseAsync("What's the biggest animal?", chatOptions);
+        Assert.NotNull(response.ContinuationToken);
+        Assert.Empty(response.Messages);
+
+        int attempts = 0;
+
+        // Continue to poll until we get the final response
+        while (response.ContinuationToken is not null && ++attempts < 10)
+        {
+            response = await ChatClient.GetResponseAsync(response.ContinuationToken, chatOptions);
+            await Task.Delay(500);
+        }
+
+        Assert.Contains("whale", response.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [ConditionalFact]
+    public async Task GetResponseAsync_BackgroundResponses_WithFunction()
+    {
+        SkipIfNotEnabled();
+
+        using var chatClient = new FunctionInvokingChatClient(ChatClient);
+
+        var chatOptions = new ChatOptions
+        {
+            BackgroundResponsesOptions = new() { Allow = true },
+            Tools = [AIFunctionFactory.Create(() => "5:43", new AIFunctionFactoryOptions { Name = "GetCurrentTime" })]
+        };
+
+        // Get initial response with continuation token
+        var response = await chatClient.GetResponseAsync("What time is it?", chatOptions);
+        Assert.NotNull(response.ContinuationToken);
+        Assert.Empty(response.Messages);
+
+        int attempts = 0;
+
+        // Poll until the result is received
+        while (response.ContinuationToken is not null && ++attempts < 10)
+        {
+            response = await chatClient.GetResponseAsync(response.ContinuationToken, chatOptions);
+            await Task.Delay(1000);
+        }
+
+        Assert.Contains("5:43", response.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [ConditionalFact]
+    public async Task GetStreamingResponseAsync_BackgroundResponses()
+    {
+        SkipIfNotEnabled();
+
+        ChatOptions chatOptions = new()
+        {
+            BackgroundResponsesOptions = new BackgroundResponsesOptions { Allow = true },
+        };
+
+        string responseText = "";
+
+        await foreach (var update in ChatClient.GetStreamingResponseAsync("What is the capital of France?", chatOptions))
+        {
+            responseText += update;
+        }
+
+        // Assert
+        Assert.Contains("Paris", responseText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [ConditionalFact]
+    public async Task GetStreamingResponseAsync_BackgroundResponses_StreamResumption()
+    {
+        SkipIfNotEnabled();
+
+        ChatOptions chatOptions = new()
+        {
+            BackgroundResponsesOptions = new BackgroundResponsesOptions { Allow = true },
+        };
+
+        int updateNumber = 0;
+        string responseText = "";
+        ResumptionToken? continuationToken = null;
+
+        await foreach (var update in ChatClient.GetStreamingResponseAsync("What is the capital of France?", chatOptions))
+        {
+            responseText += update;
+
+            // Simulate an interruption after receiving 8 updates.
+            if (updateNumber++ == 8)
+            {
+                continuationToken = update.ContinuationToken;
+                break;
+            }
+        }
+
+        Assert.DoesNotContain("Paris", responseText);
+
+        // Resume streaming from the point of interruption captured by the continuation token.
+        await foreach (var update in ChatClient.GetStreamingResponseAsync(continuationToken!, chatOptions))
+        {
+            responseText += update;
+        }
+
+        Assert.Contains("Paris", responseText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [ConditionalFact]
+    public async Task GetStreamingResponseAsync_BackgroundResponses_WithFunction()
+    {
+        SkipIfNotEnabled();
+
+        using var chatClient = new FunctionInvokingChatClient(ChatClient);
+
+        var chatOptions = new ChatOptions
+        {
+            BackgroundResponsesOptions = new() { Allow = true },
+            Tools = [AIFunctionFactory.Create(() => "5:43", new AIFunctionFactoryOptions { Name = "GetCurrentTime" })]
+        };
+
+        string responseText = "";
+
+        await foreach (var update in chatClient.GetStreamingResponseAsync("What time is it?", chatOptions))
+        {
+            responseText += update;
+        }
+
+        Assert.Contains("5:43", responseText);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -6,6 +6,7 @@ using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
@@ -1507,6 +1508,476 @@ public class OpenAIResponseClientTests
     }
 
     [Fact]
+    public async Task GetResponseAsync_BackgroundResponses_FirstCall()
+    {
+        const string Input = """
+            {
+                "temperature":0.5,
+                "model":"gpt-4o-mini",
+                "background":true,
+                "input": [{
+                    "type":"message",
+                    "role":"user",
+                    "content":[{"type":"input_text","text":"hello"}]
+                }],
+                "max_output_tokens":20
+            }
+            """;
+
+        const string Output = """
+            {
+              "id": "resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed7",
+              "object": "response",
+              "created_at": 1758712522,
+              "status": "queued",
+              "background": true,
+              "error": null,
+              "incomplete_details": null,
+              "instructions": null,
+              "max_output_tokens": null,
+              "model": "gpt-4o-mini-2024-07-18",
+              "output": [],
+              "parallel_tool_calls": true,
+              "previous_response_id": null,
+              "reasoning": {
+                "effort": null,
+                "generate_summary": null
+              },
+              "store": true,
+              "temperature": 0.5,
+              "text": {
+                "format": {
+                  "type": "text"
+                }
+              },
+              "tool_choice": "auto",
+              "tools": [],
+              "top_p": 1.0,
+              "usage": null,
+              "user": null,
+              "metadata": {}
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-4o-mini");
+
+        var response = await client.GetResponseAsync("hello", new()
+        {
+            MaxOutputTokens = 20,
+            Temperature = 0.5f,
+            BackgroundResponsesOptions = new BackgroundResponsesOptions
+            {
+                Allow = true
+            }
+        });
+        Assert.NotNull(response);
+
+        Assert.Equal("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed7", response.ResponseId);
+        Assert.Equal("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed7", response.ConversationId);
+        Assert.Empty(response.Messages);
+
+        Assert.NotNull(response.ContinuationToken);
+        var responsesContinuationToken = TestOpenAIResponsesContinuationToken.FromToken(response.ContinuationToken);
+        Assert.Equal("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed7", responsesContinuationToken.ResponseId);
+        Assert.Null(responsesContinuationToken.SequenceNumber);
+    }
+
+    [Theory]
+    [InlineData(ResponseStatus.Queued)]
+    [InlineData(ResponseStatus.InProgress)]
+    [InlineData(ResponseStatus.Completed)]
+    [InlineData(ResponseStatus.Cancelled)]
+    [InlineData(ResponseStatus.Failed)]
+    [InlineData(ResponseStatus.Incomplete)]
+    public async Task GetResponseAsync_BackgroundResponses_PollingCall(ResponseStatus expectedStatus)
+    {
+        var expectedInput = new HttpHandlerExpectedInput
+        {
+            Uri = new Uri("https://api.openai.com/v1/responses/resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8"),
+            Method = HttpMethod.Get,
+        };
+
+        string output = $$""""
+            {
+              "id": "resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8",
+              "object": "response",
+              "created_at": 1758712522,
+              "status": "{{ResponseStatusToRequestValue(expectedStatus)}}",
+              "background": true,
+              "error": null,
+              "incomplete_details": null,
+              "instructions": null,
+              "max_output_tokens": null,
+              "model": "gpt-4o-mini-2024-07-18",
+              "output": {{(expectedStatus is (ResponseStatus.Queued or ResponseStatus.InProgress)
+                ? "[]"
+                : """
+                    [{
+                      "type": "message",
+                      "id": "msg_67d32764fcdc8191bcf2e444d4088804058a5e08c46a181d",
+                      "status": "completed",
+                      "role": "assistant",
+                      "content": [
+                        {
+                          "type": "output_text",
+                          "text": "The background response result.",
+                          "annotations": []
+                        }
+                      ]
+                    }]
+                    """
+              )}},
+              "parallel_tool_calls": true,
+              "previous_response_id": null,
+              "reasoning": {
+                "effort": null,
+                "generate_summary": null
+              },
+              "store": true,
+              "temperature": 0.5,
+              "text": {
+                "format": {
+                  "type": "text"
+                }
+              },
+              "tool_choice": "auto",
+              "tools": [],
+              "top_p": 1.0,
+              "usage": null,
+              "user": null,
+              "metadata": {}
+            }
+            """";
+
+        using VerbatimHttpHandler handler = new(expectedInput, output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-4o-mini");
+
+        var continuationToken = new TestOpenAIResponsesContinuationToken("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8");
+
+        var response = await client.GetResponseAsync(continuationToken, new()
+        {
+            BackgroundResponsesOptions = new()
+            {
+                Allow = true
+            }
+        });
+        Assert.NotNull(response);
+
+        Assert.Equal("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8", response.ResponseId);
+        Assert.Equal("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8", response.ConversationId);
+
+        switch (expectedStatus)
+        {
+            case ResponseStatus.Queued:
+            case ResponseStatus.InProgress:
+            {
+                Assert.NotNull(response.ContinuationToken);
+
+                var responsesContinuationToken = TestOpenAIResponsesContinuationToken.FromToken(response.ContinuationToken);
+                Assert.Equal("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8", responsesContinuationToken.ResponseId);
+                Assert.Null(responsesContinuationToken.SequenceNumber);
+
+                Assert.Empty(response.Messages);
+                break;
+            }
+
+            case ResponseStatus.Completed:
+            case ResponseStatus.Cancelled:
+            case ResponseStatus.Failed:
+            case ResponseStatus.Incomplete:
+            {
+                Assert.Null(response.ContinuationToken);
+
+                Assert.Equal("The background response result.", response.Text);
+                Assert.Single(response.Messages.Single().Contents);
+                Assert.Equal(ChatRole.Assistant, response.Messages.Single().Role);
+                break;
+            }
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(expectedStatus), expectedStatus, null);
+        }
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_BackgroundResponses_PollingCall_WithMessages()
+    {
+        using VerbatimHttpHandler handler = new(string.Empty, string.Empty);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-4o-mini");
+
+        var options = new ChatOptions
+        {
+            ContinuationToken = new TestOpenAIResponsesContinuationToken("resp_68d3d2c9ef7c8195863e4e2b2ec226a205007262ecbbfed8"),
+            BackgroundResponsesOptions = new BackgroundResponsesOptions
+            {
+                Allow = true
+            }
+        };
+
+        // A try to update a background response with new messages should fail.
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await client.GetResponseAsync("Please book hotel as well", options);
+        });
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_BackgroundResponses()
+    {
+        const string Input = """
+            {
+              "model": "gpt-4o-2024-08-06",
+              "background": true,
+              "input":[{
+                "type":"message",
+                "role":"user",
+                "content":[{
+                  "type":"input_text",
+                  "text":"hello"
+                }]
+              }],
+              
+              "stream": true
+            }
+            """;
+
+        const string Output = """
+            event: response.created
+            data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_68d401a7b36c81a288600e95a5a119d4073420ed59d5f559","object":"response","created_at":1758724519,"status":"queued","background":true,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+            event: response.queued
+            data: {"type":"response.queued","sequence_number":1,"response":{"id":"resp_68d401a7b36c81a288600e95a5a119d4073420ed59d5f559","object":"response","created_at":1758724519,"status":"queued","background":true,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+            event: response.in_progress
+            data: {"type":"response.in_progress","sequence_number":2,"response":{"truncation":"disabled","id":"resp_68d401a7b36c81a288600e95a5a119d4073420ed59d5f559","tool_choice":"auto","temperature":1.0,"top_p":1.0,"status":"in_progress","top_logprobs":0,"usage":null,"object":"response","created_at":1758724519,"prompt_cache_key":null,"text":{"format":{"type":"text"},"verbosity":"medium"},"incomplete_details":null,"model":"gpt-4o-2024-08-06","previous_response_id":null,"safety_identifier":null,"metadata":{},"store":true,"output":[],"parallel_tool_calls":true,"error":null,"background":true,"instructions":null,"service_tier":"auto","max_tool_calls":null,"max_output_tokens":null,"tools":[],"user":null,"reasoning":{"effort":null,"summary":null}}}
+
+            event: response.output_item.added
+            data: {"type":"response.output_item.added","sequence_number":3,"item":{"id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content":[],"role":"assistant","status":"in_progress","type":"message"},"output_index":0}
+
+            event: response.content_part.added
+            data: {"type":"response.content_part.added","sequence_number":4,"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"part":{"text":"","logprobs":[],"type":"output_text","annotations":[]},"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":5,"delta":"Hello","logprobs":[],"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":6,"delta":"!","logprobs":[],"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":7,"delta":" How","logprobs":[],"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":8,"delta":" can","logprobs":[],"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":9,"delta":" I","logprobs":[],"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":10,"delta":" assist","logprobs":[],"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":11,"delta":" you","logprobs":[],"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":12,"delta":" today","logprobs":[],"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":13,"delta":"?","logprobs":[],"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"output_index":0}
+
+            event: response.output_text.done
+            data: {"type":"response.output_text.done","sequence_number":14,"text":"Hello! How can I assist you today?","logprobs":[],"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"output_index":0}
+
+            event: response.content_part.done
+            data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content_index":0,"part":{"text":"Hello! How can I assist you today?","logprobs":[],"type":"output_text","annotations":[]},"output_index":0}
+
+            event: response.output_item.done
+            data: {"type":"response.output_item.done","sequence_number":16,"item":{"id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content":[{"text":"Hello! How can I assist you today?","logprobs":[],"type":"output_text","annotations":[]}],"role":"assistant","status":"completed","type":"message"},"output_index":0}
+
+            event: response.completed
+            data: {"type":"response.completed","sequence_number":17,"response":{"truncation":"disabled","id":"resp_68d401a7b36c81a288600e95a5a119d4073420ed59d5f559","tool_choice":"auto","temperature":1.0,"top_p":1.0,"status":"completed","top_logprobs":0,"usage":{"total_tokens":18,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0},"output_tokens":10,"input_tokens":8},"object":"response","created_at":1758724519,"prompt_cache_key":null,"text":{"format":{"type":"text"},"verbosity":"medium"},"incomplete_details":null,"model":"gpt-4o-2024-08-06","previous_response_id":null,"safety_identifier":null,"metadata":{},"store":true,"output":[{"id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content":[{"text":"Hello! How can I assist you today?","logprobs":[],"type":"output_text","annotations":[]}],"role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"error":null,"background":true,"instructions":null,"service_tier":"default","max_tool_calls":null,"max_output_tokens":null,"tools":[],"user":null,"reasoning":{"effort":null,"summary":null}}}
+
+            
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-4o-2024-08-06");
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (var update in client.GetStreamingResponseAsync("hello", new()
+        {
+            BackgroundResponsesOptions = new BackgroundResponsesOptions
+            {
+                Allow = true
+            },
+        }))
+        {
+            updates.Add(update);
+        }
+
+        Assert.Equal("Hello! How can I assist you today?", string.Concat(updates.Select(u => u.Text)));
+        Assert.Equal(18, updates.Count);
+
+        var createdAt = DateTimeOffset.FromUnixTimeSeconds(1_758_724_519);
+
+        for (int i = 0; i < updates.Count; i++)
+        {
+            Assert.Equal("resp_68d401a7b36c81a288600e95a5a119d4073420ed59d5f559", updates[i].ResponseId);
+            Assert.Equal("resp_68d401a7b36c81a288600e95a5a119d4073420ed59d5f559", updates[i].ConversationId);
+            Assert.Equal(createdAt, updates[i].CreatedAt);
+            Assert.Equal("gpt-4o-2024-08-06", updates[i].ModelId);
+            Assert.Null(updates[i].AdditionalProperties);
+
+            if (i < updates.Count - 1)
+            {
+                Assert.NotNull(updates[i].ContinuationToken);
+                var responsesContinuationToken = TestOpenAIResponsesContinuationToken.FromToken(updates[i].ContinuationToken!);
+                Assert.Equal("resp_68d401a7b36c81a288600e95a5a119d4073420ed59d5f559", responsesContinuationToken.ResponseId);
+                Assert.Equal(i, responsesContinuationToken.SequenceNumber);
+                Assert.Null(updates[i].FinishReason);
+            }
+            else
+            {
+                Assert.Null(updates[i].ContinuationToken);
+                Assert.Equal(ChatFinishReason.Stop, updates[i].FinishReason);
+            }
+
+            Assert.Equal((i >= 5 && i <= 13) || i == 17 ? 1 : 0, updates[i].Contents.Count);
+        }
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_BackgroundResponses_StreamResumption()
+    {
+        var expectedInput = new HttpHandlerExpectedInput
+        {
+            Uri = new Uri("https://api.openai.com/v1/responses/resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b?stream=true&starting_after=9"),
+            Method = HttpMethod.Get,
+        };
+
+        const string Output = """
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":10,"delta":" assist","logprobs":[],"item_id":"msg_68d40dcb2d34819c88f5d6a8ca7b0308029e611c3cc4a34b","content_index":0,"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":11,"delta":" you","logprobs":[],"item_id":"msg_68d40dcb2d34819c88f5d6a8ca7b0308029e611c3cc4a34b","content_index":0,"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":12,"delta":" today","logprobs":[],"item_id":"msg_68d40dcb2d34819c88f5d6a8ca7b0308029e611c3cc4a34b","content_index":0,"output_index":0}
+
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","sequence_number":13,"delta":"?","logprobs":[],"item_id":"msg_68d40dcb2d34819c88f5d6a8ca7b0308029e611c3cc4a34b","content_index":0,"output_index":0}
+
+            event: response.output_text.done
+            data: {"type":"response.output_text.done","sequence_number":14,"text":"Hello! How can I assist you today?","logprobs":[],"item_id":"msg_68d40dcb2d34819c88f5d6a8ca7b0308029e611c3cc4a34b","content_index":0,"output_index":0}
+
+            event: response.content_part.done
+            data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_68d40dcb2d34819c88f5d6a8ca7b0308029e611c3cc4a34b","content_index":0,"part":{"text":"Hello! How can I assist you today?","logprobs":[],"type":"output_text","annotations":[]},"output_index":0}
+
+            event: response.output_item.done
+            data: {"type":"response.output_item.done","sequence_number":16,"item":{"id":"msg_68d40dcb2d34819c88f5d6a8ca7b0308029e611c3cc4a34b","content":[{"text":"Hello! How can I assist you today?","logprobs":[],"type":"output_text","annotations":[]}],"role":"assistant","status":"completed","type":"message"},"output_index":0}
+
+            event: response.completed
+            data: {"type":"response.completed","sequence_number":17,"response":{"truncation":"disabled","id":"resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b","tool_choice":"auto","temperature":1.0,"top_p":1.0,"status":"completed","top_logprobs":0,"usage":{"total_tokens":18,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0},"output_tokens":10,"input_tokens":8},"object":"response","created_at":1758727622,"prompt_cache_key":null,"text":{"format":{"type":"text"},"verbosity":"medium"},"incomplete_details":null,"model":"gpt-4o-2024-08-06","previous_response_id":null,"safety_identifier":null,"metadata":{},"store":true,"output":[{"id":"msg_68d40dcb2d34819c88f5d6a8ca7b0308029e611c3cc4a34b","content":[{"text":"Hello! How can I assist you today?","logprobs":[],"type":"output_text","annotations":[]}],"role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"error":null,"background":true,"instructions":null,"service_tier":"default","max_tool_calls":null,"max_output_tokens":null,"tools":[],"user":null,"reasoning":{"effort":null,"summary":null}}}
+
+            
+            """;
+
+        using VerbatimHttpHandler handler = new(expectedInput, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-4o-2024-08-06");
+
+        // Emulating resumption of the stream after receiving the first 9 updates that provided the text "Hello! How can I"
+        var continuationToken = new TestOpenAIResponsesContinuationToken("resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b")
+        {
+            SequenceNumber = 9
+        };
+
+        var chatOptions = new ChatOptions
+        {
+            BackgroundResponsesOptions = new BackgroundResponsesOptions { Allow = true },
+        };
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (var update in client.GetStreamingResponseAsync(continuationToken, chatOptions))
+        {
+            updates.Add(update);
+        }
+
+        // Receiving the remaining updates to complete the response "Hello! How can I assist you today?"
+        Assert.Equal(" assist you today?", string.Concat(updates.Select(u => u.Text)));
+        Assert.Equal(8, updates.Count);
+
+        var createdAt = DateTimeOffset.FromUnixTimeSeconds(1_758_727_622);
+
+        for (int i = 0; i < updates.Count; i++)
+        {
+            Assert.Equal("resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b", updates[i].ResponseId);
+            Assert.Equal("resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b", updates[i].ConversationId);
+
+            var sequenceNumber = i + 10;
+
+            if (sequenceNumber is (>= 10 and <= 13))
+            {
+                // Text deltas
+                Assert.NotNull(updates[i].ContinuationToken);
+                var responsesContinuationToken = TestOpenAIResponsesContinuationToken.FromToken(updates[i].ContinuationToken!);
+                Assert.Equal("resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b", responsesContinuationToken.ResponseId);
+                Assert.Equal(sequenceNumber, responsesContinuationToken.SequenceNumber);
+
+                Assert.Single(updates[i].Contents);
+            }
+            else if (sequenceNumber is (>= 14 and <= 16))
+            {
+                // Response Complete and Assistant message updates
+                Assert.NotNull(updates[i].ContinuationToken);
+                var responsesContinuationToken = TestOpenAIResponsesContinuationToken.FromToken(updates[i].ContinuationToken!);
+                Assert.Equal("resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b", responsesContinuationToken.ResponseId);
+                Assert.Equal(sequenceNumber, responsesContinuationToken.SequenceNumber);
+
+                Assert.Empty(updates[i].Contents);
+            }
+            else
+            {
+                // The last update with the response completion
+                Assert.Null(updates[i].ContinuationToken);
+                Assert.Single(updates[i].Contents);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_BackgroundResponses_StreamResumption_WithMessages()
+    {
+        using VerbatimHttpHandler handler = new(string.Empty, string.Empty);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-4o-2024-08-06");
+
+        // Emulating resumption of the stream after receiving the first 9 updates that provided the text "Hello! How can I"
+        var chatOptions = new ChatOptions
+        {
+            BackgroundResponsesOptions = new BackgroundResponsesOptions { Allow = true, },
+            ContinuationToken = new TestOpenAIResponsesContinuationToken("resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b")
+            {
+                SequenceNumber = 9
+            }
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var update in client.GetStreamingResponseAsync("Please book a hotel for me", chatOptions))
+#pragma warning disable S108 // Nested blocks of code should not be left empty
+            {
+            }
+#pragma warning restore S108 // Nested blocks of code should not be left empty
+        });
+    }
+
+    [Fact]
     public async Task RequestHeaders_UserAgent_ContainsMEAI()
     {
         using var handler = new ThrowUserAgentExceptionHandler();
@@ -1525,4 +1996,96 @@ public class OpenAIResponseClientTests
             new OpenAIClientOptions { Transport = new HttpClientPipelineTransport(httpClient) })
         .GetOpenAIResponseClient(modelId)
         .AsIChatClient();
+
+    private static string ResponseStatusToRequestValue(ResponseStatus status)
+    {
+        if (status == ResponseStatus.InProgress)
+        {
+            return "in_progress";
+        }
+
+        return status.ToString().ToLowerInvariant();
+    }
+
+    private sealed class TestOpenAIResponsesContinuationToken : ResumptionToken
+    {
+        internal TestOpenAIResponsesContinuationToken(string responseId)
+        {
+            ResponseId = responseId;
+        }
+
+        /// <summary>Gets or sets the Id of the response.</summary>
+        internal string ResponseId { get; set; }
+
+        /// <summary>Gets or sets the sequence number of a streamed update.</summary>
+        internal int? SequenceNumber { get; set; }
+
+        internal static TestOpenAIResponsesContinuationToken FromToken(ResumptionToken token)
+        {
+            if (token is TestOpenAIResponsesContinuationToken longRunResumptionToken)
+            {
+                return longRunResumptionToken;
+            }
+
+            byte[] data = token.ToBytes();
+
+            Utf8JsonReader reader = new(data);
+
+            string responseId = null!;
+            int? startAfter = null;
+
+            _ = reader.Read();
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    break;
+                }
+
+                string propertyName = reader.GetString()!;
+
+                switch (propertyName)
+                {
+                    case "responseId":
+                        _ = reader.Read();
+                        responseId = reader.GetString()!;
+                        break;
+                    case "sequenceNumber":
+                        _ = reader.Read();
+                        startAfter = reader.GetInt32();
+                        break;
+                    default:
+                        throw new JsonException($"Unrecognized property '{propertyName}'.");
+                }
+            }
+
+            return new(responseId)
+            {
+                SequenceNumber = startAfter
+            };
+        }
+
+        public override byte[] ToBytes()
+        {
+            using MemoryStream stream = new();
+            using Utf8JsonWriter writer = new(stream);
+
+            writer.WriteStartObject();
+
+            writer.WriteString("responseId", ResponseId);
+
+            if (SequenceNumber.HasValue)
+            {
+                writer.WriteNumber("sequenceNumber", SequenceNumber.Value);
+            }
+
+            writer.WriteEndObject();
+
+            writer.Flush();
+            stream.Position = 0;
+
+            return stream.ToArray();
+        }
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -1194,6 +1194,44 @@ public class FunctionInvokingChatClientTests
         Assert.Equal(0, invoked);
     }
 
+    [Fact]
+    public async Task ClonesChatOptionsAndResetContinuationTokenForBackgroundResponsesAsync()
+    {
+        ChatOptions? actualChatOptions = null;
+
+        using var innerChatClient = new TestChatClient
+        {
+            GetResponseAsyncCallback = (chatContents, chatOptions, cancellationToken) =>
+            {
+                actualChatOptions = chatOptions;
+
+                List<ChatMessage> messages = [];
+
+                // Simulate the model returning a function call for the first call only
+                if (!chatContents.Any(m => m.Contents.OfType<FunctionCallContent>().Any()))
+                {
+                    messages.Add(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1")]));
+                }
+
+                return Task.FromResult(new ChatResponse { Messages = messages });
+            }
+        };
+
+        using var chatClient = new FunctionInvokingChatClient(innerChatClient);
+
+        var originalChatOptions = new ChatOptions
+        {
+            Tools = [AIFunctionFactory.Create(() => { }, "Func1")],
+            ContinuationToken = ResumptionToken.FromBytes(new byte[] { 1, 2, 3, 4 }),
+        };
+
+        await chatClient.GetResponseAsync("hi", originalChatOptions);
+
+        // The original options should be cloned and have a null ContinuationToken
+        Assert.NotSame(originalChatOptions, actualChatOptions);
+        Assert.Null(actualChatOptions!.ContinuationToken);
+    }
+
     private sealed class CustomSynchronizationContext : SynchronizationContext
     {
         public override void Post(SendOrPostCallback d, object? state)


### PR DESCRIPTION
This PR adds a model for supporting background responses (long-running operations), updates the chat completion model to use it, and integrates this functionality into `OpenAIResponsesChatClient`.

Background responses use a continuation token returned by the `GetResponseAsync` and `GetStreamingResponseAsync` methods in the `ChatResponse` and `ChatResponseUpdate` classes, respectively, when background responses are enabled and supported by the chat client.

The continuation token contains all necessary details to enable polling for a background response using the non-streaming `GetResponseAsync` method. It also allows resuming a streamed background response with the `GetStreamingResponseAsync` method if the stream is interrupted. In both cases, the continuation token obtained from the initial chat result or the streamed update received before the interruption should be supplied as input for follow-up calls.

When a background response has completed, failed, or cannot proceed further (for example, when user input is required), the continuation token returned by either method will be null, signaling to consumers that processing is complete and there is nothing to poll or resume. The result returned by either method can then be used for further processing.

#### Non-streaming API:
````csharp
var chatOptions = new ChatOptions
{
    BackgroundResponsesOptions = new() { Allow = true }
};

// Get initial response with continuation token
var response = await chatClient.GetResponseAsync("What's the biggest animal?", chatOptions);

// Continue to poll until the final response is received
while (response.ContinuationToken is not null)
{
    response = await chatClient.GetResponseAsync(response.ContinuationToken, chatOptions);
}

Console.WriteLine(response);
````

#### Streaming API:
````csharp
ChatOptions chatOptions = new()
{
    BackgroundResponsesOptions = new BackgroundResponsesOptions { Allow = true },
};

string response = "";
ResumptionToken? continuationToken = null;

await foreach (var update in chatClient.GetStreamingResponseAsync("What is the capital of France?", chatOptions))
{
    response += update;

    // Simulate an interruption
    continuationToken = update.ContinuationToken;
    break;
}

// Resume streaming from the point captured by the continuation token
await foreach (var update in chatClient.GetStreamingResponseAsync(continuationToken!, chatOptions))
{
    response += update;
}

Console.WriteLine(response);
````