### PR TITLE
Reset Microsoft.Agents.AI.ProjectTemplates versioning

### DIFF
--- a/src/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.csproj
+++ b/src/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.csproj
@@ -13,7 +13,6 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <VersionSuffix>preview.251110.2</VersionSuffix>
 
     <Workstream>AI</Workstream>
     <MinCodeCoverage>0</MinCodeCoverage>


### PR DESCRIPTION
The version suffix gets overriden during official builds; no need to have it set.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7034)