### PR TITLE
Add copy constructors to option types (ChatOptions, etc.)

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## NOT YET RELEASED
+
+- Added protected copy constructors to options types.
+
 ## 9.9.1
 
 - Added new `ChatResponseFormat.ForJsonSchema` overloads that export a JSON schema from a .NET type.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
@@ -11,6 +11,46 @@ namespace Microsoft.Extensions.AI;
 /// <related type="Article" href="https://learn.microsoft.com/dotnet/ai/microsoft-extensions-ai#provide-options">Provide options.</related>
 public class ChatOptions
 {
+    /// <summary>Initializes a new instance of the <see cref="ChatOptions"/> class.</summary>
+    public ChatOptions()
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ChatOptions"/> class, performing a shallow copy of all properties from <paramref name="other"/>.</summary>
+    protected ChatOptions(ChatOptions? other)
+    {
+        if (other is null)
+        {
+            return;
+        }
+
+        AdditionalProperties = other.AdditionalProperties?.Clone();
+        AllowMultipleToolCalls = other.AllowMultipleToolCalls;
+        ConversationId = other.ConversationId;
+        FrequencyPenalty = other.FrequencyPenalty;
+        Instructions = other.Instructions;
+        MaxOutputTokens = other.MaxOutputTokens;
+        ModelId = other.ModelId;
+        PresencePenalty = other.PresencePenalty;
+        RawRepresentationFactory = other.RawRepresentationFactory;
+        ResponseFormat = other.ResponseFormat;
+        Seed = other.Seed;
+        Temperature = other.Temperature;
+        ToolMode = other.ToolMode;
+        TopK = other.TopK;
+        TopP = other.TopP;
+
+        if (other.StopSequences is not null)
+        {
+            StopSequences = [.. other.StopSequences];
+        }
+
+        if (other.Tools is not null)
+        {
+            Tools = [.. other.Tools];
+        }
+    }
+
     /// <summary>Gets or sets an optional identifier used to associate a request with an existing conversation.</summary>
     /// <related type="Article" href="https://learn.microsoft.com/dotnet/ai/microsoft-extensions-ai#stateless-vs-stateful-clients">Stateless vs. stateful clients.</related>
     public string? ConversationId { get; set; }
@@ -141,41 +181,14 @@ public class ChatOptions
     /// <summary>Produces a clone of the current <see cref="ChatOptions"/> instance.</summary>
     /// <returns>A clone of the current <see cref="ChatOptions"/> instance.</returns>
     /// <remarks>
+    /// <para>
     /// The clone will have the same values for all properties as the original instance. Any collections, like <see cref="Tools"/>,
     /// <see cref="StopSequences"/>, and <see cref="AdditionalProperties"/>, are shallow-cloned, meaning a new collection instance is created,
     /// but any references contained by the collections are shared with the original.
+    /// </para>
+    /// <para>
+    /// Derived types should override <see cref="Clone"/> to return an instance of the derived type.
+    /// </para>
     /// </remarks>
-    public virtual ChatOptions Clone()
-    {
-        ChatOptions options = new()
-        {
-            AdditionalProperties = AdditionalProperties?.Clone(),
-            AllowMultipleToolCalls = AllowMultipleToolCalls,
-            ConversationId = ConversationId,
-            FrequencyPenalty = FrequencyPenalty,
-            Instructions = Instructions,
-            MaxOutputTokens = MaxOutputTokens,
-            ModelId = ModelId,
-            PresencePenalty = PresencePenalty,
-            RawRepresentationFactory = RawRepresentationFactory,
-            ResponseFormat = ResponseFormat,
-            Seed = Seed,
-            Temperature = Temperature,
-            ToolMode = ToolMode,
-            TopK = TopK,
-            TopP = TopP,
-        };
-
-        if (StopSequences is not null)
-        {
-            options.StopSequences = new List<string>(StopSequences);
-        }
-
-        if (Tools is not null)
-        {
-            options.Tools = new List<AITool>(Tools);
-        }
-
-        return options;
-    }
+    public virtual ChatOptions Clone() => new(this);
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/EmbeddingGenerationOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/EmbeddingGenerationOptions.cs
@@ -10,6 +10,25 @@ namespace Microsoft.Extensions.AI;
 /// <summary>Represents the options for an embedding generation request.</summary>
 public class EmbeddingGenerationOptions
 {
+    /// <summary>Initializes a new instance of the <see cref="EmbeddingGenerationOptions"/> class.</summary>
+    public EmbeddingGenerationOptions()
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="EmbeddingGenerationOptions"/> class, performing a shallow copy of all properties from <paramref name="other"/>.</summary>
+    protected EmbeddingGenerationOptions(EmbeddingGenerationOptions? other)
+    {
+        if (other is null)
+        {
+            return;
+        }
+
+        AdditionalProperties = other.AdditionalProperties?.Clone();
+        Dimensions = other.Dimensions;
+        ModelId = other.ModelId;
+        RawRepresentationFactory = other.RawRepresentationFactory;
+    }
+
     /// <summary>Gets or sets the number of dimensions requested in the embedding.</summary>
     public int? Dimensions
     {
@@ -56,11 +75,5 @@ public class EmbeddingGenerationOptions
     /// The clone will have the same values for all properties as the original instance. Any collections, like <see cref="AdditionalProperties"/>
     /// are shallow-cloned, meaning a new collection instance is created, but any references contained by the collections are shared with the original.
     /// </remarks>
-    public virtual EmbeddingGenerationOptions Clone() =>
-        new()
-        {
-            ModelId = ModelId,
-            Dimensions = Dimensions,
-            AdditionalProperties = AdditionalProperties?.Clone(),
-        };
+    public virtual EmbeddingGenerationOptions Clone() => new(this);
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Image/ImageGenerationOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Image/ImageGenerationOptions.cs
@@ -12,6 +12,28 @@ namespace Microsoft.Extensions.AI;
 [Experimental("MEAI001")]
 public class ImageGenerationOptions
 {
+    /// <summary>Initializes a new instance of the <see cref="ImageGenerationOptions"/> class.</summary>
+    public ImageGenerationOptions()
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ImageGenerationOptions"/> class, performing a shallow copy of all properties from <paramref name="other"/>.</summary>
+    protected ImageGenerationOptions(ImageGenerationOptions? other)
+    {
+        if (other is null)
+        {
+            return;
+        }
+
+        AdditionalProperties = other.AdditionalProperties?.Clone();
+        Count = other.Count;
+        ImageSize = other.ImageSize;
+        MediaType = other.MediaType;
+        ModelId = other.ModelId;
+        RawRepresentationFactory = other.RawRepresentationFactory;
+        ResponseFormat = other.ResponseFormat;
+    }
+
     /// <summary>
     /// Gets or sets the number of images to generate.
     /// </summary>
@@ -64,21 +86,7 @@ public class ImageGenerationOptions
 
     /// <summary>Produces a clone of the current <see cref="ImageGenerationOptions"/> instance.</summary>
     /// <returns>A clone of the current <see cref="ImageGenerationOptions"/> instance.</returns>
-    public virtual ImageGenerationOptions Clone()
-    {
-        ImageGenerationOptions options = new()
-        {
-            AdditionalProperties = AdditionalProperties?.Clone(),
-            Count = Count,
-            MediaType = MediaType,
-            ImageSize = ImageSize,
-            ModelId = ModelId,
-            RawRepresentationFactory = RawRepresentationFactory,
-            ResponseFormat = ResponseFormat
-        };
-
-        return options;
-    }
+    public virtual ImageGenerationOptions Clone() => new(this);
 }
 
 /// <summary>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -984,6 +984,10 @@
           "Stage": "Stable"
         },
         {
+          "Member": "Microsoft.Extensions.AI.ChatOptions.ChatOptions(Microsoft.Extensions.AI.ChatOptions? other);",
+          "Stage": "Stable"
+        },
+        {
           "Member": "virtual Microsoft.Extensions.AI.ChatOptions Microsoft.Extensions.AI.ChatOptions.Clone();",
           "Stage": "Stable"
         }
@@ -1691,6 +1695,10 @@
       "Methods": [
         {
           "Member": "Microsoft.Extensions.AI.EmbeddingGenerationOptions.EmbeddingGenerationOptions();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.EmbeddingGenerationOptions.EmbeddingGenerationOptions(Microsoft.Extensions.AI.EmbeddingGenerationOptions? other);",
           "Stage": "Stable"
         },
         {

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/SpeechToText/SpeechToTextOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/SpeechToText/SpeechToTextOptions.cs
@@ -11,6 +11,27 @@ namespace Microsoft.Extensions.AI;
 [Experimental("MEAI001")]
 public class SpeechToTextOptions
 {
+    /// <summary>Initializes a new instance of the <see cref="SpeechToTextOptions"/> class.</summary>
+    public SpeechToTextOptions()
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="SpeechToTextOptions"/> class, performing a shallow copy of all properties from <paramref name="other"/>.</summary>
+    protected SpeechToTextOptions(SpeechToTextOptions? other)
+    {
+        if (other is null)
+        {
+            return;
+        }
+
+        AdditionalProperties = other.AdditionalProperties?.Clone();
+        ModelId = other.ModelId;
+        RawRepresentationFactory = other.RawRepresentationFactory;
+        SpeechLanguage = other.SpeechLanguage;
+        SpeechSampleRate = other.SpeechSampleRate;
+        TextLanguage = other.TextLanguage;
+    }
+
     /// <summary>Gets or sets any additional properties associated with the options.</summary>
     public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
 
@@ -47,17 +68,5 @@ public class SpeechToTextOptions
 
     /// <summary>Produces a clone of the current <see cref="SpeechToTextOptions"/> instance.</summary>
     /// <returns>A clone of the current <see cref="SpeechToTextOptions"/> instance.</returns>
-    public virtual SpeechToTextOptions Clone()
-    {
-        SpeechToTextOptions options = new()
-        {
-            AdditionalProperties = AdditionalProperties?.Clone(),
-            ModelId = ModelId,
-            SpeechLanguage = SpeechLanguage,
-            SpeechSampleRate = SpeechSampleRate,
-            TextLanguage = TextLanguage,
-        };
-
-        return options;
-    }
+    public virtual SpeechToTextOptions Clone() => new(this);
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyChatOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyChatOptions.cs
@@ -1,10 +1,27 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Shared.Diagnostics;
+
 namespace Microsoft.Extensions.AI.Evaluation.Safety;
 
-internal sealed class ContentSafetyChatOptions(string annotationTask, string evaluatorName) : ChatOptions
+internal sealed class ContentSafetyChatOptions : ChatOptions
 {
-    internal string AnnotationTask { get; } = annotationTask;
-    internal string EvaluatorName { get; } = evaluatorName;
+    public ContentSafetyChatOptions(string annotationTask, string evaluatorName)
+    {
+        AnnotationTask = annotationTask;
+        EvaluatorName = evaluatorName;
+    }
+
+    private ContentSafetyChatOptions(ContentSafetyChatOptions other)
+        : base(Throw.IfNull(other))
+    {
+        AnnotationTask = other.AnnotationTask;
+        EvaluatorName = other.EvaluatorName;
+    }
+
+    public string AnnotationTask { get; }
+    public string EvaluatorName { get; }
+
+    public override ChatOptions Clone() => new ContentSafetyChatOptions(this);
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatOptionsTests.cs
@@ -198,4 +198,70 @@ public class ChatOptionsTests
         Assert.IsType<JsonElement>(value);
         Assert.Equal("value", ((JsonElement)value!).GetString());
     }
+
+    [Fact]
+    public void CopyConstructors_EnableHeirarchyCloning()
+    {
+        OptionsB b = new()
+        {
+            ModelId = "test",
+            A = 42,
+            B = 84,
+        };
+
+        ChatOptions clone = b.Clone();
+
+        Assert.Equal("test", clone.ModelId);
+        Assert.Equal(42, Assert.IsType<OptionsA>(clone, exactMatch: false).A);
+        Assert.Equal(84, Assert.IsType<OptionsB>(clone, exactMatch: true).B);
+    }
+
+    private class OptionsA : ChatOptions
+    {
+        public OptionsA()
+        {
+        }
+
+        protected OptionsA(OptionsA other)
+            : base(other)
+        {
+            A = other.A;
+        }
+
+        public int A { get; set; }
+
+        public override ChatOptions Clone() => new OptionsA(this);
+    }
+
+    private class OptionsB : OptionsA
+    {
+        public OptionsB()
+        {
+        }
+
+        protected OptionsB(OptionsB other)
+            : base(other)
+        {
+            B = other.B;
+        }
+
+        public int B { get; set; }
+
+        public override ChatOptions Clone() => new OptionsB(this);
+    }
+
+    [Fact]
+    public void CopyConstructor_Null_Valid()
+    {
+        PassedNullToBaseOptions options = new();
+        Assert.NotNull(options);
+    }
+
+    private class PassedNullToBaseOptions : ChatOptions
+    {
+        public PassedNullToBaseOptions()
+            : base(null)
+        {
+        }
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Image/ImageGenerationOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Image/ImageGenerationOptionsTests.cs
@@ -132,4 +132,70 @@ public class ImageGenerationOptionsTests
             Assert.Equal(responseFormat, deserialized);
         }
     }
+
+    [Fact]
+    public void CopyConstructors_EnableHeirarchyCloning()
+    {
+        OptionsB b = new()
+        {
+            ModelId = "test",
+            A = 42,
+            B = 84,
+        };
+
+        ImageGenerationOptions clone = b.Clone();
+
+        Assert.Equal("test", clone.ModelId);
+        Assert.Equal(42, Assert.IsType<OptionsA>(clone, exactMatch: false).A);
+        Assert.Equal(84, Assert.IsType<OptionsB>(clone, exactMatch: true).B);
+    }
+
+    private class OptionsA : ImageGenerationOptions
+    {
+        public OptionsA()
+        {
+        }
+
+        protected OptionsA(OptionsA other)
+            : base(other)
+        {
+            A = other.A;
+        }
+
+        public int A { get; set; }
+
+        public override ImageGenerationOptions Clone() => new OptionsA(this);
+    }
+
+    private class OptionsB : OptionsA
+    {
+        public OptionsB()
+        {
+        }
+
+        protected OptionsB(OptionsB other)
+            : base(other)
+        {
+            B = other.B;
+        }
+
+        public int B { get; set; }
+
+        public override ImageGenerationOptions Clone() => new OptionsB(this);
+    }
+
+    [Fact]
+    public void CopyConstructor_Null_Valid()
+    {
+        PassedNullToBaseOptions options = new();
+        Assert.NotNull(options);
+    }
+
+    private class PassedNullToBaseOptions : ImageGenerationOptions
+    {
+        public PassedNullToBaseOptions()
+            : base(null)
+        {
+        }
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/SpeechToText/SpeechToTextOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/SpeechToText/SpeechToTextOptionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text.Json;
 using Xunit;
 
@@ -34,21 +35,26 @@ public class SpeechToTextOptionsTests
             ["key"] = "value",
         };
 
+        Func<ISpeechToTextClient?, object?> rawRepresentationFactory = (c) => null;
+
         options.ModelId = "modelId";
         options.SpeechLanguage = "en-US";
         options.SpeechSampleRate = 44100;
         options.AdditionalProperties = additionalProps;
+        options.RawRepresentationFactory = rawRepresentationFactory;
 
         Assert.Equal("modelId", options.ModelId);
         Assert.Equal("en-US", options.SpeechLanguage);
         Assert.Equal(44100, options.SpeechSampleRate);
         Assert.Same(additionalProps, options.AdditionalProperties);
+        Assert.Same(rawRepresentationFactory, options.RawRepresentationFactory);
 
         SpeechToTextOptions clone = options.Clone();
         Assert.Equal("modelId", clone.ModelId);
         Assert.Equal("en-US", clone.SpeechLanguage);
         Assert.Equal(44100, clone.SpeechSampleRate);
         Assert.Equal(additionalProps, clone.AdditionalProperties);
+        Assert.Same(rawRepresentationFactory, clone.RawRepresentationFactory);
     }
 
     [Fact]
@@ -80,5 +86,71 @@ public class SpeechToTextOptionsTests
         Assert.True(deserialized.AdditionalProperties.TryGetValue("key", out object? value));
         Assert.IsType<JsonElement>(value);
         Assert.Equal("value", ((JsonElement)value!).GetString());
+    }
+
+    [Fact]
+    public void CopyConstructors_EnableHeirarchyCloning()
+    {
+        OptionsB b = new()
+        {
+            ModelId = "test",
+            A = 42,
+            B = 84,
+        };
+
+        SpeechToTextOptions clone = b.Clone();
+
+        Assert.Equal("test", clone.ModelId);
+        Assert.Equal(42, Assert.IsType<OptionsA>(clone, exactMatch: false).A);
+        Assert.Equal(84, Assert.IsType<OptionsB>(clone, exactMatch: true).B);
+    }
+
+    private class OptionsA : SpeechToTextOptions
+    {
+        public OptionsA()
+        {
+        }
+
+        protected OptionsA(OptionsA other)
+            : base(other)
+        {
+            A = other.A;
+        }
+
+        public int A { get; set; }
+
+        public override SpeechToTextOptions Clone() => new OptionsA(this);
+    }
+
+    private class OptionsB : OptionsA
+    {
+        public OptionsB()
+        {
+        }
+
+        protected OptionsB(OptionsB other)
+            : base(other)
+        {
+            B = other.B;
+        }
+
+        public int B { get; set; }
+
+        public override SpeechToTextOptions Clone() => new OptionsB(this);
+    }
+
+    [Fact]
+    public void CopyConstructor_Null_Valid()
+    {
+        PassedNullToBaseOptions options = new();
+        Assert.NotNull(options);
+    }
+
+    private class PassedNullToBaseOptions : SpeechToTextOptions
+    {
+        public PassedNullToBaseOptions()
+            : base(null)
+        {
+        }
     }
 }


### PR DESCRIPTION
To enable the Clone methods to support derivation and to enable decorators to pass down cloneable state.

This also fixes a bug that EmbeddingGenerationOptions.Clone and SpeechToTextOptions.Clone were not cloning raw representation.