### PR TITLE
.NET AI ResponseItem Conversion Repro Example

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -1196,6 +1196,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                         !string.IsNullOrWhiteSpace(part.InputImageFileId) ? new HostedFileContent(part.InputImageFileId) { MediaType = "image/*" } :
                         !string.IsNullOrWhiteSpace(part.InputFileId) ? new HostedFileContent(part.InputFileId) { Name = part.InputFilename } :
                         part.InputFileBytes is not null ? new DataContent(part.InputFileBytes, part.InputFileBytesMediaType ?? "application/octet-stream") { Name = part.InputFilename } :
+                        //// MISSING: (part.InputImageUrl ? "http:"? : "data:") :
                         null;
                     break;
 


### PR DESCRIPTION
This draft PR demonstrates the failure to convert `ResponseItem` with `ResponseContentPart` that defines reference or data via image url:

```c#
ResponseContentPart.CreateInputImagePart(new Uri("https://example.com/image.png")),
```

Or

```c#
ResponseContentPart.CreateInputImagePart(BinaryData.FromBytes(Encoding.UTF8.GetBytes("image data")), "image/png"),
```

Note: Supporting this pattern requires an update to the OpenAI SDK:

**PR:** https://github.com/openai/openai-dotnet/pull/874
**ISSUE:** https://github.com/openai/openai-dotnet/issues/875
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7176)