### PR TITLE
Assign authors only on PR creation

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -158,6 +158,8 @@ configuration:
       description: Assign PRs to authors
     - if:
       - payloadType: Issue_Comment
+      - isAction:
+          action: Opened
       - isActivitySender:
           issueAuthor: True
       - hasLabel:
@@ -222,3 +224,4 @@ configuration:
 
 onFailure: 
 onSuccess:
+


### PR DESCRIPTION
Prevents policies from re-assigning it when value is changed later
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7083)