### PR TITLE
Adjust cgroupv2 drive format check for .NET 10 and higher

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringLinuxCgroupVersion.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringLinuxCgroupVersion.cs
@@ -23,7 +23,13 @@ internal static class ResourceMonitoringLinuxCgroupVersion
     {
         DriveInfo[] allDrives = DriveInfo.GetDrives();
         var injectParserV2 = false;
-        const string CgroupVersion = "cgroup2fs";
+        const string CgroupVersion =
+#if NET10_0_OR_GREATER
+        "cgroup2";
+#else
+        "cgroup2fs";
+#endif
+
         const string UnifiedCgroupPath = "/sys/fs/cgroup/unified";
 
         // We check which cgroup version is mounted in the system and based on that we inject the parser.


### PR DESCRIPTION
Fixes https://github.com/dotnet/extensions/issues/6832

I cannot run tests locally because of https://github.com/dotnet/extensions/issues/6463