### PR TITLE
Disallow approval response contents on non-user roles

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -1314,6 +1314,11 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
                         break;
 
                     case FunctionApprovalResponseContent farc:
+                        if (message.Role != ChatRole.User)
+                        {
+                            Throw.ArgumentException(nameof(messages), $"{nameof(FunctionApprovalResponseContent)} can only be included in messages with ChatRole.User.");
+                        }
+
                         // Validation: Remove the call id for each approval response, to check it off the list of requests we need responses for.
                         _ = approvalRequestCallIds?.Remove(farc.FunctionCall.CallId);
                         (allApprovalResponses ??= []).Add(farc);

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
@@ -167,7 +167,7 @@ public class OpenAIResponseClientIntegrationTests : ChatClientIntegrationTests
                     input.AddRange(response.Messages);
                 }
 
-                var approvalResponse = new ChatMessage(ChatRole.Tool,
+                var approvalResponse = new ChatMessage(ChatRole.User,
                     response.Messages
                             .SelectMany(m => m.Contents)
                             .OfType<McpServerToolApprovalRequestContent>()


### PR DESCRIPTION
Context: https://github.com/dotnet/extensions/pull/6881#discussion_r2419557556

FunctionApprovalResponseContent and McpServerToolApprovalResponseContent should be included only in ChatMessages with ChatRole.User. These approval responses represent user decisions to approve or reject function/tool calls, so it's semantically correct to require them to come from the user role.

@westey-m 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6961)