### PR TITLE
Fix flaky test failure in HttpRequestBuffering_DoesNotBufferDisabledOrOversizedLogs (#7148)

### DIFF
--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Logging/AcceptanceTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Logging/AcceptanceTests.cs
@@ -947,7 +947,9 @@ public partial class AcceptanceTests
                 // 1st log record is from DfaMatcher,
                 // 2, 3, 4th are from our "test" category
                 // and 5 and 6th are logs from the /logatrequest endpoint
-                Assert.Equal(6, logCollector.Count);
+                var entries = logCollector.GetSnapshot();
+                var relevantCount = entries.Count(x => x.Category == "Microsoft.AspNetCore.Routing.Matching.DfaMatcher" || x.Category == "test" || x.Category == "logatrequest");
+                Assert.Equal(6, relevantCount);
                 Assert.Equal(LogLevel.Trace, logCollector.LatestRecord.Level);
                 Assert.Equal("test", logCollector.LatestRecord.Category);
             });


### PR DESCRIPTION
This PR fixes a flaky test failure in 

HttpRequestBuffering_DoesNotBufferDisabledOrOversizedLogs
 where the test occasionally received 7 logs instead of the expected 6.

Changes

Updated the assertion in 

AcceptanceTests.cs
 to explicitly filter for the log categories intended by the test case: Microsoft.AspNetCore.Routing.Matching.DfaMatcher, test, and logatrequest.
This prevents environmental noise or default HttpLoggingMiddleware logs from causing intermittent failures.
Fixes #7148
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7328)