### PR TITLE
Fix mcpserver test baselines

### DIFF
--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.AotTrue.verified/mcpserver/.mcp/server.json
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.AotTrue.verified/mcpserver/.mcp/server.json
@@ -1,12 +1,16 @@
 ﻿{
-  "$schema": "https://modelcontextprotocol.io/schemas/draft/2025-07-09/server.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "description": "<your description here>",
   "name": "io.github.<your GitHub username here>/<your repo name>",
+  "version": "0.1.0-beta",
   "packages": [
     {
-      "registry_name": "nuget",
-      "name": "<your package ID here>",
+      "registry_type": "nuget",
+      "identifier": "<your package ID here>",
       "version": "0.1.0-beta",
+      "transport": {
+        "type": "stdio"
+      },
       "package_arguments": [],
       "environment_variables": []
     }
@@ -14,8 +18,5 @@
   "repository": {
     "url": "https://github.com/<your GitHub username here>/<your repo name>",
     "source": "github"
-  },
-  "version_detail": {
-    "version": "0.1.0-beta"
   }
 }

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.SelfContainedFalse.verified/mcpserver/.mcp/server.json
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.SelfContainedFalse.verified/mcpserver/.mcp/server.json
@@ -1,12 +1,16 @@
 ﻿{
-  "$schema": "https://modelcontextprotocol.io/schemas/draft/2025-07-09/server.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "description": "<your description here>",
   "name": "io.github.<your GitHub username here>/<your repo name>",
+  "version": "0.1.0-beta",
   "packages": [
     {
-      "registry_name": "nuget",
-      "name": "<your package ID here>",
+      "registry_type": "nuget",
+      "identifier": "<your package ID here>",
       "version": "0.1.0-beta",
+      "transport": {
+        "type": "stdio"
+      },
       "package_arguments": [],
       "environment_variables": []
     }
@@ -14,8 +18,5 @@
   "repository": {
     "url": "https://github.com/<your GitHub username here>/<your repo name>",
     "source": "github"
-  },
-  "version_detail": {
-    "version": "0.1.0-beta"
   }
 }

--- a/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.net10.verified/mcpserver/.mcp/server.json
+++ b/test/ProjectTemplates/Microsoft.Extensions.AI.Templates.IntegrationTests/Snapshots/mcpserver.net10.verified/mcpserver/.mcp/server.json
@@ -1,12 +1,16 @@
 ﻿{
-  "$schema": "https://modelcontextprotocol.io/schemas/draft/2025-07-09/server.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "description": "<your description here>",
   "name": "io.github.<your GitHub username here>/<your repo name>",
+  "version": "0.1.0-beta",
   "packages": [
     {
-      "registry_name": "nuget",
-      "name": "<your package ID here>",
+      "registry_type": "nuget",
+      "identifier": "<your package ID here>",
       "version": "0.1.0-beta",
+      "transport": {
+        "type": "stdio"
+      },
       "package_arguments": [],
       "environment_variables": []
     }
@@ -14,8 +18,5 @@
   "repository": {
     "url": "https://github.com/<your GitHub username here>/<your repo name>",
     "source": "github"
-  },
-  "version_detail": {
-    "version": "0.1.0-beta"
   }
 }


### PR DESCRIPTION
Follow-up to #6796. There were new MCP Server template test baselines added before that PR was created, and those baselines were not updated. This is causing integration test failures in main.

This was caused by us merging [(#6772) Update MCP server template](https://github.com/dotnet/extensions/pull/6772) before merging [(#6796) Update MCP template for new registry specification](https://github.com/dotnet/extensions/pull/6796) and without merging main into that PR's branch before merge.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6874)