### PR TITLE
Fix rolling build pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -271,7 +271,7 @@ extends:
       displayName: CodeCoverage
       dependsOn:
       - build
-      condition: and(succeeded('build'), ne(variables['SkipQualityGates'], 'true'), eq(parameters.runTests, true))
+      condition: and(succeeded('build'), ne(variables['SkipQualityGates'], 'true'), ${{ eq(parameters.runTests, true) }})
       variables:
       - template: /eng/common/templates-official/variables/pool-providers.yml@self
       jobs:


### PR DESCRIPTION
This fixes an issue introduced by [Skip tests by default in internal rolling builds (#7151)](https://github.com/dotnet/extensions/pull/7151/changes#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5R274)

Using parameters within a condition requires `${{ }}` evaluation. https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops#parameters-in-conditions

This fix was validated by triggering a run against this branch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7171)