### PR TITLE
Update public pipeline pool images to fix broken builds

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -113,7 +113,7 @@ stages:
 
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals windows.vs2022preview.amd64.open
+          demands: ImageOverride -equals 1es-windows-2022-open
 
         variables:
           - _buildScript: $(Build.SourcesDirectory)/build.cmd -ci -NativeToolsOnMachine
@@ -145,7 +145,7 @@ stages:
 
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals build.ubuntu.2004.amd64.open
+          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
 
         variables:
           - _buildScript: $(Build.SourcesDirectory)/build.sh --ci
@@ -198,7 +198,7 @@ stages:
 
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals build.ubuntu.2004.amd64.open
+          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
 
         preSteps:
           - checkout: self
@@ -237,7 +237,7 @@ stages:
 
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals windows.vs2022preview.amd64.open
+          demands: ImageOverride -equals 1es-windows-2022-open
 
         variables:
           - _buildScript: $(Build.SourcesDirectory)/build.cmd -ci -NativeToolsOnMachine


### PR DESCRIPTION
Update the pool image references in azure-pipelines-public.yml:
- Windows: \windows.vs2022preview.amd64.open\ → \1es-windows-2022-open\
- Ubuntu: \uild.ubuntu.2004.amd64.open\ → \Build.Ubuntu.2204.Amd64.Open\

The old images have been retired and are no longer available, causing build failures. This matches the equivalent change made in [dotnet/aspire#14486](https://github.com/dotnet/aspire/pull/14486).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7292)