### PR TITLE
Fix Assistants IChatClient handling of unrelated tool calls in history

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NOT YET RELEASED
 
+- Fixed issue with IChatClient for Assistants API where a chat history including unrelated function calls would cause an exception.
+
 ## 9.9.1-preview.1.25474.6
 
 - Updated to depend on OpenAI 2.5.0.


### PR DESCRIPTION
The implementation is assuming that any tool results in the incoming message history mean a thread ID is required, which would be necessary if those tool results were for an active run. But that's not the case if the history just contains historical function calls/responses, as is the case in agent scenarios where the message history from one agent is passed to another.  The fix is to just stop throwing based on this incorrect assumption.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6891)