### PR TITLE
Fix expected conversation length in `SummarizingChatReducer` integration tests

### DIFF
--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
@@ -1164,6 +1164,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
                 Assert.Equal(ChatRole.Assistant, m.Role); // Indicates this is the assistant's summary
                 Assert.Contains("Alice", m.Text);
             },
+            m => Assert.StartsWith("I hiked the section", m.Text, StringComparison.Ordinal),
             m => Assert.StartsWith("The Sierra Nevada section", m.Text, StringComparison.Ordinal),
             m => Assert.StartsWith("What's my name", m.Text, StringComparison.Ordinal));
 


### PR DESCRIPTION
## Overview

There were some [recent changes](https://github.com/dotnet/extensions/pull/6908) made to `SummarizingChatReducer` to avoid orphaning an assistant response from the user message, so long as the unsummarized message count remains within the configured limit. The functional tests were updated, but the integration tests weren't, causing `SummarizingChatReducer_PreservesConversationContext` to fail with:

```
Message: 
Assert.Equal() Failure: Values differ
Expected: 3
Actual:   4

  Stack Trace: 
ChatClientIntegrationTests.SummarizingChatReducer_PreservesConversationContext() line 1160
--- End of stack trace from previous location ---
```

## Changes

This PR updates the expected message count to 4 (summary + user message + assistant response + user message).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7119)