### PR TITLE
When using latest .NET packages, force System.Numerics.Tensors to 10.0 (for MEAI)

### DIFF
--- a/eng/packages/General-net10.props
+++ b/eng/packages/General-net10.props
@@ -38,6 +38,7 @@
     <PackageVersion Include="System.IO.Pipelines" Version="$(SystemIOPipelinesNet10Version)" />
     <PackageVersion Include="System.Memory.Data" Version="$(SystemMemoryDataNet10Version)" />
     <PackageVersion Include="System.Net.Http.Json" Version="$(SystemNetHttpJsonNet10Version)" />
+    <PackageVersion Include="System.Numerics.Tensors" Version="$(SystemNumericsTensorsNet10Version)" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebNet10Version)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonNet10Version)" />
     <PackageVersion Include="System.Threading.Channels" Version="$(SystemThreadingChannelsNet10Version)" />

--- a/eng/packages/General-net9.props
+++ b/eng/packages/General-net9.props
@@ -38,6 +38,7 @@
     <PackageVersion Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
     <PackageVersion Include="System.Memory.Data" Version="$(SystemMemoryDataVersion)" />
     <PackageVersion Include="System.Net.Http.Json" Version="$(SystemNetHttpJsonVersion)" />
+    <PackageVersion Include="System.Numerics.Tensors" Version="$(SystemNumericsTensorsVersion)" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageVersion Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />

--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -33,7 +33,6 @@
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
-    <PackageVersion Include="System.Numerics.Tensors" Version="$(SystemNumericsTensorsVersion)" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Runtime.Caching" Version="$(SystemRuntimeCachingVersion)" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/Microsoft.Extensions.AI.Integration.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/Microsoft.Extensions.AI.Integration.Tests.csproj
@@ -46,7 +46,6 @@
     <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
     <PackageReference Include="PdfPig" />
-    <PackageReference Include="System.Numerics.Tensors" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The MEAI libraries depend on System.Numerics.Tensors, but with [Make MEAI packages use 10.0 runtime packages (#7028)](https://github.com/dotnet/extensions/pull/7028) that package is not getting set to the 10.0 version. This PR adds that package into the list of packages to bump up to the 10.0 version.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7031)