### PR TITLE
Update OpenTelemetryChatClient to output data on all tools

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -1952,6 +1952,10 @@
         {
           "Member": "System.Collections.Generic.IList<Microsoft.Extensions.AI.AIContent>? Microsoft.Extensions.AI.HostedCodeInterpreterTool.Inputs { get; set; }",
           "Stage": "Stable"
+        },
+        {
+          "Member": "override string Microsoft.Extensions.AI.HostedCodeInterpreterTool.Name { get; }",
+          "Stage": "Stable"
         }
       ]
     },
@@ -1972,6 +1976,10 @@
         {
           "Member": "int? Microsoft.Extensions.AI.HostedFileSearchTool.MaximumResultCount { get; set; }",
           "Stage": "Stable"
+        },
+        {
+          "Member": "override string Microsoft.Extensions.AI.HostedFileSearchTool.Name { get; }",
+          "Stage": "Stable"
         }
       ]
     },
@@ -1981,6 +1989,12 @@
       "Methods": [
         {
           "Member": "Microsoft.Extensions.AI.HostedWebSearchTool.HostedWebSearchTool();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "override string Microsoft.Extensions.AI.HostedWebSearchTool.Name { get; }",
           "Stage": "Stable"
         }
       ]

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/HostedCodeInterpreterTool.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/HostedCodeInterpreterTool.cs
@@ -17,6 +17,9 @@ public class HostedCodeInterpreterTool : AITool
     {
     }
 
+    /// <inheritdoc />
+    public override string Name => "code_interpreter";
+
     /// <summary>Gets or sets a collection of <see cref="AIContent"/> to be used as input to the code interpreter tool.</summary>
     /// <remarks>
     /// Services support different varied kinds of inputs. Most support the IDs of files that are hosted by the service,

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/HostedFileSearchTool.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/HostedFileSearchTool.cs
@@ -17,6 +17,9 @@ public class HostedFileSearchTool : AITool
     {
     }
 
+    /// <inheritdoc />
+    public override string Name => "file_search";
+
     /// <summary>Gets or sets a collection of <see cref="AIContent"/> to be used as input to the file search tool.</summary>
     /// <remarks>
     /// If no explicit inputs are provided, the service determines what inputs should be searched. Different services

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/HostedMcpServerTool.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/HostedMcpServerTool.cs
@@ -39,6 +39,9 @@ public class HostedMcpServerTool : AITool
         Url = Throw.IfNull(url);
     }
 
+    /// <inheritdoc />
+    public override string Name => "mcp";
+
     /// <summary>
     /// Gets the name of the remote MCP server that is used to identify it.
     /// </summary>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/HostedWebSearchTool.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/HostedWebSearchTool.cs
@@ -14,4 +14,7 @@ public class HostedWebSearchTool : AITool
     public HostedWebSearchTool()
     {
     }
+
+    /// <inheritdoc />
+    public override string Name => "web_search";
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/HostedCodeInterpreterToolTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/HostedCodeInterpreterToolTests.cs
@@ -11,11 +11,11 @@ public class HostedCodeInterpreterToolTests
     public void Constructor_Roundtrips()
     {
         var tool = new HostedCodeInterpreterTool();
-        Assert.Equal(nameof(HostedCodeInterpreterTool), tool.Name);
+        Assert.Equal("code_interpreter", tool.Name);
         Assert.Empty(tool.Description);
         Assert.Empty(tool.AdditionalProperties);
         Assert.Null(tool.Inputs);
-        Assert.Equal(nameof(HostedCodeInterpreterTool), tool.ToString());
+        Assert.Equal(tool.Name, tool.ToString());
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/HostedFileSearchToolTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/HostedFileSearchToolTests.cs
@@ -11,12 +11,12 @@ public class HostedFileSearchToolTests
     public void Constructor_Roundtrips()
     {
         var tool = new HostedFileSearchTool();
-        Assert.Equal(nameof(HostedFileSearchTool), tool.Name);
+        Assert.Equal("file_search", tool.Name);
         Assert.Empty(tool.Description);
         Assert.Empty(tool.AdditionalProperties);
         Assert.Null(tool.Inputs);
         Assert.Null(tool.MaximumResultCount);
-        Assert.Equal(nameof(HostedFileSearchTool), tool.ToString());
+        Assert.Equal(tool.Name, tool.ToString());
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/HostedMcpServerToolTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/HostedMcpServerToolTests.cs
@@ -31,7 +31,8 @@ public class HostedMcpServerToolTests
 
         Assert.Empty(tool.AdditionalProperties);
         Assert.Empty(tool.Description);
-        Assert.Equal(nameof(HostedMcpServerTool), tool.Name);
+        Assert.Equal("mcp", tool.Name);
+        Assert.Equal(tool.Name, tool.ToString());
 
         Assert.Equal("serverName", tool.ServerName);
         Assert.Equal("https://localhost/", tool.Url.ToString());

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/HostedWebSearchToolTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/HostedWebSearchToolTests.cs
@@ -11,9 +11,9 @@ public class HostedWebSearchToolTests
     public void Constructor_Roundtrips()
     {
         var tool = new HostedWebSearchTool();
-        Assert.Equal(nameof(HostedWebSearchTool), tool.Name);
+        Assert.Equal("web_search", tool.Name);
         Assert.Empty(tool.Description);
         Assert.Empty(tool.AdditionalProperties);
-        Assert.Equal(nameof(HostedWebSearchTool), tool.ToString());
+        Assert.Equal(tool.Name, tool.ToString());
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
@@ -134,6 +134,9 @@ public class OpenTelemetryChatClientTests
             [
                 AIFunctionFactory.Create((string personName) => personName, "GetPersonAge", "Gets the age of a person by name."),
                 new HostedWebSearchTool(),
+                new HostedFileSearchTool(),
+                new HostedCodeInterpreterTool(),
+                new HostedMcpServerTool("myAwesomeServer", "http://localhost:1234/somewhere"),
                 AIFunctionFactory.Create((string location) => "", "GetCurrentWeather", "Gets the current weather for a location.").AsDeclarationOnly(),
             ],
         };
@@ -287,6 +290,18 @@ public class OpenTelemetryChatClientTests
                         "personName"
                       ]
                     }
+                  },
+                  {
+                    "type": "web_search"
+                  },
+                  {
+                    "type": "file_search"
+                  },
+                  {
+                    "type": "code_interpreter"
+                  },
+                  {
+                    "type": "mcp"
                   },
                   {
                     "type": "function",


### PR DESCRIPTION
We're currently filtering down to only AITools that are AIFunctionDeclaration. With this, we'll handle AIFunctionDeclaration wrappers the same as well, and for all other tools emit their name as the type. This can be further extended as otel adds more details about how non-function tools should be represented.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6906)