### PR TITLE
Add content to represent service-side actions

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
@@ -293,7 +293,7 @@ public static class ChatResponseExtensions
         Coalesce<CodeInterpreterToolCallContent>(
             contents,
             mergeSingle: true,
-            canMerge: static (r1, r2) => r1.CallId == r2.CallId,
+            canMerge: static (r1, r2) => r1.Id == r2.Id,
             static (contents, start, end) =>
             {
                 var firstContent = (CodeInterpreterToolCallContent)contents[start];
@@ -320,9 +320,8 @@ public static class ChatResponseExtensions
                     CoalesceContent(inputs);
                 }
 
-                return new()
+                return new(firstContent.Id)
                 {
-                    CallId = firstContent.CallId,
                     Inputs = inputs,
                     AdditionalProperties = firstContent.AdditionalProperties?.Clone(),
                 };
@@ -331,7 +330,7 @@ public static class ChatResponseExtensions
         Coalesce<CodeInterpreterToolResultContent>(
             contents,
             mergeSingle: true,
-            canMerge: static (r1, r2) => r1.CallId is not null && r2.CallId is not null && r1.CallId == r2.CallId,
+            canMerge: static (r1, r2) => r1.Id == r2.Id,
             static (contents, start, end) =>
             {
                 var firstContent = (CodeInterpreterToolResultContent)contents[start];
@@ -358,9 +357,8 @@ public static class ChatResponseExtensions
                     CoalesceContent(output);
                 }
 
-                return new()
+                return new(firstContent.Id)
                 {
-                    CallId = firstContent.CallId,
                     Outputs = output,
                     AdditionalProperties = firstContent.AdditionalProperties?.Clone(),
                 };

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/AIContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/AIContent.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Extensions.AI;
 // [JsonDerivedType(typeof(McpServerToolApprovalResponseContent), typeDiscriminator: "mcpServerToolApprovalResponse")]
 // [JsonDerivedType(typeof(CodeInterpreterToolCallContent), typeDiscriminator: "codeInterpreterToolCall")]
 // [JsonDerivedType(typeof(CodeInterpreterToolResultContent), typeDiscriminator: "codeInterpreterToolResult")]
+// [JsonDerivedType(typeof(ServiceActionContent), typeDiscriminator: "serviceAction")]
 
 public class AIContent
 {

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/CodeInterpreterToolCallContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/CodeInterpreterToolCallContent.cs
@@ -14,19 +14,13 @@ namespace Microsoft.Extensions.AI;
 /// It is informational only and represents the call itself, not the result.
 /// </remarks>
 [Experimental("MEAI001")]
-public sealed class CodeInterpreterToolCallContent : AIContent
+public sealed class CodeInterpreterToolCallContent : ServiceActionContent
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CodeInterpreterToolCallContent"/> class.
-    /// </summary>
-    public CodeInterpreterToolCallContent()
+    /// <inheritdoc/>
+    public CodeInterpreterToolCallContent(string id)
+        : base(id)
     {
     }
-
-    /// <summary>
-    /// Gets or sets the tool call ID.
-    /// </summary>
-    public string? CallId { get; set; }
 
     /// <summary>
     /// Gets or sets the inputs to the code interpreter tool.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/CodeInterpreterToolResultContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/CodeInterpreterToolResultContent.cs
@@ -10,19 +10,13 @@ namespace Microsoft.Extensions.AI;
 /// Represents the result of a code interpreter tool invocation by a hosted service.
 /// </summary>
 [Experimental("MEAI001")]
-public sealed class CodeInterpreterToolResultContent : AIContent
+public sealed class CodeInterpreterToolResultContent : ServiceActionContent
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CodeInterpreterToolResultContent"/> class.
-    /// </summary>
-    public CodeInterpreterToolResultContent()
+    /// <inheritdoc/>
+    public CodeInterpreterToolResultContent(string id)
+        : base(id)
     {
     }
-
-    /// <summary>
-    /// Gets or sets the tool call ID that this result corresponds to.
-    /// </summary>
-    public string? CallId { get; set; }
 
     /// <summary>
     /// Gets or sets the output of code interpreter tool.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/McpServerToolCallContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/McpServerToolCallContent.cs
@@ -16,27 +16,22 @@ namespace Microsoft.Extensions.AI;
 /// It is informational only.
 /// </remarks>
 [Experimental("MEAI001")]
-public sealed class McpServerToolCallContent : AIContent
+public sealed class McpServerToolCallContent : ServiceActionContent
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="McpServerToolCallContent"/> class.
     /// </summary>
-    /// <param name="callId">The tool call ID.</param>
+    /// <param name="id">The tool call ID.</param>
     /// <param name="toolName">The tool name.</param>
     /// <param name="serverName">The MCP server name that hosts the tool.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="callId"/> or <paramref name="toolName"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentException"><paramref name="callId"/> or <paramref name="toolName"/> is empty or composed entirely of whitespace.</exception>
-    public McpServerToolCallContent(string callId, string toolName, string? serverName)
+    /// <exception cref="ArgumentNullException"><paramref name="id"/> or <paramref name="toolName"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="id"/> or <paramref name="toolName"/> is empty or composed entirely of whitespace.</exception>
+    public McpServerToolCallContent(string id, string toolName, string? serverName)
+        : base(id)
     {
-        CallId = Throw.IfNullOrWhitespace(callId);
         ToolName = Throw.IfNullOrWhitespace(toolName);
         ServerName = serverName;
     }
-
-    /// <summary>
-    /// Gets the tool call ID.
-    /// </summary>
-    public string CallId { get; }
 
     /// <summary>
     /// Gets the name of the tool called.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/McpServerToolResultContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/McpServerToolResultContent.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
 
@@ -16,23 +14,13 @@ namespace Microsoft.Extensions.AI;
 /// It is informational only.
 /// </remarks>
 [Experimental("MEAI001")]
-public sealed class McpServerToolResultContent : AIContent
+public sealed class McpServerToolResultContent : ServiceActionContent
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="McpServerToolResultContent"/> class.
-    /// </summary>
-    /// <param name="callId">The tool call ID.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="callId"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentException"><paramref name="callId"/> is empty or composed entirely of whitespace.</exception>
-    public McpServerToolResultContent(string callId)
+    /// <inheritdoc/>
+    public McpServerToolResultContent(string id)
+        : base(id)
     {
-        CallId = Throw.IfNullOrWhitespace(callId);
     }
-
-    /// <summary>
-    /// Gets the tool call ID.
-    /// </summary>
-    public string CallId { get; }
 
     /// <summary>
     /// Gets or sets the output of the tool call.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ServiceActionContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ServiceActionContent.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>
+/// Represents an action performed by a hosted service.
+/// </summary>
+/// <remarks>
+/// This content type is used to represent actions performed by the service such as calls to other services or invocation of service tools.
+/// It is informational only.
+/// </remarks>
+[Experimental("MEAI001")]
+public class ServiceActionContent : AIContent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServiceActionContent"/> class.
+    /// </summary>
+    /// <param name="id">The ID for the service-side action.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="id"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="id"/> is empty or composed entirely of whitespace.</exception>
+    public ServiceActionContent(string id)
+    {
+        Id = Throw.IfNullOrWhitespace(id);
+    }
+
+    /// <summary>
+    /// Gets the ID for the service-side action.
+    /// </summary>
+    public string Id { get; }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs
@@ -59,6 +59,7 @@ public static partial class AIJsonUtilities
         AddAIContentType(options, typeof(McpServerToolApprovalResponseContent), typeDiscriminatorId: "mcpServerToolApprovalResponse", checkBuiltIn: false);
         AddAIContentType(options, typeof(CodeInterpreterToolCallContent), typeDiscriminatorId: "codeInterpreterToolCall", checkBuiltIn: false);
         AddAIContentType(options, typeof(CodeInterpreterToolResultContent), typeDiscriminatorId: "codeInterpreterToolResult", checkBuiltIn: false);
+        AddAIContentType(options, typeof(ServiceActionContent), typeDiscriminatorId: "serviceAction", checkBuiltIn: false);
 
         if (JsonSerializer.IsReflectionEnabledByDefault)
         {
@@ -133,6 +134,7 @@ public static partial class AIJsonUtilities
     [JsonSerializable(typeof(McpServerToolApprovalResponseContent))]
     [JsonSerializable(typeof(CodeInterpreterToolCallContent))]
     [JsonSerializable(typeof(CodeInterpreterToolResultContent))]
+    [JsonSerializable(typeof(ServiceActionContent))]
     [JsonSerializable(typeof(ResponseContinuationToken))]
 
     // IEmbeddingGenerator

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantsChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantsChatClient.cs
@@ -199,9 +199,8 @@ internal sealed class OpenAIAssistantsChatClient : IChatClient
                 case RunStepDetailsUpdate details:
                     if (!string.IsNullOrEmpty(details.CodeInterpreterInput))
                     {
-                        CodeInterpreterToolCallContent hcitcc = new()
+                        CodeInterpreterToolCallContent hcitcc = new(details.ToolCallId)
                         {
-                            CallId = details.ToolCallId,
                             Inputs = [new DataContent(Encoding.UTF8.GetBytes(details.CodeInterpreterInput), "text/x-python")],
                             RawRepresentation = details,
                         };
@@ -218,9 +217,8 @@ internal sealed class OpenAIAssistantsChatClient : IChatClient
 
                     if (details.CodeInterpreterOutputs is { Count: > 0 })
                     {
-                        CodeInterpreterToolResultContent hcitrc = new()
+                        CodeInterpreterToolResultContent hcitrc = new(details.ToolCallId)
                         {
-                            CallId = details.ToolCallId,
                             RawRepresentation = details,
                         };
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -1099,14 +1099,14 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                             break;
 
                         case McpServerToolCallContent mstcc:
-                            (idToContentMapping ??= [])[mstcc.CallId] = mstcc;
+                            (idToContentMapping ??= [])[mstcc.Id] = mstcc;
                             break;
 
                         case McpServerToolResultContent mstrc:
-                            if (idToContentMapping?.TryGetValue(mstrc.CallId, out AIContent? callContentFromMapping) is true &&
+                            if (idToContentMapping?.TryGetValue(mstrc.Id, out AIContent? callContentFromMapping) is true &&
                                 callContentFromMapping is McpServerToolCallContent associatedCall)
                             {
-                                _ = idToContentMapping.Remove(mstrc.CallId);
+                                _ = idToContentMapping.Remove(mstrc.Id);
                                 McpToolCallItem mtci = ResponseItem.CreateMcpToolCallItem(
                                     associatedCall.ServerName,
                                     associatedCall.ToolName,
@@ -1287,9 +1287,8 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
     /// <summary>Adds new <see cref="AIContent"/> for the specified <paramref name="cicri"/> into <paramref name="contents"/>.</summary>
     private static void AddCodeInterpreterContents(CodeInterpreterCallResponseItem cicri, IList<AIContent> contents)
     {
-        contents.Add(new CodeInterpreterToolCallContent
+        contents.Add(new CodeInterpreterToolCallContent(cicri.Id)
         {
-            CallId = cicri.Id,
             Inputs = !string.IsNullOrWhiteSpace(cicri.Code) ? [new DataContent(Encoding.UTF8.GetBytes(cicri.Code), "text/x-python")] : null,
 
             // We purposefully do not set the RawRepresentation on the HostedCodeInterpreterToolCallContent, only on the HostedCodeInterpreterToolResultContent, to avoid
@@ -1297,9 +1296,8 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
             // CodeInterpreterCallResponseItem sent back for the pair.
         });
 
-        contents.Add(new CodeInterpreterToolResultContent
+        contents.Add(new CodeInterpreterToolResultContent(cicri.Id)
         {
-            CallId = cicri.Id,
             Outputs = cicri.Outputs is { Count: > 0 } outputs ? outputs.Select<CodeInterpreterCallOutput, AIContent?>(o =>
                 o switch
                 {

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/AIContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/AIContentTests.cs
@@ -75,7 +75,8 @@ public class AIContentTests
             new McpServerToolCallContent("call123", "myTool", "myServer"),
             new McpServerToolResultContent("call123"),
             new McpServerToolApprovalRequestContent("request123", new McpServerToolCallContent("call123", "myTool", "myServer")),
-            new McpServerToolApprovalResponseContent("request123", approved: true)
+            new McpServerToolApprovalResponseContent("request123", approved: true),
+            new ServiceActionContent("action123")
         ]);
 
         var serialized = JsonSerializer.Serialize(message, AIJsonUtilities.DefaultOptions);

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/CodeInterpreterToolCallContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/CodeInterpreterToolCallContentTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Xunit;
@@ -12,21 +13,19 @@ public class CodeInterpreterToolCallContentTests
     [Fact]
     public void Constructor_PropsDefault()
     {
-        CodeInterpreterToolCallContent c = new();
+        CodeInterpreterToolCallContent c = new("call123");
         Assert.Null(c.RawRepresentation);
         Assert.Null(c.AdditionalProperties);
-        Assert.Null(c.CallId);
+        Assert.Equal("call123", c.Id);
         Assert.Null(c.Inputs);
     }
 
     [Fact]
     public void Properties_Roundtrip()
     {
-        CodeInterpreterToolCallContent c = new();
+        CodeInterpreterToolCallContent c = new("call123");
 
-        Assert.Null(c.CallId);
-        c.CallId = "call123";
-        Assert.Equal("call123", c.CallId);
+        Assert.Equal("call123", c.Id);
 
         Assert.Null(c.Inputs);
         IList<AIContent> inputs = [new TextContent("print('hello')")];
@@ -47,9 +46,8 @@ public class CodeInterpreterToolCallContentTests
     [Fact]
     public void Inputs_SupportsMultipleContentTypes()
     {
-        CodeInterpreterToolCallContent c = new()
+        CodeInterpreterToolCallContent c = new("call456")
         {
-            CallId = "call456",
             Inputs =
             [
                 new TextContent("import numpy as np"),
@@ -68,9 +66,8 @@ public class CodeInterpreterToolCallContentTests
     [Fact]
     public void Serialization_Roundtrips()
     {
-        CodeInterpreterToolCallContent content = new()
+        CodeInterpreterToolCallContent content = new("call123")
         {
-            CallId = "call123",
             Inputs =
             [
                 new TextContent("print('hello')"),
@@ -82,12 +79,19 @@ public class CodeInterpreterToolCallContentTests
         var deserializedSut = JsonSerializer.Deserialize<CodeInterpreterToolCallContent>(json, AIJsonUtilities.DefaultOptions);
 
         Assert.NotNull(deserializedSut);
-        Assert.Equal("call123", deserializedSut.CallId);
+        Assert.Equal("call123", deserializedSut.Id);
         Assert.NotNull(deserializedSut.Inputs);
         Assert.Equal(2, deserializedSut.Inputs.Count);
         Assert.IsType<TextContent>(deserializedSut.Inputs[0]);
         Assert.Equal("print('hello')", ((TextContent)deserializedSut.Inputs[0]).Text);
         Assert.IsType<HostedFileContent>(deserializedSut.Inputs[1]);
         Assert.Equal("file456", ((HostedFileContent)deserializedSut.Inputs[1]).FileId);
+    }
+
+    [Fact]
+    public void Constructor_Throws()
+    {
+        Assert.Throws<ArgumentNullException>("id", () => new CodeInterpreterToolCallContent(null!));
+        Assert.Throws<ArgumentException>("id", () => new CodeInterpreterToolCallContent(string.Empty));
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/CodeInterpreterToolResultContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/CodeInterpreterToolResultContentTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Xunit;
@@ -12,21 +13,19 @@ public class CodeInterpreterToolResultContentTests
     [Fact]
     public void Constructor_PropsDefault()
     {
-        CodeInterpreterToolResultContent c = new();
+        CodeInterpreterToolResultContent c = new("call123");
         Assert.Null(c.RawRepresentation);
         Assert.Null(c.AdditionalProperties);
-        Assert.Null(c.CallId);
+        Assert.Equal("call123", c.Id);
         Assert.Null(c.Outputs);
     }
 
     [Fact]
     public void Properties_Roundtrip()
     {
-        CodeInterpreterToolResultContent c = new();
+        CodeInterpreterToolResultContent c = new("call123");
 
-        Assert.Null(c.CallId);
-        c.CallId = "call123";
-        Assert.Equal("call123", c.CallId);
+        Assert.Equal("call123", c.Id);
 
         Assert.Null(c.Outputs);
         IList<AIContent> output = [new TextContent("Hello, World!")];
@@ -47,9 +46,8 @@ public class CodeInterpreterToolResultContentTests
     [Fact]
     public void Output_SupportsMultipleContentTypes()
     {
-        CodeInterpreterToolResultContent c = new()
+        CodeInterpreterToolResultContent c = new("call789")
         {
-            CallId = "call789",
             Outputs =
             [
                 new TextContent("Execution completed"),
@@ -70,9 +68,8 @@ public class CodeInterpreterToolResultContentTests
     [Fact]
     public void Serialization_Roundtrips()
     {
-        CodeInterpreterToolResultContent content = new()
+        CodeInterpreterToolResultContent content = new("call123")
         {
-            CallId = "call123",
             Outputs =
             [
                 new TextContent("Hello, World!"),
@@ -84,12 +81,19 @@ public class CodeInterpreterToolResultContentTests
         var deserializedSut = JsonSerializer.Deserialize<CodeInterpreterToolResultContent>(json, AIJsonUtilities.DefaultOptions);
 
         Assert.NotNull(deserializedSut);
-        Assert.Equal("call123", deserializedSut.CallId);
+        Assert.Equal("call123", deserializedSut.Id);
         Assert.NotNull(deserializedSut.Outputs);
         Assert.Equal(2, deserializedSut.Outputs.Count);
         Assert.IsType<TextContent>(deserializedSut.Outputs[0]);
         Assert.Equal("Hello, World!", ((TextContent)deserializedSut.Outputs[0]).Text);
         Assert.IsType<HostedFileContent>(deserializedSut.Outputs[1]);
         Assert.Equal("result.txt", ((HostedFileContent)deserializedSut.Outputs[1]).FileId);
+    }
+
+    [Fact]
+    public void Constructor_Throws()
+    {
+        Assert.Throws<ArgumentNullException>("id", () => new CodeInterpreterToolResultContent(null!));
+        Assert.Throws<ArgumentException>("id", () => new CodeInterpreterToolResultContent(string.Empty));
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/McpServerToolResultContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/McpServerToolResultContentTests.cs
@@ -13,8 +13,8 @@ public class McpServerToolResultContentTests
     [Fact]
     public void Constructor_PropsDefault()
     {
-        McpServerToolResultContent c = new("callId");
-        Assert.Equal("callId", c.CallId);
+        McpServerToolResultContent c = new("call123");
+        Assert.Equal("call123", c.Id);
         Assert.Null(c.RawRepresentation);
         Assert.Null(c.AdditionalProperties);
         Assert.Null(c.Output);
@@ -23,7 +23,7 @@ public class McpServerToolResultContentTests
     [Fact]
     public void Constructor_PropsRoundtrip()
     {
-        McpServerToolResultContent c = new("callId");
+        McpServerToolResultContent c = new("call123");
 
         Assert.Null(c.RawRepresentation);
         object raw = new();
@@ -35,7 +35,7 @@ public class McpServerToolResultContentTests
         c.AdditionalProperties = props;
         Assert.Same(props, c.AdditionalProperties);
 
-        Assert.Equal("callId", c.CallId);
+        Assert.Equal("call123", c.Id);
 
         Assert.Null(c.Output);
         IList<AIContent> output = [];
@@ -46,8 +46,8 @@ public class McpServerToolResultContentTests
     [Fact]
     public void Constructor_Throws()
     {
-        Assert.Throws<ArgumentException>("callId", () => new McpServerToolResultContent(string.Empty));
-        Assert.Throws<ArgumentNullException>("callId", () => new McpServerToolResultContent(null!));
+        Assert.Throws<ArgumentException>("id", () => new McpServerToolResultContent(string.Empty));
+        Assert.Throws<ArgumentNullException>("id", () => new McpServerToolResultContent(null!));
     }
 
     [Fact]
@@ -62,7 +62,9 @@ public class McpServerToolResultContentTests
         var deserializedContent = JsonSerializer.Deserialize<McpServerToolResultContent>(json, AIJsonUtilities.DefaultOptions);
 
         Assert.NotNull(deserializedContent);
-        Assert.Equal(content.CallId, deserializedContent.CallId);
+        Assert.Equal(content.Id, deserializedContent.Id);
         Assert.NotNull(deserializedContent.Output);
+        Assert.IsType<TextContent>(deserializedContent.Output[0]);
+        Assert.Equal("result", ((TextContent)deserializedContent.Output[0]).Text);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/ServiceActionContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/ServiceActionContentTests.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text.Json;
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class ServiceActionContentTests
+{
+    [Fact]
+    public void Constructor_PropsDefault()
+    {
+        ServiceActionContent c = new("action123");
+        Assert.Null(c.RawRepresentation);
+        Assert.Null(c.AdditionalProperties);
+        Assert.Equal("action123", c.Id);
+    }
+
+    [Fact]
+    public void Properties_Roundtrip()
+    {
+        ServiceActionContent c = new("action123");
+
+        Assert.Equal("action123", c.Id);
+
+        Assert.Null(c.RawRepresentation);
+        object raw = new();
+        c.RawRepresentation = raw;
+        Assert.Same(raw, c.RawRepresentation);
+
+        Assert.Null(c.AdditionalProperties);
+        AdditionalPropertiesDictionary props = new() { { "key", "value" } };
+        c.AdditionalProperties = props;
+        Assert.Same(props, c.AdditionalProperties);
+    }
+
+    [Fact]
+    public void Serialization_Roundtrips()
+    {
+        ServiceActionContent content = new("action123")
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary { { "key", "value" } }
+        };
+
+        var json = JsonSerializer.Serialize(content, AIJsonUtilities.DefaultOptions);
+        var deserializedSut = JsonSerializer.Deserialize<ServiceActionContent>(json, AIJsonUtilities.DefaultOptions);
+
+        Assert.NotNull(deserializedSut);
+        Assert.Equal("action123", deserializedSut.Id);
+        Assert.NotNull(deserializedSut.AdditionalProperties);
+        Assert.Single(deserializedSut.AdditionalProperties);
+        Assert.Equal("value", deserializedSut.AdditionalProperties["key"]?.ToString());
+    }
+
+    [Fact]
+    public void Constructor_Throws()
+    {
+        Assert.Throws<ArgumentNullException>("id", () => new ServiceActionContent(null!));
+        Assert.Throws<ArgumentException>("id", () => new ServiceActionContent(string.Empty));
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIAssistantChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIAssistantChatClientIntegrationTests.cs
@@ -64,10 +64,7 @@ public class OpenAIAssistantChatClientIntegrationTests : ChatClientIntegrationTe
         // Validate CodeInterpreterToolCallContent
         var toolCallContent = response.Messages.SelectMany(m => m.Contents).OfType<CodeInterpreterToolCallContent>().SingleOrDefault();
         Assert.NotNull(toolCallContent);
-        if (toolCallContent.CallId is not null)
-        {
-            Assert.NotEmpty(toolCallContent.CallId);
-        }
+        Assert.NotEmpty(toolCallContent.Id);
 
         if (toolCallContent.Inputs is not null)
         {
@@ -83,10 +80,7 @@ public class OpenAIAssistantChatClientIntegrationTests : ChatClientIntegrationTe
         var toolResultContents = response.Messages.SelectMany(m => m.Contents).OfType<CodeInterpreterToolResultContent>().ToList();
         foreach (var toolResultContent in toolResultContents)
         {
-            if (toolResultContent.CallId is not null)
-            {
-                Assert.NotEmpty(toolResultContent.CallId);
-            }
+            Assert.NotEmpty(toolResultContent.Id);
 
             if (toolResultContent.Outputs is not null)
             {

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
@@ -40,8 +40,8 @@ public class OpenAIResponseClientIntegrationTests : ChatClientIntegrationTests
         // Validate CodeInterpreterToolCallContent
         var toolCallContent = response.Messages.SelectMany(m => m.Contents).OfType<CodeInterpreterToolCallContent>().SingleOrDefault();
         Assert.NotNull(toolCallContent);
-        Assert.NotNull(toolCallContent.CallId);
-        Assert.NotEmpty(toolCallContent.CallId);
+        Assert.NotNull(toolCallContent.Id);
+        Assert.NotEmpty(toolCallContent.Id);
         Assert.NotNull(toolCallContent.Inputs);
         Assert.NotEmpty(toolCallContent.Inputs);
 
@@ -53,8 +53,8 @@ public class OpenAIResponseClientIntegrationTests : ChatClientIntegrationTests
         // Validate CodeInterpreterToolResultContent
         var toolResultContent = response.Messages.SelectMany(m => m.Contents).OfType<CodeInterpreterToolResultContent>().FirstOrDefault();
         Assert.NotNull(toolResultContent);
-        Assert.NotNull(toolResultContent.CallId);
-        Assert.NotEmpty(toolResultContent.CallId);
+        Assert.NotNull(toolResultContent.Id);
+        Assert.NotEmpty(toolResultContent.Id);
 
         if (toolResultContent.Outputs is not null)
         {
@@ -199,7 +199,7 @@ public class OpenAIResponseClientIntegrationTests : ChatClientIntegrationTests
                     response.Messages
                             .SelectMany(m => m.Contents)
                             .OfType<McpServerToolApprovalRequestContent>()
-                            .Select(c => new McpServerToolApprovalResponseContent(c.ToolCall.CallId, true))
+                            .Select(c => new McpServerToolApprovalResponseContent(c.ToolCall.Id, true))
                             .ToArray());
                 if (approvalResponse.Contents.Count == 0)
                 {

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -1438,7 +1438,7 @@ public class OpenAIResponseClientTests
             Assert.Equal(3, message.Contents.Count);
 
             var call = Assert.IsType<McpServerToolCallContent>(message.Contents[0]);
-            Assert.Equal("mcp_06ee3b1962eeb8470068e6b21cbaa081a3b5aa2a6c989f4c6f", call.CallId);
+            Assert.Equal("mcp_06ee3b1962eeb8470068e6b21cbaa081a3b5aa2a6c989f4c6f", call.Id);
             Assert.Equal("deepwiki", call.ServerName);
             Assert.Equal("ask_question", call.ToolName);
             Assert.NotNull(call.Arguments);
@@ -1447,7 +1447,7 @@ public class OpenAIResponseClientTests
             Assert.Equal("What is the path to the README.md file for Microsoft.Extensions.AI.Abstractions?", ((JsonElement)call.Arguments["question"]!).GetString());
 
             var result = Assert.IsType<McpServerToolResultContent>(message.Contents[1]);
-            Assert.Equal("mcp_06ee3b1962eeb8470068e6b21cbaa081a3b5aa2a6c989f4c6f", result.CallId);
+            Assert.Equal("mcp_06ee3b1962eeb8470068e6b21cbaa081a3b5aa2a6c989f4c6f", result.Id);
             Assert.NotNull(result.Output);
             Assert.StartsWith("The `README.md` file for `Microsoft.Extensions.AI.Abstractions` is located at", Assert.IsType<TextContent>(Assert.Single(result.Output)).Text);
 
@@ -1694,7 +1694,7 @@ public class OpenAIResponseClientTests
         Assert.Equal(6, message.Contents.Count);
 
         var firstCall = Assert.IsType<McpServerToolCallContent>(message.Contents[1]);
-        Assert.Equal("mcp_68be4166acfc8191bc5e0a751eed358b0384f747588fc3f5", firstCall.CallId);
+        Assert.Equal("mcp_68be4166acfc8191bc5e0a751eed358b0384f747588fc3f5", firstCall.Id);
         Assert.Equal("deepwiki", firstCall.ServerName);
         Assert.Equal("read_wiki_structure", firstCall.ToolName);
         Assert.NotNull(firstCall.Arguments);
@@ -1702,12 +1702,12 @@ public class OpenAIResponseClientTests
         Assert.Equal("dotnet/extensions", ((JsonElement)firstCall.Arguments["repoName"]!).GetString());
 
         var firstResult = Assert.IsType<McpServerToolResultContent>(message.Contents[2]);
-        Assert.Equal("mcp_68be4166acfc8191bc5e0a751eed358b0384f747588fc3f5", firstResult.CallId);
+        Assert.Equal("mcp_68be4166acfc8191bc5e0a751eed358b0384f747588fc3f5", firstResult.Id);
         Assert.NotNull(firstResult.Output);
         Assert.StartsWith("Available pages for dotnet/extensions", Assert.IsType<TextContent>(Assert.Single(firstResult.Output)).Text);
 
         var secondCall = Assert.IsType<McpServerToolCallContent>(message.Contents[3]);
-        Assert.Equal("mcp_68be416900f88191837ae0718339a4ce0384f747588fc3f5", secondCall.CallId);
+        Assert.Equal("mcp_68be416900f88191837ae0718339a4ce0384f747588fc3f5", secondCall.Id);
         Assert.Equal("deepwiki", secondCall.ServerName);
         Assert.Equal("ask_question", secondCall.ToolName);
         Assert.NotNull(secondCall.Arguments);
@@ -1715,7 +1715,7 @@ public class OpenAIResponseClientTests
         Assert.Equal("What is the path to the README.md file for Microsoft.Extensions.AI.Abstractions?", ((JsonElement)secondCall.Arguments["question"]!).GetString());
 
         var secondResult = Assert.IsType<McpServerToolResultContent>(message.Contents[4]);
-        Assert.Equal("mcp_68be416900f88191837ae0718339a4ce0384f747588fc3f5", secondResult.CallId);
+        Assert.Equal("mcp_68be416900f88191837ae0718339a4ce0384f747588fc3f5", secondResult.Id);
         Assert.NotNull(secondResult.Output);
         Assert.StartsWith("The `README.md` file for `Microsoft.Extensions.AI.Abstractions` is located at", Assert.IsType<TextContent>(Assert.Single(secondResult.Output)).Text);
 
@@ -2108,7 +2108,7 @@ public class OpenAIResponseClientTests
         Assert.Equal(6, message.Contents.Count);
 
         var firstCall = Assert.IsType<McpServerToolCallContent>(message.Contents[1]);
-        Assert.Equal("mcp_68be4503d45c819e89cb574361c8eba003a2537be0e84a54", firstCall.CallId);
+        Assert.Equal("mcp_68be4503d45c819e89cb574361c8eba003a2537be0e84a54", firstCall.Id);
         Assert.Equal("deepwiki", firstCall.ServerName);
         Assert.Equal("read_wiki_structure", firstCall.ToolName);
         Assert.NotNull(firstCall.Arguments);
@@ -2116,12 +2116,12 @@ public class OpenAIResponseClientTests
         Assert.Equal("dotnet/extensions", ((JsonElement)firstCall.Arguments["repoName"]!).GetString());
 
         var firstResult = Assert.IsType<McpServerToolResultContent>(message.Contents[2]);
-        Assert.Equal("mcp_68be4503d45c819e89cb574361c8eba003a2537be0e84a54", firstResult.CallId);
+        Assert.Equal("mcp_68be4503d45c819e89cb574361c8eba003a2537be0e84a54", firstResult.Id);
         Assert.NotNull(firstResult.Output);
         Assert.StartsWith("Available pages for dotnet/extensions", Assert.IsType<TextContent>(Assert.Single(firstResult.Output)).Text);
 
         var secondCall = Assert.IsType<McpServerToolCallContent>(message.Contents[3]);
-        Assert.Equal("mcp_68be4505f134819e806c002f27cce0c303a2537be0e84a54", secondCall.CallId);
+        Assert.Equal("mcp_68be4505f134819e806c002f27cce0c303a2537be0e84a54", secondCall.Id);
         Assert.Equal("deepwiki", secondCall.ServerName);
         Assert.Equal("ask_question", secondCall.ToolName);
         Assert.NotNull(secondCall.Arguments);
@@ -2129,7 +2129,7 @@ public class OpenAIResponseClientTests
         Assert.Equal("What is the path to the README.md file for Microsoft.Extensions.AI.Abstractions?", ((JsonElement)secondCall.Arguments["question"]!).GetString());
 
         var secondResult = Assert.IsType<McpServerToolResultContent>(message.Contents[4]);
-        Assert.Equal("mcp_68be4505f134819e806c002f27cce0c303a2537be0e84a54", secondResult.CallId);
+        Assert.Equal("mcp_68be4505f134819e806c002f27cce0c303a2537be0e84a54", secondResult.Id);
         Assert.NotNull(secondResult.Output);
         Assert.StartsWith("The path to the `README.md` file", Assert.IsType<TextContent>(Assert.Single(secondResult.Output)).Text);
 
@@ -2722,7 +2722,7 @@ public class OpenAIResponseClientTests
         Assert.Equal("text/x-python", codeInput.MediaType);
 
         var codeResult = Assert.IsType<CodeInterpreterToolResultContent>(message.Contents[1]);
-        Assert.Equal(codeCall.CallId, codeResult.CallId);
+        Assert.Equal(codeCall.Id, codeResult.Id);
 
         var textContent = Assert.IsType<TextContent>(message.Contents[2]);
         Assert.Equal("15", textContent.Text);
@@ -2943,7 +2943,7 @@ public class OpenAIResponseClientTests
         Assert.Contains("sum_of_numbers", Encoding.UTF8.GetString(codeInput.Data.ToArray()));
 
         var codeResult = Assert.IsType<CodeInterpreterToolResultContent>(message.Contents[1]);
-        Assert.Equal(codeCall.CallId, codeResult.CallId);
+        Assert.Equal(codeCall.Id, codeResult.Id);
 
         var textContent = Assert.IsType<TextContent>(message.Contents[2]);
         Assert.Equal("The sum of numbers from 1 to 10 is 55.", textContent.Text);


### PR DESCRIPTION
Introduce ServiceActionContent and implement it in CodeInterpreter and McpServerTool contents.

Naming considerations:
* HostedServiceCallContent - Not nice for Result contents, and may be confusing with FunctionCallContent.
* HostedServiceSideContent - "Side" is uncommon in the codebase.
* HostedServiceContent - If we use this name, HostedFileContent should also extend it which escapes the scope of "content about server side actions".
* **ServiceActionContent** - Breaks the Hosted prefix we've been using but I like the shortness; con: "Action" may be too broad.  

Contributes to https://github.com/dotnet/extensions/issues/6492#issuecomment-3603938270.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7109)