### PR TITLE
Add Image Detail support for Image DataContent to OpenAIResponsesChatClient.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -851,11 +851,11 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                             break;
 
                         case UriContent uriContent when uriContent.HasTopLevelMediaType("image"):
-                            (parts ??= []).Add(ResponseContentPart.CreateInputImagePart(uriContent.Uri));
+                            (parts ??= []).Add(ResponseContentPart.CreateInputImagePart(uriContent.Uri, GetImageDetail(item)));
                             break;
 
                         case DataContent dataContent when dataContent.HasTopLevelMediaType("image"):
-                            (parts ??= []).Add(ResponseContentPart.CreateInputImagePart(BinaryData.FromBytes(dataContent.Data), dataContent.MediaType));
+                            (parts ??= []).Add(ResponseContentPart.CreateInputImagePart(BinaryData.FromBytes(dataContent.Data), dataContent.MediaType, GetImageDetail(item)));
                             break;
 
                         case DataContent dataContent when dataContent.MediaType.StartsWith("application/pdf", StringComparison.OrdinalIgnoreCase):
@@ -1380,6 +1380,21 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
             }
 
             return OpenAIResponsesContinuationToken.FromToken(token);
+        }
+
+        return null;
+    }
+
+    private static ResponseImageDetailLevel? GetImageDetail(AIContent content)
+    {
+        if (content.AdditionalProperties?.TryGetValue("detail", out object? value) is true)
+        {
+            return value switch
+            {
+                string detailString => new ResponseImageDetailLevel(detailString),
+                ResponseImageDetailLevel detail => detail,
+                _ => null
+            };
         }
 
         return null;

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -4246,7 +4246,9 @@ public class OpenAIResponseClientTests
                         "content":[
                             {"type":"input_text","text":"Check this image: "},
                             {"type":"input_image","image_url":"https://example.com/image.png"},
+                            {"type":"input_image","image_url":"https://example.com/image.png","detail":"high"},
                             {"type":"input_image","image_url":"data:image/png;base64,iVBORw0KGgo="},
+                            {"type":"input_image","image_url":"data:image/png;base64,iVBORw0KGgo=","detail":"low"},
                             {"type":"input_file","file_data":"data:application/pdf;base64,cGRmZGF0YQ==","filename":"doc.pdf"},
                             {"type":"input_file","file_id":"file-123"},
                             {"type":"refusal","refusal":"I cannot process this"}
@@ -4278,7 +4280,9 @@ public class OpenAIResponseClientTests
             new ChatMessage(ChatRole.User, [
                 new TextContent("Check this image: "),
                 new UriContent(new Uri("https://example.com/image.png"), "image/png"),
+                new UriContent(new Uri("https://example.com/image.png"), "image/png") { AdditionalProperties = new AdditionalPropertiesDictionary { ["detail"] = "high" }},
                 new DataContent(imageData, "image/png"),
+                new DataContent(imageData, "image/png") { AdditionalProperties = new AdditionalPropertiesDictionary { ["detail"] = ResponseImageDetailLevel.Low }},
                 new DataContent(pdfData, "application/pdf") { Name = "doc.pdf" },
                 new HostedFileContent("file-123"),
                 new ErrorContent("I cannot process this") { ErrorCode = "Refusal" }


### PR DESCRIPTION
Similar how it is handled by the `OpenAIChatClient` this allows setting the ImageDetail for `OpenAIResponsesChatClient`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7042)