### PR TITLE
Update to 1.38 of the otel genai standard convention

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryImageGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryImageGenerator.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a delegating image generator that implements the OpenTelemetry Semantic Conventions for Generative AI systems.</summary>
 /// <remarks>
-/// This class provides an implementation of the Semantic Conventions for Generative AI systems v1.37, defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
+/// This class provides an implementation of the Semantic Conventions for Generative AI systems v1.38, defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
 /// The specification is still experimental and subject to change; as such, the telemetry output by this client is also subject to change.
 /// </remarks>
 [Experimental("MEAI001")]

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a delegating embedding generator that implements the OpenTelemetry Semantic Conventions for Generative AI systems.</summary>
 /// <remarks>
-/// This class provides an implementation of the Semantic Conventions for Generative AI systems v1.37, defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
+/// This class provides an implementation of the Semantic Conventions for Generative AI systems v1.38, defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
 /// The specification is still experimental and subject to change; as such, the telemetry output by this client is also subject to change.
 /// </remarks>
 /// <typeparam name="TInput">The type of input used to produce embeddings.</typeparam>

--- a/src/Libraries/Microsoft.Extensions.AI/SpeechToText/OpenTelemetrySpeechToTextClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/SpeechToText/OpenTelemetrySpeechToTextClient.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a delegating speech-to-text client that implements the OpenTelemetry Semantic Conventions for Generative AI systems.</summary>
 /// <remarks>
-/// This class provides an implementation of the Semantic Conventions for Generative AI systems v1.37, defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
+/// This class provides an implementation of the Semantic Conventions for Generative AI systems v1.38, defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
 /// The specification is still experimental and subject to change; as such, the telemetry output by this client is also subject to change.
 /// </remarks>
 [Experimental("MEAI001")]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
@@ -333,6 +333,192 @@ public class OpenTelemetryChatClientTests
         }
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AllOfficialOtelContentPartTypes_SerializedCorrectly(bool streaming)
+    {
+        var sourceName = Guid.NewGuid().ToString();
+        var activities = new List<Activity>();
+        using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .AddInMemoryExporter(activities)
+            .Build();
+
+        using var innerClient = new TestChatClient
+        {
+            GetResponseAsyncCallback = async (messages, options, cancellationToken) =>
+            {
+                await Task.Yield();
+                return new ChatResponse(new ChatMessage(ChatRole.Assistant,
+                [
+                    new TextContent("Assistant response text"),
+                    new TextReasoningContent("This is reasoning"),
+                    new FunctionCallContent("call-123", "GetWeather", new Dictionary<string, object?> { ["location"] = "Seattle" }),
+                    new FunctionResultContent("call-123", "72°F and sunny"),
+                    new DataContent(Convert.FromBase64String("aGVsbG8gd29ybGQ="), "image/png"),
+                    new UriContent(new Uri("https://example.com/image.jpg"), "image/jpeg"),
+                    new HostedFileContent("file-abc123"),
+                ]));
+            },
+            GetStreamingResponseAsyncCallback = CallbackAsync,
+        };
+
+        async static IAsyncEnumerable<ChatResponseUpdate> CallbackAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            yield return new(ChatRole.Assistant, "Assistant response text");
+            yield return new() { Contents = [new TextReasoningContent("This is reasoning")] };
+            yield return new() { Contents = [new FunctionCallContent("call-123", "GetWeather", new Dictionary<string, object?> { ["location"] = "Seattle" })] };
+            yield return new() { Contents = [new FunctionResultContent("call-123", "72°F and sunny")] };
+            yield return new() { Contents = [new DataContent(Convert.FromBase64String("aGVsbG8gd29ybGQ="), "image/png")] };
+            yield return new() { Contents = [new UriContent(new Uri("https://example.com/image.jpg"), "image/jpeg")] };
+            yield return new() { Contents = [new HostedFileContent("file-abc123")] };
+        }
+
+        using var chatClient = innerClient
+            .AsBuilder()
+            .UseOpenTelemetry(null, sourceName, configure: instance =>
+            {
+                instance.EnableSensitiveData = true;
+                instance.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;
+            })
+            .Build();
+
+        List<ChatMessage> messages =
+        [
+            new(ChatRole.User,
+            [
+                new TextContent("User request text"),
+                new TextReasoningContent("User reasoning"),
+                new DataContent(Convert.FromBase64String("ZGF0YSBjb250ZW50"), "audio/mp3"),
+                new UriContent(new Uri("https://example.com/video.mp4"), "video/mp4"),
+                new HostedFileContent("file-xyz789"),
+            ]),
+            new(ChatRole.Assistant, [new FunctionCallContent("call-456", "SearchFiles")]),
+            new(ChatRole.Tool, [new FunctionResultContent("call-456", "Found 3 files")]),
+        ];
+
+        if (streaming)
+        {
+            await foreach (var update in chatClient.GetStreamingResponseAsync(messages))
+            {
+                await Task.Yield();
+            }
+        }
+        else
+        {
+            await chatClient.GetResponseAsync(messages);
+        }
+
+        var activity = Assert.Single(activities);
+        Assert.NotNull(activity);
+
+        var inputMessages = activity.Tags.First(kvp => kvp.Key == "gen_ai.input.messages").Value;
+        Assert.Equal(ReplaceWhitespace("""
+            [
+              {
+                "role": "user",
+                "parts": [
+                  {
+                    "type": "text",
+                    "content": "User request text"
+                  },
+                  {
+                    "type": "reasoning",
+                    "content": "User reasoning"
+                  },
+                  {
+                    "type": "blob",
+                    "content": "ZGF0YSBjb250ZW50",
+                    "mime_type": "audio/mp3",
+                    "modality": "audio"
+                  },
+                  {
+                    "type": "uri",
+                    "uri": "https://example.com/video.mp4",
+                    "mime_type": "video/mp4",
+                    "modality": "video"
+                  },
+                  {
+                    "type": "file",
+                    "file_id": "file-xyz789"
+                  }
+                ]
+              },
+              {
+                "role": "assistant",
+                "parts": [
+                  {
+                    "type": "tool_call",
+                    "id": "call-456",
+                    "name": "SearchFiles"
+                  }
+                ]
+              },
+              {
+                "role": "tool",
+                "parts": [
+                  {
+                    "type": "tool_call_response",
+                    "id": "call-456",
+                    "response": "Found 3 files"
+                  }
+                ]
+              }
+            ]
+            """), ReplaceWhitespace(inputMessages));
+
+        var outputMessages = activity.Tags.First(kvp => kvp.Key == "gen_ai.output.messages").Value;
+        Assert.Equal(ReplaceWhitespace("""
+            [
+              {
+                "role": "assistant",
+                "parts": [
+                  {
+                    "type": "text",
+                    "content": "Assistant response text"
+                  },
+                  {
+                    "type": "reasoning",
+                    "content": "This is reasoning"
+                  },
+                  {
+                    "type": "tool_call",
+                    "id": "call-123",
+                    "name": "GetWeather",
+                    "arguments": {
+                      "location": "Seattle"
+                    }
+                  },
+                  {
+                    "type": "tool_call_response",
+                    "id": "call-123",
+                    "response": "72°F and sunny"
+                  },
+                  {
+                    "type": "blob",
+                    "content": "aGVsbG8gd29ybGQ=",
+                    "mime_type": "image/png",
+                    "modality": "image"
+                  },
+                  {
+                    "type": "uri",
+                    "uri": "https://example.com/image.jpg",
+                    "mime_type": "image/jpeg",
+                    "modality": "image"
+                  },
+                  {
+                    "type": "file",
+                    "file_id": "file-abc123"
+                  }
+                ]
+              }
+            ]
+            """), ReplaceWhitespace(outputMessages));
+    }
+
     [Fact]
     public async Task UnknownContentTypes_Ignored()
     {

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Image/OpenTelemetryImageGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Image/OpenTelemetryImageGeneratorTests.cs
@@ -125,8 +125,10 @@ public class OpenTelemetryImageGeneratorTests
                         "content": "This is the input prompt."
                       },
                       {
-                        "type": "image",
-                        "content": "http://example/input.png"
+                        "type": "uri",
+                        "uri": "http://example/input.png",
+                        "mime_type": "image/png",
+                        "modality": "image"
                       }
                     ]
                   }
@@ -139,12 +141,16 @@ public class OpenTelemetryImageGeneratorTests
                     "role": "assistant",
                     "parts": [
                       {
-                        "type": "image",
-                        "content": "http://example/output.png"
+                        "type": "uri",
+                        "uri": "http://example/output.png",
+                        "mime_type": "image/png",
+                        "modality": "image"
                       },
                       {
-                        "type": "image",
-                        "content": "data:image/png;base64,AQIDBA=="
+                        "type": "blob",
+                        "content": "AQIDBA==",
+                        "mime_type": "image/png",
+                        "modality": "image"
                       }
                     ]
                   }


### PR DESCRIPTION
https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.38.0

These blob, file, and uri parts just got added to the spec earlier today and were the only updates for 1.38 we didn't yet incorporate.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/6981)