### PR TITLE
Set Microsoft.McpServer.ProjectTemplates version to align with MCP packages

### DIFF
--- a/src/ProjectTemplates/Microsoft.McpServer.ProjectTemplates/Microsoft.McpServer.ProjectTemplates.csproj
+++ b/src/ProjectTemplates/Microsoft.McpServer.ProjectTemplates/Microsoft.McpServer.ProjectTemplates.csproj
@@ -7,7 +7,14 @@
     <PackageTags>dotnet-new;templates;ai</PackageTags>
 
     <Stage>preview</Stage>
+
+    <!-- Set the version info to align with ModelContextProtocol packages -->
+    <MajorVersion>0</MajorVersion>
+    <MinorVersion>5</MinorVersion>
+    <PatchVersion>0</PatchVersion>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+
     <Workstream>AI</Workstream>
     <MinCodeCoverage>0</MinCodeCoverage>
     <MinMutationScore>0</MinMutationScore>


### PR DESCRIPTION
Caught this while validating [[release/10.1] AI Project Template Servicing (#7169)](https://github.com/dotnet/extensions/pull/7169). This is included in that PR as well, but this backports the change into main.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7170)