### PR TITLE
Remove unnecessary description tags

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -49,23 +49,23 @@ public static partial class AIFunctionFactory
     /// <list type="bullet">
     ///   <item>
     ///     <see cref="CancellationToken"/> parameters are automatically bound to the <see cref="CancellationToken"/> passed into
-    ///       the invocation via <see cref="AIFunction.InvokeAsync"/>'s <see cref="CancellationToken"/> parameter. The parameter is
-    ///       not included in the generated JSON schema. The behavior of <see cref="CancellationToken"/> parameters can't be overridden.
+    ///     the invocation via <see cref="AIFunction.InvokeAsync"/>'s <see cref="CancellationToken"/> parameter. The parameter is
+    ///     not included in the generated JSON schema. The behavior of <see cref="CancellationToken"/> parameters can't be overridden.
     ///   </item>
     ///   <item>
     ///     By default, <see cref="IServiceProvider"/> parameters are bound from the <see cref="AIFunctionArguments.Services"/> property
-    ///       and are not included in the JSON schema. If the parameter is optional, such that a default value is provided,
-    ///       <see cref="AIFunctionArguments.Services"/> is allowed to be <see langword="null"/>; otherwise, <see cref="AIFunctionArguments.Services"/>
-    ///       must be non-<see langword="null"/>, or else the invocation will fail with an exception due to the required nature of the parameter.
-    ///       The handling of <see cref="IServiceProvider"/> parameters can be overridden via <see cref="AIFunctionFactoryOptions.ConfigureParameterBinding"/>.
+    ///     and are not included in the JSON schema. If the parameter is optional, such that a default value is provided,
+    ///     <see cref="AIFunctionArguments.Services"/> is allowed to be <see langword="null"/>; otherwise, <see cref="AIFunctionArguments.Services"/>
+    ///     must be non-<see langword="null"/>, or else the invocation will fail with an exception due to the required nature of the parameter.
+    ///     The handling of <see cref="IServiceProvider"/> parameters can be overridden via <see cref="AIFunctionFactoryOptions.ConfigureParameterBinding"/>.
     ///   </item>
     ///   <item>
     ///     By default, <see cref="AIFunctionArguments"/> parameters are bound directly to <see cref="AIFunctionArguments"/> instance
-    ///       passed into <see cref="AIFunction.InvokeAsync"/> and are not included in the JSON schema. If the <see cref="AIFunctionArguments"/>
-    ///       instance passed to <see cref="AIFunction.InvokeAsync"/> is <see langword="null"/>, the <see cref="AIFunction"/> implementation
-    ///       manufactures an empty instance, such that parameters of type <see cref="AIFunctionArguments"/> can always be satisfied, whether
-    ///       optional or not. The handling of <see cref="AIFunctionArguments"/> parameters can be overridden via
-    ///       <see cref="AIFunctionFactoryOptions.ConfigureParameterBinding"/>.
+    ///     passed into <see cref="AIFunction.InvokeAsync"/> and are not included in the JSON schema. If the <see cref="AIFunctionArguments"/>
+    ///     instance passed to <see cref="AIFunction.InvokeAsync"/> is <see langword="null"/>, the <see cref="AIFunction"/> implementation
+    ///     manufactures an empty instance, such that parameters of type <see cref="AIFunctionArguments"/> can always be satisfied, whether
+    ///     optional or not. The handling of <see cref="AIFunctionArguments"/> parameters can be overridden via
+    ///     <see cref="AIFunctionFactoryOptions.ConfigureParameterBinding"/>.
     ///   </item>
     /// </list>
     /// All other parameter types are, by default, bound from the <see cref="AIFunctionArguments"/> dictionary passed into <see cref="AIFunction.InvokeAsync"/>
@@ -130,21 +130,21 @@ public static partial class AIFunctionFactory
     /// <list type="bullet">
     ///   <item>
     ///     <see cref="CancellationToken"/> parameters are automatically bound to the <see cref="CancellationToken"/> passed into
-    ///       the invocation via <see cref="AIFunction.InvokeAsync"/>'s <see cref="CancellationToken"/> parameter. The parameter is
-    ///       not included in the generated JSON schema.
+    ///     the invocation via <see cref="AIFunction.InvokeAsync"/>'s <see cref="CancellationToken"/> parameter. The parameter is
+    ///     not included in the generated JSON schema.
     ///   </item>
     ///   <item>
     ///     By default, <see cref="IServiceProvider"/> parameters are bound from the <see cref="AIFunctionArguments.Services"/> property
-    ///       and are not included in the JSON schema. If the parameter is optional, such that a default value is provided,
-    ///       <see cref="AIFunctionArguments.Services"/> is allowed to be <see langword="null"/>; otherwise, <see cref="AIFunctionArguments.Services"/>
-    ///       must be non-<see langword="null"/>, or else the invocation will fail with an exception due to the required nature of the parameter.
+    ///     and are not included in the JSON schema. If the parameter is optional, such that a default value is provided,
+    ///     <see cref="AIFunctionArguments.Services"/> is allowed to be <see langword="null"/>; otherwise, <see cref="AIFunctionArguments.Services"/>
+    ///     must be non-<see langword="null"/>, or else the invocation will fail with an exception due to the required nature of the parameter.
     ///   </item>
     ///   <item>
     ///     By default, <see cref="AIFunctionArguments"/> parameters are bound directly to <see cref="AIFunctionArguments"/> instance
-    ///       passed into <see cref="AIFunction.InvokeAsync"/> and are not included in the JSON schema. If the <see cref="AIFunctionArguments"/>
-    ///       instance passed to <see cref="AIFunction.InvokeAsync"/> is <see langword="null"/>, the <see cref="AIFunction"/> implementation
-    ///       manufactures an empty instance, such that parameters of type <see cref="AIFunctionArguments"/> can always be satisfied, whether
-    ///       optional or not.
+    ///     passed into <see cref="AIFunction.InvokeAsync"/> and are not included in the JSON schema. If the <see cref="AIFunctionArguments"/>
+    ///     instance passed to <see cref="AIFunction.InvokeAsync"/> is <see langword="null"/>, the <see cref="AIFunction"/> implementation
+    ///     manufactures an empty instance, such that parameters of type <see cref="AIFunctionArguments"/> can always be satisfied, whether
+    ///     optional or not.
     ///   </item>
     /// </list>
     /// All other parameter types are bound from the <see cref="AIFunctionArguments"/> dictionary passed into <see cref="AIFunction.InvokeAsync"/>
@@ -207,22 +207,22 @@ public static partial class AIFunctionFactory
     /// <list type="bullet">
     ///   <item>
     ///     <see cref="CancellationToken"/> parameters are automatically bound to the <see cref="CancellationToken"/> passed into
-    ///       the invocation via <see cref="AIFunction.InvokeAsync"/>'s <see cref="CancellationToken"/> parameter. The parameter is
-    ///       not included in the generated JSON schema. The behavior of <see cref="CancellationToken"/> parameters can't be overridden.
+    ///     the invocation via <see cref="AIFunction.InvokeAsync"/>'s <see cref="CancellationToken"/> parameter. The parameter is
+    ///     not included in the generated JSON schema. The behavior of <see cref="CancellationToken"/> parameters can't be overridden.
     ///   </item>
     ///   <item>
     ///     By default, <see cref="IServiceProvider"/> parameters are bound from the <see cref="AIFunctionArguments.Services"/> property
-    ///       and are not included in the JSON schema. If the parameter is optional, such that a default value is provided,
-    ///       <see cref="AIFunctionArguments.Services"/> is allowed to be <see langword="null"/>; otherwise, <see cref="AIFunctionArguments.Services"/>
-    ///       must be non-<see langword="null"/>, or else the invocation will fail with an exception due to the required nature of the parameter.
-    ///       The handling of <see cref="IServiceProvider"/> parameters can be overridden via <see cref="AIFunctionFactoryOptions.ConfigureParameterBinding"/>.
+    ///     and are not included in the JSON schema. If the parameter is optional, such that a default value is provided,
+    ///     <see cref="AIFunctionArguments.Services"/> is allowed to be <see langword="null"/>; otherwise, <see cref="AIFunctionArguments.Services"/>
+    ///     must be non-<see langword="null"/>, or else the invocation will fail with an exception due to the required nature of the parameter.
+    ///     The handling of <see cref="IServiceProvider"/> parameters can be overridden via <see cref="AIFunctionFactoryOptions.ConfigureParameterBinding"/>.
     ///   </item>
     ///   <item>
     ///     By default, <see cref="AIFunctionArguments"/> parameters are bound directly to <see cref="AIFunctionArguments"/> instance
-    ///       passed into <see cref="AIFunction.InvokeAsync"/> and are not included in the JSON schema. If the <see cref="AIFunctionArguments"/>
-    ///       instance passed to <see cref="AIFunction.InvokeAsync"/> is <see langword="null"/>, the <see cref="AIFunction"/> implementation
-    ///       manufactures an empty instance, such that parameters of type <see cref="AIFunctionArguments"/> can always be satisfied, whether
-    ///       optional or not. The handling of <see cref="AIFunctionArguments"/> parameters can be overridden via
+    ///     passed into <see cref="AIFunction.InvokeAsync"/> and are not included in the JSON schema. If the <see cref="AIFunctionArguments"/>
+    ///     instance passed to <see cref="AIFunction.InvokeAsync"/> is <see langword="null"/>, the <see cref="AIFunction"/> implementation
+    ///     manufactures an empty instance, such that parameters of type <see cref="AIFunctionArguments"/> can always be satisfied, whether
+    ///     optional or not. The handling of <see cref="AIFunctionArguments"/> parameters can be overridden via
     ///       <see cref="AIFunctionFactoryOptions.ConfigureParameterBinding"/>.
     ///   </item>
     /// </list>
@@ -295,21 +295,21 @@ public static partial class AIFunctionFactory
     /// <list type="bullet">
     ///   <item>
     ///     <see cref="CancellationToken"/> parameters are automatically bound to the <see cref="CancellationToken"/> passed into
-    ///       the invocation via <see cref="AIFunction.InvokeAsync"/>'s <see cref="CancellationToken"/> parameter. The parameter is
-    ///       not included in the generated JSON schema.
+    ///     the invocation via <see cref="AIFunction.InvokeAsync"/>'s <see cref="CancellationToken"/> parameter. The parameter is
+    ///     not included in the generated JSON schema.
     ///   </item>
     ///   <item>
     ///     By default, <see cref="IServiceProvider"/> parameters are bound from the <see cref="AIFunctionArguments.Services"/> property
-    ///       and are not included in the JSON schema. If the parameter is optional, such that a default value is provided,
-    ///       <see cref="AIFunctionArguments.Services"/> is allowed to be <see langword="null"/>; otherwise, <see cref="AIFunctionArguments.Services"/>
-    ///       must be non-<see langword="null"/>, or else the invocation will fail with an exception due to the required nature of the parameter.
+    ///     and are not included in the JSON schema. If the parameter is optional, such that a default value is provided,
+    ///     <see cref="AIFunctionArguments.Services"/> is allowed to be <see langword="null"/>; otherwise, <see cref="AIFunctionArguments.Services"/>
+    ///     must be non-<see langword="null"/>, or else the invocation will fail with an exception due to the required nature of the parameter.
     ///   </item>
     ///   <item>
     ///     By default, <see cref="AIFunctionArguments"/> parameters are bound directly to <see cref="AIFunctionArguments"/> instance
-    ///       passed into <see cref="AIFunction.InvokeAsync"/> and are not included in the JSON schema. If the <see cref="AIFunctionArguments"/>
-    ///       instance passed to <see cref="AIFunction.InvokeAsync"/> is <see langword="null"/>, the <see cref="AIFunction"/> implementation
-    ///       manufactures an empty instance, such that parameters of type <see cref="AIFunctionArguments"/> can always be satisfied, whether
-    ///       optional or not.
+    ///     passed into <see cref="AIFunction.InvokeAsync"/> and are not included in the JSON schema. If the <see cref="AIFunctionArguments"/>
+    ///     instance passed to <see cref="AIFunction.InvokeAsync"/> is <see langword="null"/>, the <see cref="AIFunction"/> implementation
+    ///     manufactures an empty instance, such that parameters of type <see cref="AIFunctionArguments"/> can always be satisfied, whether
+    ///     optional or not.
     ///   </item>
     /// </list>
     /// All other parameter types are bound from the <see cref="AIFunctionArguments"/> dictionary passed into <see cref="AIFunction.InvokeAsync"/>
@@ -385,23 +385,23 @@ public static partial class AIFunctionFactory
     /// <list type="bullet">
     ///   <item>
     ///     <see cref="CancellationToken"/> parameters are automatically bound to the <see cref="CancellationToken"/> passed into
-    ///       the invocation via <see cref="AIFunction.InvokeAsync"/>'s <see cref="CancellationToken"/> parameter. The parameter is
-    ///       not included in the generated JSON schema. The behavior of <see cref="CancellationToken"/> parameters can't be overridden.
+    ///     the invocation via <see cref="AIFunction.InvokeAsync"/>'s <see cref="CancellationToken"/> parameter. The parameter is
+    ///     not included in the generated JSON schema. The behavior of <see cref="CancellationToken"/> parameters can't be overridden.
     ///   </item>
     ///   <item>
     ///     By default, <see cref="IServiceProvider"/> parameters are bound from the <see cref="AIFunctionArguments.Services"/> property
-    ///       and are not included in the JSON schema. If the parameter is optional, such that a default value is provided,
-    ///       <see cref="AIFunctionArguments.Services"/> is allowed to be <see langword="null"/>; otherwise, <see cref="AIFunctionArguments.Services"/>
-    ///       must be non-<see langword="null"/>, or else the invocation will fail with an exception due to the required nature of the parameter.
-    ///       The handling of <see cref="IServiceProvider"/> parameters can be overridden via <see cref="AIFunctionFactoryOptions.ConfigureParameterBinding"/>.
+    ///     and are not included in the JSON schema. If the parameter is optional, such that a default value is provided,
+    ///     <see cref="AIFunctionArguments.Services"/> is allowed to be <see langword="null"/>; otherwise, <see cref="AIFunctionArguments.Services"/>
+    ///     must be non-<see langword="null"/>, or else the invocation will fail with an exception due to the required nature of the parameter.
+    ///     The handling of <see cref="IServiceProvider"/> parameters can be overridden via <see cref="AIFunctionFactoryOptions.ConfigureParameterBinding"/>.
     ///   </item>
     ///   <item>
     ///     By default, <see cref="AIFunctionArguments"/> parameters are bound directly to <see cref="AIFunctionArguments"/> instance
-    ///       passed into <see cref="AIFunction.InvokeAsync"/> and are not included in the JSON schema. If the <see cref="AIFunctionArguments"/>
-    ///       instance passed to <see cref="AIFunction.InvokeAsync"/> is <see langword="null"/>, the <see cref="AIFunction"/> implementation
-    ///       manufactures an empty instance, such that parameters of type <see cref="AIFunctionArguments"/> can always be satisfied, whether
-    ///       optional or not. The handling of <see cref="AIFunctionArguments"/> parameters can be overridden via
-    ///       <see cref="AIFunctionFactoryOptions.ConfigureParameterBinding"/>.
+    ///     passed into <see cref="AIFunction.InvokeAsync"/> and are not included in the JSON schema. If the <see cref="AIFunctionArguments"/>
+    ///     instance passed to <see cref="AIFunction.InvokeAsync"/> is <see langword="null"/>, the <see cref="AIFunction"/> implementation
+    ///     manufactures an empty instance, such that parameters of type <see cref="AIFunctionArguments"/> can always be satisfied, whether
+    ///     optional or not. The handling of <see cref="AIFunctionArguments"/> parameters can be overridden via
+    ///     <see cref="AIFunctionFactoryOptions.ConfigureParameterBinding"/>.
     ///   </item>
     /// </list>
     /// All other parameter types are, by default, bound from the <see cref="AIFunctionArguments"/> dictionary passed into <see cref="AIFunction.InvokeAsync"/>

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.Build/BuildMetadata.cs
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.Build/BuildMetadata.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Extensions.AmbientMetadata;
 /// At startup time, the class properties will be initialized from the generated code.
 /// Currently supported CI pipelines:
 /// <list type="bullet">
-/// <item><see href="https://learn.microsoft.com/azure/devops/pipelines/build/variables#build-variables-devops-services">Azure DevOps</see></item>
-/// <item><see href="https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables">GitHub Actions</see></item>
+///   <item><see href="https://learn.microsoft.com/azure/devops/pipelines/build/variables#build-variables-devops-services">Azure DevOps</see></item>
+///   <item><see href="https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables">GitHub Actions</see></item>
 /// </list>
 /// </remarks>
 public class BuildMetadata

--- a/src/Libraries/Microsoft.Extensions.Resilience/Resilience/ResilienceServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Resilience/ResilienceServiceCollectionExtensions.cs
@@ -25,12 +25,12 @@ public static class ResilienceServiceCollectionExtensions
     /// <remarks>
     /// This method adds additional dimensions on top of the default ones that are built-in to the Polly library. These include:
     /// <list type="bullet">
-    /// <item>
-    /// Exception enrichment based on <see cref="IExceptionSummarizer"/>.
-    /// </item>
-    /// <item>
-    /// Request metadata enrichment based on <see cref="RequestMetadata"/>.
-    /// </item>
+    ///   <item>
+    ///   Exception enrichment based on <see cref="IExceptionSummarizer"/>.
+    ///   </item>
+    ///   <item>
+    ///   Request metadata enrichment based on <see cref="RequestMetadata"/>.
+    ///   </item>
     /// </list>
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="services"/> is <see langword="null"/>.</exception>

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Enrichment/IEnrichmentTagCollector.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Enrichment/IEnrichmentTagCollector.cs
@@ -23,22 +23,22 @@ public interface IEnrichmentTagCollector
     /// <remarks>
     /// For log enrichment, <paramref name="tagValue"/> is serialized as per the rules below:
     /// <list type="bullet">
-    /// <item>
+    ///   <item>
     ///     <term>Arrays</term>
     ///     <description>Recognized and serialized in a loop.</description>
-    ///  </item>
-    ///  <item>
+    ///   </item>
+    ///   <item>
     ///     <term><see cref="IDictionary"/></term>
     ///     <description>Recognized as IDictionary&lt;string, object&gt; and serialized in a loop.</description>
-    ///  </item>
-    ///  <item>
+    ///   </item>
+    ///   <item>
     ///     <term><see cref="DateTime"/></term>
     ///     <description>Recognized and serialized after converting to <see cref="DateTime.ToUniversalTime()"/>.</description>
-    ///  </item>
-    ///  <item>
+    ///   </item>
+    ///   <item>
     ///     <term>All other primitive types</term>
     ///     <description>Converted to <see cref="string"/> as is and serialized.</description>
-    ///  </item>
+    ///   </item>
     /// </list>
     /// For metric enrichment, <paramref name="tagValue"/> is converted to <see cref="string"/> format using <see cref="object.ToString()"/> method.
     /// </remarks>

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Http/RequestMetadata.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Http/RequestMetadata.cs
@@ -44,15 +44,15 @@ public class RequestMetadata
     /// <remarks>
     /// Request Route is used for multiple use cases:
     /// <list type="bullet">
-    /// <item>
-    /// For outgoing request metrics, it is used as the request name dimension (if RequestName is not provided).
-    /// </item>
-    /// <item>
-    /// For Logs and traces, it is used to identify sensitive parameters from the path and redact them in the exported path, so sensitive data leakage can be avoided.
-    /// If you are using redaction, the template should be accurate for the request else redaction won't be applied to sensitive parameters.
-    /// For example, the template would look something like /v1/users/{userId}/chats/{chatId}/messages. For parameters to be redacted, the sensitive parameter names should match exactly as provided
-    /// in configuration for outgoing tracing and outgoing logging autocollectors.
-    /// </item>
+    ///   <item>
+    ///   For outgoing request metrics, it is used as the request name dimension (if RequestName is not provided).
+    ///   </item>
+    ///   <item>
+    ///   For Logs and traces, it is used to identify sensitive parameters from the path and redact them in the exported path, so sensitive data leakage can be avoided.
+    ///   If you are using redaction, the template should be accurate for the request else redaction won't be applied to sensitive parameters.
+    ///   For example, the template would look something like /v1/users/{userId}/chats/{chatId}/messages. For parameters to be redacted, the sensitive parameter names should match exactly as provided
+    ///   in configuration for outgoing tracing and outgoing logging autocollectors.
+    ///   </item>
     /// </list>
     /// </remarks>
     public string RequestRoute { get; set; } = TelemetryConstants.Unknown;
@@ -63,18 +63,18 @@ public class RequestMetadata
     /// <remarks>
     /// RequestName is used in the following manner by outgoing HTTP request auto collectors:
     /// <list type="bullet">
-    /// <item>
-    /// For outgoing request metrics: RequestName is used as the request name dimension if present. If not provided, the RequestRoute value is used instead.
-    /// </item>
-    /// <item>
-    /// For outgoing request traces: RequestName is used as the Display name for the activity. That is, when looking at the E2E trace flow, this name is used in the Tree view of traces.
-    /// </item>
-    /// <item>
-    /// If RequestName isn't provided, the RequestRoute value is used instead.
-    /// </item>
-    /// <item>
-    /// For outgoing request logs: When present, RequestName is added as an additional tag to logs.
-    /// </item>
+    ///   <item>
+    ///   For outgoing request metrics: RequestName is used as the request name dimension if present. If not provided, the RequestRoute value is used instead.
+    ///   </item>
+    ///   <item>
+    ///   For outgoing request traces: RequestName is used as the Display name for the activity. That is, when looking at the E2E trace flow, this name is used in the Tree view of traces.
+    ///   </item>
+    ///   <item>
+    ///   If RequestName isn't provided, the RequestRoute value is used instead.
+    ///   </item>
+    ///   <item>
+    ///   For outgoing request logs: When present, RequestName is added as an additional tag to logs.
+    ///   </item>
     /// </list>
     /// </remarks>
     public string RequestName { get; set; } = TelemetryConstants.Unknown;
@@ -85,12 +85,12 @@ public class RequestMetadata
     /// <remarks>
     /// DependencyName is used in the following manner by outgoing http request auto collectors:
     /// <list type="bullet">
-    /// <item>
-    /// For outgoing request metrics: This is added as dependency name dimension so metrics can be pivoted based on the dependency.
-    /// </item>
-    /// <item>
-    /// For outgoing request traces and logs: This is added as dependency name dimension for better diagnosability.
-    /// </item>
+    ///   <item>
+    ///   For outgoing request metrics: This is added as dependency name dimension so metrics can be pivoted based on the dependency.
+    ///   </item>
+    ///   <item>
+    ///   For outgoing request traces and logs: This is added as dependency name dimension for better diagnosability.
+    ///   </item>
     /// </list>
     /// </remarks>
     public string DependencyName { get; set; } = TelemetryConstants.Unknown;

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/TagProviderAttribute.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/TagProviderAttribute.cs
@@ -38,7 +38,7 @@ public sealed class TagProviderAttribute : Attribute
     ///   <item>
     ///     Second parameter of type <c>T?</c>, where <c>T</c> is the type of logging method parameter that you want to log.
     ///   </item>
-    ///   </list>
+    /// </list>
     /// </remarks>
     /// <example>
     /// <code language="csharp">

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/CounterAttribute.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/CounterAttribute.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Extensions.Diagnostics.Metrics;
 /// <remarks>
 /// This attribute is applied to a method that has the following constraints:
 /// <list type="bullet">
-/// <item>Must be a partial method.</item>
-/// <item>Must return <c>metricName</c> as the type. A class with that name will be generated.</item>
-/// <item>Must not be generic.</item>
-/// <item>Must have <c>System.Diagnostics.Metrics.Meter</c> as first parameter.</item>
-/// <item>Must have all the keys provided in <c>staticTagNames</c> as string type parameters.</item>
+///   <item>Must be a partial method.</item>
+///   <item>Must return <c>metricName</c> as the type. A class with that name will be generated.</item>
+///   <item>Must not be generic.</item>
+///   <item>Must have <c>System.Diagnostics.Metrics.Meter</c> as first parameter.</item>
+///   <item>Must have all the keys provided in <c>staticTagNames</c> as string type parameters.</item>
 /// </list>
 /// </remarks>
 /// <example>

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/CounterAttributeT.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/CounterAttributeT.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Extensions.Diagnostics.Metrics;
 /// <remarks>
 /// This attribute is applied to a method that has the following constraints:
 /// <list type="bullet">
-/// <item>Must be a partial method.</item>
-/// <item>Must return <c>metricName</c> as the type. A class with that name will be generated.</item>
-/// <item>Must not be generic.</item>
-/// <item>Must have <c>System.Diagnostics.Metrics.Meter</c> as first parameter.</item>
-/// <item>Must have all the keys provided in <c>staticTags</c> as string type parameters.</item>
+///   <item>Must be a partial method.</item>
+///   <item>Must return <c>metricName</c> as the type. A class with that name will be generated.</item>
+///   <item>Must not be generic.</item>
+///   <item>Must have <c>System.Diagnostics.Metrics.Meter</c> as first parameter.</item>
+///   <item>Must have all the keys provided in <c>staticTags</c> as string type parameters.</item>
 /// </list>
 /// </remarks>
 /// <example>

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/GaugeAttribute.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/GaugeAttribute.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Extensions.Diagnostics.Metrics;
 /// <remarks>
 /// This attribute is applied to a method that has the following constraints:
 /// <list type="bullet">
-/// <item>Must be a partial method.</item>
-/// <item>Must return <c>metricName</c> as the type. A class with that name will be generated.</item>
-/// <item>Must not be generic.</item>
-/// <item>Must have <c>System.Diagnostics.Metrics.Meter</c> as first parameter.</item>
-/// <item>Must have all the keys provided in <c>staticTags</c> as string type parameters.</item>
+///   <item>Must be a partial method.</item>
+///   <item>Must return <c>metricName</c> as the type. A class with that name will be generated.</item>
+///   <item>Must not be generic.</item>
+///   <item>Must have <c>System.Diagnostics.Metrics.Meter</c> as first parameter.</item>
+///   <item>Must have all the keys provided in <c>staticTags</c> as string type parameters.</item>
 /// </list>
 /// </remarks>
 /// <example>

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/HistogramAttribute.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/HistogramAttribute.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Extensions.Diagnostics.Metrics;
 /// <remarks>
 /// This attribute is applied to a method that has the following constraints:
 /// <list type="bullet">
-/// <item>Must be a partial method.</item>
-/// <item>Must return <c>metricName</c> as the type. A class with that name will be generated.</item>
-/// <item>Must not be generic.</item>
-/// <item>Must have <c>System.Diagnostics.Metrics.Meter</c> as first parameter.</item>
-/// <item>Must have all the keys provided in <c>staticTags</c> as string type parameters.</item>
+///   <item>Must be a partial method.</item>
+///   <item>Must return <c>metricName</c> as the type. A class with that name will be generated.</item>
+///   <item>Must not be generic.</item>
+///   <item>Must have <c>System.Diagnostics.Metrics.Meter</c> as first parameter.</item>
+///   <item>Must have all the keys provided in <c>staticTags</c> as string type parameters.</item>
 /// </list>
 /// </remarks>
 /// <example>

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/HistogramAttributeT.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Metrics/HistogramAttributeT.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Extensions.Diagnostics.Metrics;
 /// <remarks>
 /// This attribute is applied to a method that has the following constraints:
 /// <list type="bullet">
-/// <item>Must be a partial method.</item>
-/// <item>Must return <c>metricName</c> as the type. A class with that name will be generated.</item>
-/// <item>Must not be generic.</item>
-/// <item>Must have <c>System.Diagnostics.Metrics.Meter</c> as first parameter.</item>
-/// <item>Must have all the keys provided in <c>staticTags</c> as string type parameters.</item>
+///   <item>Must be a partial method.</item>
+///   <item>Must return <c>metricName</c> as the type. A class with that name will be generated.</item>
+///   <item>Must not be generic.</item>
+///   <item>Must have <c>System.Diagnostics.Metrics.Meter</c> as first parameter.</item>
+///   <item>Must have all the keys provided in <c>staticTags</c> as string type parameters.</item>
 /// </list>
 /// </remarks>
 /// <example>


### PR DESCRIPTION
Learn platform fixed a bug such that \<description> tags within bullet list \<item> elements are no longer necessary. See https://ceapex.visualstudio.com/Engineering/_workitems/edit/1122283/.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7226)