### PR TITLE
AI Abstractions - Make `ChatOptions.AllowBackgroundResponses` property non-nullable.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
@@ -182,7 +182,7 @@ public class ChatOptions
     /// </remarks>
     [Experimental("MEAI001")]
     [JsonIgnore]
-    public bool? AllowBackgroundResponses { get; set; }
+    public bool AllowBackgroundResponses { get; set; }
 
     /// <summary>Gets or sets the continuation token for resuming and getting the result of the chat response identified by this token.</summary>
     /// <remarks>


### PR DESCRIPTION
Minor, non-breaking tweak based on API surface review:

<img width="1439" height="372" alt="image" src="https://github.com/user-attachments/assets/550ad966-598b-4d8a-9e57-ea3cfa6e34dd" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7142)
 
 Corresponds with: https://github.com/microsoft/agent-framework/pull/2819