### PR TITLE
Use smaller windows.vs2022.amd64.open pool image

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -113,7 +113,7 @@ stages:
 
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-windows-2022-open
+          demands: ImageOverride -equals windows.vs2022.amd64.open
 
         variables:
           - _buildScript: $(Build.SourcesDirectory)/build.cmd -ci -NativeToolsOnMachine
@@ -237,7 +237,7 @@ stages:
 
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-windows-2022-open
+          demands: ImageOverride -equals windows.vs2022.amd64.open
 
         variables:
           - _buildScript: $(Build.SourcesDirectory)/build.cmd -ci -NativeToolsOnMachine


### PR DESCRIPTION
Follow-up to #7292. The 1es-windows-2022-open image is the large kitchen sink image. Switch to windows.vs2022.amd64.open which is the appropriate smaller image for our build needs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7298)