### PR TITLE
Pass sourceIndexBuildCommand through to SourceIndex

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,11 +128,11 @@ variables:
   - ${{ if and(ne(variables['runAsPublic'], 'true'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
     - name: enableSourceIndex
       value: true
-    - name: sourceIndexBuildCommand
-      value: $(Build.SourcesDirectory)/build.cmd -ci -NativeToolsOnMachine
   - ${{ else }}:
     - name: enableSourceIndex
       value: false
+  - name: sourceIndexBuildCommand
+    value: $(Build.SourcesDirectory)/build.cmd -ci -NativeToolsOnMachine
 
 resources:
   repositories:
@@ -176,6 +176,8 @@ extends:
           enableMicrobuild: true
           enableTelemetry: true
           enableSourceIndex: ${{ variables['enableSourceIndex'] }}
+          sourceIndexParams:
+            sourceIndexBuildCommand: ${{ variables['sourceIndexBuildCommand'] }}
           runAsPublic: ${{ variables['runAsPublic'] }}
           # Publish test logs
           enablePublishTestResults: true


### PR DESCRIPTION
We were still using the default, because we weren't plumbing our variable through
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7348)