### PR TITLE
Remove SonarAnalyzer.CSharp and disable CA1508 for build perf

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -35,9 +35,6 @@
 
     <NoWarn Condition="'$(GenerateDocumentationFile)' != 'true'">$(NoWarn);SA1600;SA0001</NoWarn>
 
-    <!-- Conflicts with SA1405: Debug.Assert should provide message text -->
-    <NoWarn>$(NoWarn);S3236</NoWarn>
-
     <!-- Legacy targets do not support attributes for a nullable context thus suppressing null check warnings -->
     <NoWarn Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'">$(NoWarn);CA1062</NoWarn>
 

--- a/bench/Libraries/Microsoft.Extensions.Http.Diagnostics.PerformanceTests/DropMessageLoggerProvider.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Diagnostics.PerformanceTests/DropMessageLoggerProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
@@ -10,8 +10,6 @@ internal sealed class DropMessageLoggerProvider : ILoggerProvider
 {
     public ILogger CreateLogger(string categoryName) => new DropMessageLogger();
 
-    [SuppressMessage("Critical Code Smell", "S1186:Methods should not be empty",
-        Justification = "Noop")]
     public void Dispose()
     {
     }

--- a/bench/Libraries/Microsoft.Extensions.Telemetry.PerformanceTests/ClassicCodeGen.cs
+++ b/bench/Libraries/Microsoft.Extensions.Telemetry.PerformanceTests/ClassicCodeGen.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -6,12 +6,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.Telemetry.Bench;
 
-#pragma warning disable S103
 #pragma warning disable SA1121
-#pragma warning disable S2148
 #pragma warning disable IDE0055
 #pragma warning disable IDE1006
-#pragma warning disable S3235
 
 internal static class ClassicCodeGen
 {

--- a/eng/MSBuild/Analyzers.props
+++ b/eng/MSBuild/Analyzers.props
@@ -19,7 +19,7 @@
   <!-- The static analyzers we use  -->
   <ItemGroup Condition="'$(SkipAnalyzers)' != 'true'">
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-    <PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+
     <PackageReference Include="StyleCop.Analyzers.Unstable" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <AdditionalFiles Include="$(RepositoryEngineeringDir)\Stylecop.json" Visible="false" />
     <PackageReference Include="ReferenceTrimmer" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />

--- a/eng/Tools/ApiChief/Commands/CheckBreakingChanges.cs
+++ b/eng/Tools/ApiChief/Commands/CheckBreakingChanges.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -13,7 +13,6 @@ namespace ApiChief.Commands;
 
 internal static class CheckBreakingChanges
 {
-    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Written through reflection.")]
     private sealed class CheckBreakingChangesArgs
     {
         public FileInfo? AssemblyPath { get; }

--- a/eng/Tools/ApiChief/Commands/EmitBaseline.cs
+++ b/eng/Tools/ApiChief/Commands/EmitBaseline.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -13,8 +13,6 @@ namespace ApiChief.Commands;
 
 internal static class EmitBaseline
 {
-    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Written through reflection.")]
-    [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Written through reflection.")]
     private sealed class EmitBaselineArgs
     {
         public FileInfo? AssemblyPath { get; set; }

--- a/eng/Tools/ApiChief/Commands/EmitDelta.cs
+++ b/eng/Tools/ApiChief/Commands/EmitDelta.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -13,8 +13,6 @@ namespace ApiChief.Commands;
 
 internal static class EmitDelta
 {
-    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Written through reflection.")]
-    [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Written through reflection.")]
     private sealed class EmitDeltaArgs
     {
         public FileInfo? AssemblyPath { get; set; }

--- a/eng/Tools/ApiChief/Commands/EmitReview.cs
+++ b/eng/Tools/ApiChief/Commands/EmitReview.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -21,8 +21,6 @@ namespace ApiChief.Commands;
 
 internal static class EmitReview
 {
-    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Written through reflection.")]
-    [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Written through reflection.")]
     private sealed class EmitReviewArgs
     {
         public FileInfo? AssemblyPath { get; set; }
@@ -51,7 +49,6 @@ internal static class EmitReview
     private static async Task<int> ExecuteAsync(EmitReviewArgs args)
     {
         // once with XML comments, once without
-#pragma warning disable S109 // Magic numbers should not be used
         for (int i = 0; i < 2; i++)
         {
             var formatting = Formatter.FormattingWithXmlComments;
@@ -240,7 +237,6 @@ internal static class EmitReview
                 }
             }
         }
-#pragma warning restore S109 // Magic numbers should not be used
 
         return 0;
     }

--- a/eng/Tools/ApiChief/Commands/EmitSummary.cs
+++ b/eng/Tools/ApiChief/Commands/EmitSummary.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -16,8 +16,6 @@ namespace ApiChief.Commands;
 
 internal static class EmitSummary
 {
-    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Written through reflection.")]
-    [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Written through reflection.")]
     private sealed class EmitSummaryArgs
     {
         public FileInfo? AssemblyPath { get; set; }

--- a/eng/Tools/ApiChief/Format/FormattingExtensions.cs
+++ b/eng/Tools/ApiChief/Format/FormattingExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -37,9 +37,7 @@ internal static class FormattingExtensions
                 }
 
                 sb.Append(next);
-#pragma warning disable S127 // "for" loop stop conditions should be invariant
                 i = index;
-#pragma warning restore S127 // "for" loop stop conditions should be invariant
             }
             else if (current == ',')
             {
@@ -103,11 +101,8 @@ internal static class FormattingExtensions
                 }
 
                 sb.Append(next);
-#pragma warning disable S127 // "for" loop stop conditions should be invariant
                 i = initial;
-#pragma warning restore S127 // "for" loop stop conditions should be invariant
             }
-#pragma warning disable S2583 // Conditionally executed code should be reachable
             else if (current == '=')
             {
                 sawEqualitySign = true;
@@ -117,14 +112,12 @@ internal static class FormattingExtensions
                 var initial = i + 1;
                 var next = memberDecl[initial];
 
-#pragma warning disable S1067 // Expressions should not be too complex
                 while (char.IsDigit(next) || (char.IsDigit(memberDecl[initial - 1]) && _possibleSpecialCharactersInANumber.Contains(next)))
                 {
                     sb.Append(next);
                     initial++;
                     next = memberDecl[initial];
                 }
-#pragma warning restore S1067 // Expressions should not be too complex
 
                 if (!_numberLiterals.Contains(next))
                 {
@@ -134,12 +127,9 @@ internal static class FormattingExtensions
                 {
                     initial++;
                 }
-#pragma warning disable S127 // "for" loop stop conditions should be invariant
                 i = initial;
-#pragma warning restore S127 // "for" loop stop conditions should be invariant
                 sawEqualitySign = false;
             }
-#pragma warning restore S2583 // Conditionally executed code should be reachable
 
         }
 

--- a/eng/Tools/ApiChief/Processing/ApiProcessor.cs
+++ b/eng/Tools/ApiChief/Processing/ApiProcessor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -128,7 +128,6 @@ internal class ApiProcessor
                 && property.DeclaringType.Equals(type);
     }
 
-    [SuppressMessage("Critical Code Smell", "S1067:Expressions should not be too complex", Justification = "Cannot reduce it.")]
     private static void ProcessMethods(ITypeDefinition type, ApiType finalTypeApi, ApiStage classStage)
     {
         var methods = type.Methods

--- a/eng/Tools/ApiChief/Processing/PublicFilterVisitor.cs
+++ b/eng/Tools/ApiChief/Processing/PublicFilterVisitor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
@@ -74,7 +74,6 @@ internal sealed class PublicFilterVisitor : CSharpOutputVisitor
             foreach (var attribute in methodDeclaration.Attributes)
             {
                 var s = attribute.ToString();
-#pragma warning disable S1067
                 if (s.Contains("SkipLocalsInit")
                     || s.Contains("ExcludeFromCodeCoverage")
                     || s.Contains("DebuggerStepThrough")
@@ -83,7 +82,6 @@ internal sealed class PublicFilterVisitor : CSharpOutputVisitor
                     || s.Contains("DynamicDependency")
                     || s.Contains("RequiresUnreferencedCode")
                     || s.Contains("AsyncStateMachine"))
-#pragma warning restore S1067
                 {
                     attribute.Remove();
                 }

--- a/eng/Tools/DiagConfig/ConfigStore/Metadata.cs
+++ b/eng/Tools/DiagConfig/ConfigStore/Metadata.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -10,9 +10,7 @@ internal sealed class Metadata
     public string Category { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
-#pragma warning disable S3996 // URI properties should not be strings
     public string? HelpLinkUri { get; set; }
-#pragma warning restore S3996 // URI properties should not be strings
     public IList<string>? CustomTags { get; set; }
     public Severity DefaultSeverity { get; set; }
 }

--- a/eng/Tools/DiagConfig/MergeAnalyzersCmd.cs
+++ b/eng/Tools/DiagConfig/MergeAnalyzersCmd.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -60,9 +60,7 @@ internal static class MergeAnalyzersCmd
             Assembly asm;
             try
             {
-#pragma warning disable S3885 // "Assembly.Load" should be used
                 asm = Assembly.LoadFrom(path);
-#pragma warning restore S3885 // "Assembly.Load" should be used
             }
             catch (Exception ex)
             {

--- a/eng/Tools/DiagConfig/SaveEditorConfigCmd.cs
+++ b/eng/Tools/DiagConfig/SaveEditorConfigCmd.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -12,8 +12,6 @@ namespace DiagConfig;
 
 internal static class SaveEditorConfigCmd
 {
-#pragma warning disable S3459 // Unassigned members should be removed
-#pragma warning disable S1144 // Unused private types or members should be removed
     private sealed class SaveEditorConfigArgs
     {
         public string ConfigDirectory { get; set; } = string.Empty;
@@ -24,8 +22,6 @@ internal static class SaveEditorConfigCmd
         public bool IsGlobal { get; set; }
         public int MaxTier { get; set; } = int.MaxValue;
     }
-#pragma warning restore S1144 // Unused private types or members should be removed
-#pragma warning restore S3459 // Unassigned members should be removed
 
     public static Command Create()
     {

--- a/src/Analyzers/.editorconfig
+++ b/src/Analyzers/.editorconfig
@@ -480,7 +480,7 @@ dotnet_diagnostic.CA1507.severity = warning
 # Title    : Avoid dead conditional code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
-dotnet_diagnostic.CA1508.severity = warning
+dotnet_diagnostic.CA1508.severity = none
 
 # Title    : Invalid entry in code metrics rule specification file
 # Category : Maintainability
@@ -2889,2294 +2889,391 @@ dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
 # Redundant: IDE1006
-dotnet_diagnostic.S100.severity = none
-
-# Title    : Method overrides should not change parameter defaults
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
-dotnet_diagnostic.S1006.severity = warning
 
 # Title    : Types should be named in PascalCase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
 # Redundant: IDE1006
-dotnet_diagnostic.S101.severity = none
-
-# Title    : Lines should not be too long
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
-dotnet_diagnostic.S103.severity = warning
-
-# Title    : Files should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
-dotnet_diagnostic.S104.severity = warning
 
 # Title    : Finalizers should not throw exceptions
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
 # Redundant: CA1065
-dotnet_diagnostic.S1048.severity = none
 
 # Title    : Tabulation characters should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
 # Redundant: SA1027
-dotnet_diagnostic.S105.severity = none
-
-# Title    : Standard outputs should not be used directly to log anything
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
-dotnet_diagnostic.S106.severity = warning
-
-# Title    : Collapsible "if" statements should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
-dotnet_diagnostic.S1066.severity = none
-
-# Title    : Expressions should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
-dotnet_diagnostic.S1067.severity = warning
-
-# Title    : Methods should not have too many parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
-dotnet_diagnostic.S107.severity = warning
-
-# Title    : URIs should not be hardcoded
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
-dotnet_diagnostic.S1075.severity = warning
-
-# Title    : Nested blocks of code should not be left empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
-dotnet_diagnostic.S108.severity = warning
-
-# Title    : Magic numbers should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
-dotnet_diagnostic.S109.severity = warning
-
-# Title    : Inheritance tree of classes should not be too deep
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
-dotnet_diagnostic.S110.severity = warning
 
 # Title    : Fields should not have public accessibility
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
 # Redundant: CA1051
-dotnet_diagnostic.S1104.severity = none
 
 # Title    : A close curly brace should be located at the beginning of a line
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
 # Redundant: SA1500
-dotnet_diagnostic.S1109.severity = none
 
 # Title    : Redundant pairs of parentheses should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
 # Redundant: SA1119
-dotnet_diagnostic.S1110.severity = none
 
 # Title    : Empty statements should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
 # Redundant: SA1106
-dotnet_diagnostic.S1116.severity = none
-
-# Title    : Local variables should not shadow class fields or properties
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
-dotnet_diagnostic.S1117.severity = warning
 
 # Title    : Utility classes should not have public constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
 # Redundant: CA1052
-dotnet_diagnostic.S1118.severity = none
 
 # Title    : General exceptions should never be thrown
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
 # Redundant: CA2219
-dotnet_diagnostic.S112.severity = none
-
-# Title    : Assignments should not be made from within sub-expressions
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
-dotnet_diagnostic.S1121.severity = warning
 
 # Title    : "Obsolete" attributes should include explanations
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
 # Redundant: CA1041
-dotnet_diagnostic.S1123.severity = none
-
-# Title    : Boolean literals should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
-dotnet_diagnostic.S1125.severity = warning
-
-# Title    : Unused "using" should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
-dotnet_diagnostic.S1128.severity = warning
-
-# Title    : Files should contain an empty newline at the end
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
-dotnet_diagnostic.S113.severity = none
-
-# Title    : Deprecated code should be removed
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1133
-dotnet_diagnostic.S1133.severity = suggestion
-
-# Title    : Track uses of "FIXME" tags
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
-dotnet_diagnostic.S1134.severity = warning
-
-# Title    : Track uses of "TODO" tags
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
-dotnet_diagnostic.S1135.severity = warning
-
-# Title    : Unused private types or members should be removed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
-dotnet_diagnostic.S1144.severity = warning
-
-# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
-dotnet_diagnostic.S1145.severity = warning
-
-# Title    : Exit methods should not be called
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
-dotnet_diagnostic.S1147.severity = warning
-
-# Title    : "switch case" clauses should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
-dotnet_diagnostic.S1151.severity = none
-
-# Title    : "Any()" should be used to test for emptiness
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
-dotnet_diagnostic.S1155.severity = warning
 
 # Title    : Exceptions should not be thrown in finally blocks
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
 # Redundant: CA2219
-dotnet_diagnostic.S1163.severity = none
-
-# Title    : Empty arrays and collections should be returned instead of null
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
-dotnet_diagnostic.S1168.severity = warning
 
 # Title    : Unused method parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
 # Redundant: IDE0060
-dotnet_diagnostic.S1172.severity = none
-
-# Title    : Overriding members should do more than simply call the same member in the base class
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
-dotnet_diagnostic.S1185.severity = warning
-
-# Title    : Methods should not be empty
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
-dotnet_diagnostic.S1186.severity = warning
-
-# Title    : String literals should not be duplicated
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
-dotnet_diagnostic.S1192.severity = suggestion
-
-# Title    : Nested code blocks should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
-dotnet_diagnostic.S1199.severity = warning
-
-# Title    : Classes should not be coupled to too many other classes
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
-dotnet_diagnostic.S1200.severity = none
 
 # Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
 # Redundant: CS0659
-dotnet_diagnostic.S1206.severity = none
 
 # Title    : Control structures should use curly braces
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
 # Redundant: SA1503
-dotnet_diagnostic.S121.severity = none
 
 # Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
 # Redundant: CA1036
-dotnet_diagnostic.S1210.severity = none
-
-# Title    : "GC.Collect" should not be called
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
-dotnet_diagnostic.S1215.severity = warning
-
-# Title    : Statements should be on separate lines
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
-dotnet_diagnostic.S122.severity = none
-
-# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
-dotnet_diagnostic.S1226.severity = warning
-
-# Title    : break statements should not be used except for switch cases
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
-dotnet_diagnostic.S1227.severity = none
-
-# Title    : Floating point numbers should not be tested for equality
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
-dotnet_diagnostic.S1244.severity = error
-
-# Title    : Sections of code should not be commented out
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
-dotnet_diagnostic.S125.severity = warning
-
-# Title    : "if ... else if" constructs should end with "else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
-dotnet_diagnostic.S126.severity = none
-
-# Title    : A "while" loop should be used instead of a "for" loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
-dotnet_diagnostic.S1264.severity = warning
-
-# Title    : "for" loop stop conditions should be invariant
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
-dotnet_diagnostic.S127.severity = warning
-
-# Title    : "switch" statements should have at least 3 "case" clauses
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
-dotnet_diagnostic.S1301.severity = none
 
 # Title    : Track uses of in-source issue suppressions
 # Category : Info Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
 # Comment  : Suppressions are frequently necessary.
-dotnet_diagnostic.S1309.severity = none
-
-# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
-dotnet_diagnostic.S131.severity = none
-
-# Title    : Using hardcoded IP addresses is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
-dotnet_diagnostic.S1313.severity = warning
-
-# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
-dotnet_diagnostic.S134.severity = none
-
-# Title    : Functions should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
-dotnet_diagnostic.S138.severity = none
-
-# Title    : Culture should be specified for "string" operations
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
-dotnet_diagnostic.S1449.severity = warning
-
-# Title    : Private fields only used as local variables in methods should become local variables
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
-dotnet_diagnostic.S1450.severity = warning
 
 # Title    : Track lack of copyright and license headers
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
 # Redundant: IDE0073
-dotnet_diagnostic.S1451.severity = none
-
-# Title    : "switch" statements should not have too many "case" clauses
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
-dotnet_diagnostic.S1479.severity = warning
 
 # Title    : Unused local variables should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
 # Redundant: CS0168
-dotnet_diagnostic.S1481.severity = none
-
-# Title    : Methods and properties should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
-dotnet_diagnostic.S1541.severity = none
-
-# Title    : Tests should not be ignored
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
-dotnet_diagnostic.S1607.severity = warning
-
-# Title    : Strings should not be concatenated using '+' in a loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
-dotnet_diagnostic.S1643.severity = warning
-
-# Title    : Variables should not be self-assigned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
-dotnet_diagnostic.S1656.severity = warning
-
-# Title    : Multiple variables should not be declared on the same line
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
-dotnet_diagnostic.S1659.severity = warning
-
-# Title    : An abstract class should have both abstract and concrete methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
-dotnet_diagnostic.S1694.severity = warning
-
-# Title    : NullReferenceException should not be caught
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
-dotnet_diagnostic.S1696.severity = warning
-
-# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
-dotnet_diagnostic.S1697.severity = warning
-
-# Title    : "==" should not be used when "Equals" is overridden
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
-dotnet_diagnostic.S1698.severity = warning
-
-# Title    : Constructors should only call non-overridable methods
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
-dotnet_diagnostic.S1699.severity = warning
-
-# Title    : Loops with at most one iteration should be refactored
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
-dotnet_diagnostic.S1751.severity = warning
-
-# Title    : Identical expressions should not be used on both sides of operators
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
-dotnet_diagnostic.S1764.severity = warning
-
-# Title    : "switch" statements should not be nested
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
-dotnet_diagnostic.S1821.severity = none
-
-# Title    : Objects should not be created to be dropped immediately without being used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
-dotnet_diagnostic.S1848.severity = warning
 
 # Title    : Unused assignments should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
 # Redundant: IDE0059
-dotnet_diagnostic.S1854.severity = none
-
-# Title    : "ToString()" calls should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
-dotnet_diagnostic.S1858.severity = warning
-
-# Title    : Related "if/else if" statements should not have the same condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
-dotnet_diagnostic.S1862.severity = warning
-
-# Title    : Two branches in a conditional structure should not have exactly the same implementation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
-dotnet_diagnostic.S1871.severity = warning
 
 # Title    : Redundant casts should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
 # Redundant: IDE0004
-dotnet_diagnostic.S1905.severity = none
-
-# Title    : Inheritance list should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
-dotnet_diagnostic.S1939.severity = warning
-
-# Title    : Boolean checks should not be inverted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
-dotnet_diagnostic.S1940.severity = warning
-
-# Title    : Invalid casts should be avoided
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
-dotnet_diagnostic.S1944.severity = warning
-
-# Title    : "for" loop increment clauses should modify the loops' counters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
-dotnet_diagnostic.S1994.severity = warning
 
 # Title    : Hashes should include an unpredictable salt
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S2053.severity = none
-
-# Title    : Hard-coded credentials are security-sensitive
-# Category : Blocker Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
-dotnet_diagnostic.S2068.severity = warning
 
 # Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
 # Redundant: CA5350
-dotnet_diagnostic.S2070.severity = none
-
-# Title    : Formatting SQL queries is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
-dotnet_diagnostic.S2077.severity = warning
-
-# Title    : Creating cookies without the "secure" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
-dotnet_diagnostic.S2092.severity = warning
-
-# Title    : Classes should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2094
-dotnet_diagnostic.S2094.severity = none
-
-# Title    : Collections should not be passed as arguments to their own methods
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
-dotnet_diagnostic.S2114.severity = warning
-
-# Title    : A secure password should be used when connecting to a database
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
-dotnet_diagnostic.S2115.severity = warning
-
-# Title    : Values should not be uselessly incremented
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
-dotnet_diagnostic.S2123.severity = warning
-
-# Title    : Underscores should be used to make large numbers readable
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
-dotnet_diagnostic.S2148.severity = warning
-
-# Title    : "sealed" classes should not have "protected" members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
-dotnet_diagnostic.S2156.severity = warning
-
-# Title    : Classes named like "Exception" should extend "Exception" or a subclass
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2166
-dotnet_diagnostic.S2166.severity = warning
-
-# Title    : Short-circuit logic should be used in boolean contexts
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
-dotnet_diagnostic.S2178.severity = warning
-
-# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
-dotnet_diagnostic.S2183.severity = warning
-
-# Title    : Results of integer division should not be assigned to floating point variables
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
-dotnet_diagnostic.S2184.severity = warning
-
-# Title    : Test classes should contain at least one test case
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
-dotnet_diagnostic.S2187.severity = warning
-
-# Title    : Loops and recursions should not be infinite
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
-dotnet_diagnostic.S2190.severity = warning
-
-# Title    : Modulus results should not be checked for direct equality
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
-dotnet_diagnostic.S2197.severity = warning
-
-# Title    : Unnecessary mathematical comparisons should not be made
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2198
-dotnet_diagnostic.S2198.severity = warning
 
 # Title    : Methods without side effects should not have their return values ignored
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
 # Redundant: CA1806
-dotnet_diagnostic.S2201.severity = none
-
-# Title    : Runtime type checking should be simplified
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
-dotnet_diagnostic.S2219.severity = warning
-
-# Title    : "Exception" should not be caught
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
-dotnet_diagnostic.S2221.severity = none
-
-# Title    : Locks should be released on all paths
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
-dotnet_diagnostic.S2222.severity = warning
-
-# Title    : Non-constant static fields should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
-dotnet_diagnostic.S2223.severity = warning
-
-# Title    : "ToString()" method should not return null
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
-dotnet_diagnostic.S2225.severity = warning
-
-# Title    : Console logging should not be used
-# Category : Minor Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
-dotnet_diagnostic.S2228.severity = warning
-
-# Title    : Arguments should be passed in the same order as the method parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
-dotnet_diagnostic.S2234.severity = warning
-
-# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
-dotnet_diagnostic.S2245.severity = warning
-
-# Title    : A "for" loop update clause should move the counter in the right direction
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
-dotnet_diagnostic.S2251.severity = warning
-
-# Title    : For-loop conditions should be true at least once
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
-dotnet_diagnostic.S2252.severity = warning
-
-# Title    : Writing cookies is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
-dotnet_diagnostic.S2255.severity = warning
-
-# Title    : Using non-standard cryptographic algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
-dotnet_diagnostic.S2257.severity = warning
 
 # Title    : Null pointers should not be dereferenced
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
 # Comment  : Redundant, covered by modern C# compiler
-dotnet_diagnostic.S2259.severity = none
-
-# Title    : Composite format strings should not lead to unexpected behavior at runtime
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
-dotnet_diagnostic.S2275.severity = warning
-
-# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
-dotnet_diagnostic.S2278.severity = warning
-
-# Title    : Field-like events should not be virtual
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
-dotnet_diagnostic.S2290.severity = warning
-
-# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
-dotnet_diagnostic.S2291.severity = warning
 
 # Title    : Trivial properties should be auto-implemented
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
 # Redundant: IDE0032
-dotnet_diagnostic.S2292.severity = none
-
-# Title    : "nameof" should be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
-dotnet_diagnostic.S2302.severity = warning
-
-# Title    : "async" and "await" should not be used as identifiers
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
-dotnet_diagnostic.S2306.severity = warning
 
 # Title    : Methods and properties that don't access instance data should be static
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
 # Redundant: CA1822
-dotnet_diagnostic.S2325.severity = none
 
 # Title    : Unused type parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
 # Comment  : Valid pattern used in a number of places
-dotnet_diagnostic.S2326.severity = none
-
-# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
-dotnet_diagnostic.S2327.severity = warning
-
-# Title    : "GetHashCode" should not reference mutable fields
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
-dotnet_diagnostic.S2328.severity = warning
-
-# Title    : Array covariance should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
-dotnet_diagnostic.S2330.severity = warning
-
-# Title    : Redundant modifiers should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
-dotnet_diagnostic.S2333.severity = warning
-
-# Title    : Public constant members should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
-dotnet_diagnostic.S2339.severity = none
-
-# Title    : Enumeration types should comply with a naming convention
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
-dotnet_diagnostic.S2342.severity = none
-
-# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
-dotnet_diagnostic.S2344.severity = warning
-
-# Title    : Flags enumerations should explicitly initialize all their members
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
-dotnet_diagnostic.S2345.severity = warning
 
 # Title    : Flags enumerations zero-value members should be named "None"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
 # Redundant: CA1008
-dotnet_diagnostic.S2346.severity = none
 
 # Title    : Fields should be private
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
 # Redundant: CA1051
-dotnet_diagnostic.S2357.severity = none
-
-# Title    : Optional parameters should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
-dotnet_diagnostic.S2360.severity = none
-
-# Title    : Properties should not make collection or array copies
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
-dotnet_diagnostic.S2365.severity = warning
-
-# Title    : Public methods should not have multidimensional array parameters
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
-dotnet_diagnostic.S2368.severity = warning
-
-# Title    : Exceptions should not be thrown from property getters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
-dotnet_diagnostic.S2372.severity = warning
-
-# Title    : Write-only properties should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
-dotnet_diagnostic.S2376.severity = warning
-
-# Title    : Mutable fields should not be "public static"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
-dotnet_diagnostic.S2386.severity = warning
-
-# Title    : Child class fields should not shadow parent class fields
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
-dotnet_diagnostic.S2387.severity = warning
 
 # Title    : Types and methods should not have too many generic parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
 # Redundant: CA1005
-dotnet_diagnostic.S2436.severity = none
-
-# Title    : Unnecessary bit operations should not be performed
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
-dotnet_diagnostic.S2437.severity = warning
 
 # Title    : Blocks should be synchronized on read-only fields
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2445
 # Comment  : Noise
-dotnet_diagnostic.S2445.severity = none
-
-# Title    : Whitespace and control characters in string literals should be explicit
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
-dotnet_diagnostic.S2479.severity = warning
-
-# Title    : Generic exceptions should not be ignored
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
-dotnet_diagnostic.S2486.severity = warning
-
-# Title    : Shared resources should not be used for locking
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
-dotnet_diagnostic.S2551.severity = warning
 
 # Title    : Conditionally executed code should be reachable
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
 # Redundant: CA1508
-dotnet_diagnostic.S2583.severity = none
 
 # Title    : Boolean expressions should not be gratuitous
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
 # Comment  : Too many false positives.
-dotnet_diagnostic.S2589.severity = none
-
-# Title    : Setting loose file permissions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
-dotnet_diagnostic.S2612.severity = warning
-
-# Title    : The length returned from a stream read should be checked
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
-dotnet_diagnostic.S2674.severity = warning
-
-# Title    : Multiline blocks should be enclosed in curly braces
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
-dotnet_diagnostic.S2681.severity = warning
-
-# Title    : "NaN" should not be used in comparisons
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
-dotnet_diagnostic.S2688.severity = warning
-
-# Title    : "IndexOf" checks should not be for positive numbers
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
-dotnet_diagnostic.S2692.severity = warning
-
-# Title    : Instance members should not write to "static" fields
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
-dotnet_diagnostic.S2696.severity = warning
-
-# Title    : Tests should include assertions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
-dotnet_diagnostic.S2699.severity = warning
-
-# Title    : Literal boolean values should not be used in assertions
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
-dotnet_diagnostic.S2701.severity = warning
-
-# Title    : "catch" clauses should do more than rethrow
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
-dotnet_diagnostic.S2737.severity = warning
-
-# Title    : Static fields should not be used in generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
-dotnet_diagnostic.S2743.severity = none
-
-# Title    : XML parsers should not be vulnerable to XXE attacks
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
-dotnet_diagnostic.S2755.severity = warning
-
-# Title    : Non-existent operators like "=+" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
-dotnet_diagnostic.S2757.severity = warning
-
-# Title    : The ternary operator should not return the same value regardless of the condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
-dotnet_diagnostic.S2758.severity = warning
-
-# Title    : Sequential tests should not check the same condition
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
-dotnet_diagnostic.S2760.severity = warning
-
-# Title    : Doubled prefix operators "!!" and "~~" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
-dotnet_diagnostic.S2761.severity = warning
-
-# Title    : SQL keywords should be delimited by whitespace
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
-dotnet_diagnostic.S2857.severity = warning
-
-# Title    : "Thread.Sleep" should not be used in tests
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2925
-dotnet_diagnostic.S2925.severity = none
 
 # Title    : "IDisposables" should be disposed
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
 # Redundant: CA2000
-dotnet_diagnostic.S2930.severity = none
 
 # Title    : Classes with "IDisposable" members should implement "IDisposable"
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
 # Redundant: CA1001
-dotnet_diagnostic.S2931.severity = none
 
 # Title    : Fields that are only assigned in the constructor should be "readonly"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
 # Redundant: IDE0044
-dotnet_diagnostic.S2933.severity = none
-
-# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
-dotnet_diagnostic.S2934.severity = warning
-
-# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
-dotnet_diagnostic.S2952.severity = warning
-
-# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
-dotnet_diagnostic.S2953.severity = warning
-
-# Title    : Generic parameters not constrained to reference types should not be compared to "null"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
-dotnet_diagnostic.S2955.severity = warning
-
-# Title    : Assertions should be complete
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2970
-dotnet_diagnostic.S2970.severity = warning
-
-# Title    : "IEnumerable" LINQs should be simplified
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
-dotnet_diagnostic.S2971.severity = warning
-
-# Title    : "Object.ReferenceEquals" should not be used for value types
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
-dotnet_diagnostic.S2995.severity = warning
-
-# Title    : "ThreadStatic" fields should not be initialized
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
-dotnet_diagnostic.S2996.severity = warning
-
-# Title    : "IDisposables" created in a "using" statement should not be returned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
-dotnet_diagnostic.S2997.severity = warning
-
-# Title    : "ThreadStatic" should not be used on non-static fields
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
-dotnet_diagnostic.S3005.severity = warning
-
-# Title    : Static fields should not be updated in constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
-dotnet_diagnostic.S3010.severity = warning
-
-# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
-dotnet_diagnostic.S3011.severity = warning
 
 # Title    : Members should not be initialized to default values
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
 # Redundant: CA1805
-dotnet_diagnostic.S3052.severity = none
-
-# Title    : Types should not have members with visibility set higher than the type's visibility
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
-dotnet_diagnostic.S3059.severity = none
-
-# Title    : "is" should not be used with "this"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
-dotnet_diagnostic.S3060.severity = warning
-
-# Title    : "StringBuilder" data should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3063
-dotnet_diagnostic.S3063.severity = warning
 
 # Title    : "async" methods should not return "void"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
 # Redundant: VSTHRD100
-dotnet_diagnostic.S3168.severity = none
-
-# Title    : Multiple "OrderBy" calls should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
-dotnet_diagnostic.S3169.severity = warning
-
-# Title    : Delegates should not be subtracted
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
-dotnet_diagnostic.S3172.severity = warning
-
-# Title    : "interface" instances should not be cast to concrete types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
-dotnet_diagnostic.S3215.severity = warning
 
 # Title    : "ConfigureAwait(false)" should be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
 # Redundant: CA2007
-dotnet_diagnostic.S3216.severity = none
-
-# Title    : "Explicit" conversions of "foreach" loops should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
-dotnet_diagnostic.S3217.severity = warning
-
-# Title    : Inner class members should not shadow outer class "static" or type members
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
-dotnet_diagnostic.S3218.severity = warning
-
-# Title    : Method calls should not resolve ambiguously to overloads with "params"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
-dotnet_diagnostic.S3220.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
-dotnet_diagnostic.S3234.severity = warning
-
-# Title    : Redundant parentheses should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
-dotnet_diagnostic.S3235.severity = warning
-
-# Title    : Caller information arguments should not be provided explicitly
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
-dotnet_diagnostic.S3236.severity = warning
-
-# Title    : "value" contextual keyword should be used
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
-dotnet_diagnostic.S3237.severity = warning
 
 # Title    : The simplest possible condition syntax should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
 # Redundant: IDE0054
-dotnet_diagnostic.S3240.severity = none
-
-# Title    : Methods should not return values that are never used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
-dotnet_diagnostic.S3241.severity = warning
 
 # Title    : Method parameters should be declared with base types
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
 # Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
-dotnet_diagnostic.S3242.severity = none
-
-# Title    : Anonymous delegates should not be used to unsubscribe from Events
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
-dotnet_diagnostic.S3244.severity = warning
-
-# Title    : Generic type parameters should be co/contravariant when possible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
-dotnet_diagnostic.S3246.severity = warning
-
-# Title    : Duplicate casts should not be made
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
-dotnet_diagnostic.S3247.severity = warning
-
-# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
-dotnet_diagnostic.S3249.severity = warning
-
-# Title    : Implementations should be provided for "partial" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
-dotnet_diagnostic.S3251.severity = warning
-
-# Title    : Constructor and destructor declarations should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
-dotnet_diagnostic.S3253.severity = warning
-
-# Title    : Default parameter values should not be passed as arguments
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
-dotnet_diagnostic.S3254.severity = warning
-
-# Title    : "string.IsNullOrEmpty" should be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
-dotnet_diagnostic.S3256.severity = warning
 
 # Title    : Declarations and initializations should be as concise as possible
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
 # Comment  : Too many false positives
-dotnet_diagnostic.S3257.severity = none
 
 # Title    : Non-derived "private" classes and records should be "sealed"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
 # Redundant: R9A013
-dotnet_diagnostic.S3260.severity = none
-
-# Title    : Namespaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
-dotnet_diagnostic.S3261.severity = warning
-
-# Title    : "params" should be used on overrides
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
-dotnet_diagnostic.S3262.severity = warning
-
-# Title    : Static fields should appear in the order they must be initialized 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
-dotnet_diagnostic.S3263.severity = warning
-
-# Title    : Events should be invoked
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
-dotnet_diagnostic.S3264.severity = warning
-
-# Title    : Non-flags enums should not be used in bitwise operations
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
-dotnet_diagnostic.S3265.severity = warning
-
-# Title    : Loops should be simplified with "LINQ" expressions
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
-dotnet_diagnostic.S3267.severity = none
 
 # Title    : Cipher Block Chaining IVs should be unpredictable
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S3329.severity = none
-
-# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
-dotnet_diagnostic.S3330.severity = warning
-
-# Title    : Caller information parameters should come at the end of the parameter list
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
-dotnet_diagnostic.S3343.severity = warning
-
-# Title    : Expressions used in "Debug.Assert" should not produce side effects
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
-dotnet_diagnostic.S3346.severity = warning
-
-# Title    : Unchanged local variables should be "const"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
-dotnet_diagnostic.S3353.severity = warning
-
-# Title    : Ternary operators should not be nested
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
-dotnet_diagnostic.S3358.severity = warning
-
-# Title    : Date and time should not be used as a type for primary keys
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3363
-dotnet_diagnostic.S3363.severity = warning
-
-# Title    : "this" should not be exposed from constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
-dotnet_diagnostic.S3366.severity = warning
 
 # Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
 # Redundant: CA1710
-dotnet_diagnostic.S3376.severity = none
-
-# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
-dotnet_diagnostic.S3397.severity = warning
-
-# Title    : "private" methods called only by inner classes should be moved to those classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3398
-dotnet_diagnostic.S3398.severity = warning
-
-# Title    : Methods should not return constants
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
-dotnet_diagnostic.S3400.severity = warning
-
-# Title    : Assertion arguments should be passed in the correct order
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
-dotnet_diagnostic.S3415.severity = warning
-
-# Title    : Method overloads with default parameter values should not overlap
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
-dotnet_diagnostic.S3427.severity = warning
-
-# Title    : "[ExpectedException]" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
-dotnet_diagnostic.S3431.severity = warning
-
-# Title    : Test method signatures should be correct
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
-dotnet_diagnostic.S3433.severity = warning
-
-# Title    : Variables should not be checked against the values they're about to be assigned
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
-dotnet_diagnostic.S3440.severity = warning
-
-# Title    : Redundant property names should be omitted in anonymous classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
-dotnet_diagnostic.S3441.severity = warning
-
-# Title    : "abstract" classes should not have "public" constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
-dotnet_diagnostic.S3442.severity = warning
-
-# Title    : Type should not be examined on "System.Type" instances
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
-dotnet_diagnostic.S3443.severity = warning
-
-# Title    : Interfaces should not simply inherit from base interfaces with colliding members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
-dotnet_diagnostic.S3444.severity = warning
-
-# Title    : Exceptions should not be explicitly rethrown
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
-dotnet_diagnostic.S3445.severity = warning
-
-# Title    : "[Optional]" should not be used on "ref" or "out" parameters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
-dotnet_diagnostic.S3447.severity = warning
-
-# Title    : Right operands of shift operators should be integers
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
-dotnet_diagnostic.S3449.severity = warning
-
-# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
-dotnet_diagnostic.S3450.severity = warning
-
-# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
-dotnet_diagnostic.S3451.severity = warning
-
-# Title    : Classes should not have only "private" constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
-dotnet_diagnostic.S3453.severity = warning
-
-# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
-dotnet_diagnostic.S3456.severity = warning
-
-# Title    : Composite format strings should be used correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
-dotnet_diagnostic.S3457.severity = warning
-
-# Title    : Empty "case" clauses that fall through to the "default" should be omitted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
-dotnet_diagnostic.S3458.severity = warning
-
-# Title    : Unassigned members should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
-dotnet_diagnostic.S3459.severity = warning
-
-# Title    : Type inheritance should not be recursive
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
-dotnet_diagnostic.S3464.severity = warning
-
-# Title    : Optional parameters should be passed to "base" calls
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
-dotnet_diagnostic.S3466.severity = warning
-
-# Title    : Empty "default" clauses should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
-dotnet_diagnostic.S3532.severity = warning
-
-# Title    : "ServiceContract" and "OperationContract" attributes should be used together
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
-dotnet_diagnostic.S3597.severity = warning
-
-# Title    : One-way "OperationContract" methods should have "void" return type
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
-dotnet_diagnostic.S3598.severity = warning
-
-# Title    : "params" should not be introduced on overrides
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
-dotnet_diagnostic.S3600.severity = warning
-
-# Title    : Methods with "Pure" attribute should return a value 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
-dotnet_diagnostic.S3603.severity = warning
-
-# Title    : Member initializer values should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
-dotnet_diagnostic.S3604.severity = warning
-
-# Title    : Nullable type comparison should not be redundant
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
-dotnet_diagnostic.S3610.severity = warning
-
-# Title    : Jump statements should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
-dotnet_diagnostic.S3626.severity = warning
-
-# Title    : Empty nullable value should not be accessed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
-dotnet_diagnostic.S3655.severity = warning
-
-# Title    : Exception constructors should not throw exceptions
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
-dotnet_diagnostic.S3693.severity = warning
-
-# Title    : Track use of "NotImplementedException"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
-dotnet_diagnostic.S3717.severity = warning
 
 # Title    : Cognitive Complexity of methods should not be too high
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
 # Comment  : Code gets complicated
-dotnet_diagnostic.S3776.severity = none
-
-# Title    : "SafeHandle.DangerousGetHandle" should not be called
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
-dotnet_diagnostic.S3869.severity = warning
 
 # Title    : Exception types should be "public"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
 # Redundant: CA1064
-dotnet_diagnostic.S3871.severity = none
-
-# Title    : Parameter names should not duplicate the names of their methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
-dotnet_diagnostic.S3872.severity = warning
 
 # Title    : "out" and "ref" parameters should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
 # Redundant: CA1021
-dotnet_diagnostic.S3874.severity = none
-
-# Title    : "operator==" should not be overloaded on reference types
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
-dotnet_diagnostic.S3875.severity = warning
-
-# Title    : Strings or integral types should be used for indexers
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
-dotnet_diagnostic.S3876.severity = warning
-
-# Title    : Exceptions should not be thrown from unexpected methods
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
-dotnet_diagnostic.S3877.severity = warning
-
-# Title    : Arrays should not be created for params parameters
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3878
-dotnet_diagnostic.S3878.severity = suggestion
-
-# Title    : Finalizers should not be empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
-dotnet_diagnostic.S3880.severity = warning
-
-# Title    : "IDisposable" should be implemented correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
-dotnet_diagnostic.S3881.severity = none
-
-# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
-dotnet_diagnostic.S3884.severity = warning
-
-# Title    : "Assembly.Load" should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
-dotnet_diagnostic.S3885.severity = warning
-
-# Title    : Mutable, non-private fields should not be "readonly"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
-dotnet_diagnostic.S3887.severity = warning
-
-# Title    : "Thread.Resume" and "Thread.Suspend" should not be used
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
-dotnet_diagnostic.S3889.severity = warning
-
-# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
-dotnet_diagnostic.S3897.severity = warning
-
-# Title    : Value types should implement "IEquatable<T>"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
-dotnet_diagnostic.S3898.severity = none
 
 # Title    : Arguments of public methods should be validated against null
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
 # Redundant: CA1062
-dotnet_diagnostic.S3900.severity = none
-
-# Title    : "Assembly.GetExecutingAssembly" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
-dotnet_diagnostic.S3902.severity = warning
 
 # Title    : Types should be defined in named namespaces
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
 # Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
-dotnet_diagnostic.S3903.severity = none
-
-# Title    : Assemblies should have version information
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
-dotnet_diagnostic.S3904.severity = warning
-
-# Title    : Event Handlers should have the correct signature
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
-dotnet_diagnostic.S3906.severity = warning
-
-# Title    : Generic event handlers should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
-dotnet_diagnostic.S3908.severity = warning
 
 # Title    : Collections should implement the generic interface
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
 # Redundant: CA1010
-dotnet_diagnostic.S3909.severity = none
-
-# Title    : All branches in a conditional structure should not have exactly the same implementation
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
-dotnet_diagnostic.S3923.severity = warning
 
 # Title    : "ISerializable" should be implemented correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
 # Comment  : TODO - is ISerializable still relevant?
-dotnet_diagnostic.S3925.severity = none
-
-# Title    : Deserialization methods should be provided for "OptionalField" members
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
-dotnet_diagnostic.S3926.severity = warning
-
-# Title    : Serialization event handlers should be implemented correctly
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
-dotnet_diagnostic.S3927.severity = warning
-
-# Title    : Parameter names used into ArgumentException constructors should match an existing one 
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
-dotnet_diagnostic.S3928.severity = warning
-
-# Title    : Number patterns should be regular
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
-dotnet_diagnostic.S3937.severity = warning
-
-# Title    : Calculations should not overflow
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
-dotnet_diagnostic.S3949.severity = suggestion
 
 # Title    : "Generic.List" instances should not be part of public APIs
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
 # Redundant: CA1002
-dotnet_diagnostic.S3956.severity = none
 
 # Title    : "static readonly" constants should be "const" instead
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
 # Redundant: CA1802
-dotnet_diagnostic.S3962.severity = none
 
 # Title    : "static" fields should be initialized inline
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
 # Redundant: CA1810 and CA2207
-dotnet_diagnostic.S3963.severity = none
-
-# Title    : Objects should not be disposed more than once
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
-dotnet_diagnostic.S3966.severity = warning
-
-# Title    : Multidimensional arrays should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
-dotnet_diagnostic.S3967.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
-dotnet_diagnostic.S3971.severity = warning
-
-# Title    : Conditionals should start on new lines
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
-dotnet_diagnostic.S3972.severity = warning
-
-# Title    : A conditionally executed single line should be denoted by indentation
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
-dotnet_diagnostic.S3973.severity = warning
-
-# Title    : Collection sizes and array length comparisons should make sense
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
-dotnet_diagnostic.S3981.severity = warning
-
-# Title    : Exceptions should not be created without being thrown
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
-dotnet_diagnostic.S3984.severity = warning
 
 # Title    : Assemblies should be marked as CLS compliant
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
 # Redundant: CA1014
-dotnet_diagnostic.S3990.severity = none
 
 # Title    : Assemblies should explicitly specify COM visibility
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
 # Redundant: CA1017
-dotnet_diagnostic.S3992.severity = none
 
 # Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
 # Redundant: CA1018
-dotnet_diagnostic.S3993.severity = none
-
-# Title    : URI Parameters should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
-dotnet_diagnostic.S3994.severity = none
-
-# Title    : URI return values should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
-dotnet_diagnostic.S3995.severity = warning
-
-# Title    : URI properties should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
-dotnet_diagnostic.S3996.severity = warning
-
-# Title    : String URI overloads should call "System.Uri" overloads
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
-dotnet_diagnostic.S3997.severity = warning
-
-# Title    : Threads should not lock on objects with weak identity
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
-dotnet_diagnostic.S3998.severity = warning
-
-# Title    : Pointers to unmanaged memory should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
-dotnet_diagnostic.S4000.severity = warning
-
-# Title    : Disposable types should declare finalizers
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
-dotnet_diagnostic.S4002.severity = warning
 
 # Title    : Collection properties should be readonly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
 # Redundant: CA2227
-dotnet_diagnostic.S4004.severity = none
 
 # Title    : "System.Uri" arguments should be used instead of strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
 # Redundant: CA2234
-dotnet_diagnostic.S4005.severity = none
-
-# Title    : Inherited member visibility should not be decreased
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
-dotnet_diagnostic.S4015.severity = warning
-
-# Title    : Enumeration members should not be named "Reserved"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
-dotnet_diagnostic.S4016.severity = warning
-
-# Title    : Method signatures should not contain nested generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
-dotnet_diagnostic.S4017.severity = none
-
-# Title    : All type parameters should be used in the parameter list to enable type inference
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
-dotnet_diagnostic.S4018.severity = none
-
-# Title    : Base class methods should not be hidden
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
-dotnet_diagnostic.S4019.severity = warning
-
-# Title    : Enumerations should have "Int32" storage
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
-dotnet_diagnostic.S4022.severity = warning
-
-# Title    : Interfaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
-dotnet_diagnostic.S4023.severity = none
-
-# Title    : Child class fields should not differ from parent class fields only by capitalization
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
-dotnet_diagnostic.S4025.severity = warning
-
-# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
-dotnet_diagnostic.S4026.severity = warning
 
 # Title    : Exceptions should provide standard constructors
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
 # Redundant: CA1032
-dotnet_diagnostic.S4027.severity = none
-
-# Title    : Classes implementing "IEquatable<T>" should be sealed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
-dotnet_diagnostic.S4035.severity = warning
-
-# Title    : Searching OS commands in PATH is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
-dotnet_diagnostic.S4036.severity = warning
-
-# Title    : Interface methods should be callable by derived types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
-dotnet_diagnostic.S4039.severity = warning
 
 # Title    : Strings should be normalized to uppercase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
 # Redundant: CA1308
-dotnet_diagnostic.S4040.severity = none
-
-# Title    : Type names should not match namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
-dotnet_diagnostic.S4041.severity = warning
-
-# Title    : Generics should be used when appropriate
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
-dotnet_diagnostic.S4047.severity = warning
 
 # Title    : Properties should be preferred
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
 # Redundant: CA1024
-dotnet_diagnostic.S4049.severity = none
-
-# Title    : Operators should be overloaded consistently
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
-dotnet_diagnostic.S4050.severity = warning
-
-# Title    : Types should not extend outdated base types
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
-dotnet_diagnostic.S4052.severity = warning
-
-# Title    : Literals should not be passed as localized parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
-dotnet_diagnostic.S4055.severity = none
 
 # Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
 # Redundant: CA1305
-dotnet_diagnostic.S4056.severity = none
-
-# Title    : Locales should be set for data types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
-dotnet_diagnostic.S4057.severity = warning
 
 # Title    : Overloads with a "StringComparison" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
 # Redundant: CA1310
-dotnet_diagnostic.S4058.severity = none
-
-# Title    : Property names should not match get methods
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
-dotnet_diagnostic.S4059.severity = warning
 
 # Title    : Non-abstract attributes should be sealed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
 # Redundant: CA1813
-dotnet_diagnostic.S4060.severity = none
-
-# Title    : "params" should be used instead of "varargs"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
-dotnet_diagnostic.S4061.severity = warning
 
 # Title    : Operator overloads should have named alternatives
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
 # Redundant: CA2225
-dotnet_diagnostic.S4069.severity = none
 
 # Title    : Non-flags enums should not be marked with "FlagsAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
 # Redundant: CA2217
-dotnet_diagnostic.S4070.severity = none
-
-# Title    : Method overloads should be grouped together
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
-dotnet_diagnostic.S4136.severity = warning
-
-# Title    : Duplicate values should not be passed as arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
-dotnet_diagnostic.S4142.severity = warning
-
-# Title    : Collection elements should not be replaced unconditionally
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
-dotnet_diagnostic.S4143.severity = warning
-
-# Title    : Methods should not have identical implementations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
-dotnet_diagnostic.S4144.severity = warning
 
 # Title    : Empty collections should not be accessed or iterated
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
 # Comment  : Too many false positives
-dotnet_diagnostic.S4158.severity = none
-
-# Title    : Classes should implement their "ExportAttribute" interfaces
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
-dotnet_diagnostic.S4159.severity = warning
-
-# Title    : Native methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
-dotnet_diagnostic.S4200.severity = warning
-
-# Title    : Null checks should not be used with "is"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
-dotnet_diagnostic.S4201.severity = warning
-
-# Title    : Windows Forms entry points should be marked with STAThread
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
-dotnet_diagnostic.S4210.severity = warning
-
-# Title    : Members should not have conflicting transparency annotations
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
-dotnet_diagnostic.S4211.severity = warning
-
-# Title    : Serialization constructors should be secured
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
-dotnet_diagnostic.S4212.severity = warning
-
-# Title    : "P/Invoke" methods should not be visible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
-dotnet_diagnostic.S4214.severity = warning
-
-# Title    : Events should have proper arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
-dotnet_diagnostic.S4220.severity = warning
-
-# Title    : Extension methods should not extend "object"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
-dotnet_diagnostic.S4225.severity = warning
-
-# Title    : Extensions should be in separate namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
-dotnet_diagnostic.S4226.severity = none
-
-# Title    : "ConstructorArgument" parameters should exist in constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
-dotnet_diagnostic.S4260.severity = warning
-
-# Title    : Methods should be named according to their synchronicities
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
-dotnet_diagnostic.S4261.severity = none
-
-# Title    : Getters and setters should access the expected fields
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
-dotnet_diagnostic.S4275.severity = warning
-
-# Title    : "Shared" parts should not be created with "new"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
-dotnet_diagnostic.S4277.severity = warning
-
-# Title    : Weak SSL/TLS protocols should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
-dotnet_diagnostic.S4423.severity = warning
-
-# Title    : Cryptographic keys should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
-dotnet_diagnostic.S4426.severity = warning
-
-# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
-dotnet_diagnostic.S4428.severity = warning
-
-# Title    : AES encryption algorithm should be used with secured mode
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
-dotnet_diagnostic.S4432.severity = warning
-
-# Title    : LDAP connections should be authenticated
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
-dotnet_diagnostic.S4433.severity = warning
-
-# Title    : Parameter validation in yielding methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
-dotnet_diagnostic.S4456.severity = warning
-
-# Title    : Parameter validation in "async"/"await" methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
-dotnet_diagnostic.S4457.severity = warning
 
 # Title    : Calls to "async" methods should not be blocking
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
 # Redundant: VSTHRD002
-dotnet_diagnostic.S4462.severity = none
 
 # Title    : Unread "private" fields should be removed
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
 # Redundant: IDE0052
-dotnet_diagnostic.S4487.severity = none
-
-# Title    : Disabling CSRF protections is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
-dotnet_diagnostic.S4502.severity = warning
-
-# Title    : Delivering code in production with debug features activated is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
-dotnet_diagnostic.S4507.severity = warning
-
-# Title    : "default" clauses should be first or last
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
-dotnet_diagnostic.S4524.severity = warning
-
-# Title    : "DebuggerDisplayAttribute" strings should reference existing members
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4545
-dotnet_diagnostic.S4545.severity = warning
-
-# Title    : ASP.NET HTTP request validation feature should not be disabled
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
-dotnet_diagnostic.S4564.severity = warning
-
-# Title    : "new Guid()" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
-dotnet_diagnostic.S4581.severity = warning
-
-# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
-dotnet_diagnostic.S4583.severity = warning
-
-# Title    : Non-async "Task/Task<T>" methods should not return null
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
-dotnet_diagnostic.S4586.severity = warning
-
-# Title    : Start index should be used instead of calling Substring
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
-dotnet_diagnostic.S4635.severity = warning
-
-# Title    : Comments should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4663
-dotnet_diagnostic.S4663.severity = suggestion
-
-# Title    : Using regular expressions is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
-dotnet_diagnostic.S4784.severity = warning
-
-# Title    : Encrypting data is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
-dotnet_diagnostic.S4787.severity = warning
-
-# Title    : Using weak hashing algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
-dotnet_diagnostic.S4790.severity = warning
-
-# Title    : Configuring loggers is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
-dotnet_diagnostic.S4792.severity = warning
-
-# Title    : Using Sockets is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
-dotnet_diagnostic.S4818.severity = warning
-
-# Title    : Using command line arguments is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
-dotnet_diagnostic.S4823.severity = warning
-
-# Title    : Reading the Standard Input is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
-dotnet_diagnostic.S4829.severity = warning
 
 # Title    : Server certificates should be verified during SSL/TLS connections
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
 # Redundant: CA5359
-dotnet_diagnostic.S4830.severity = none
-
-# Title    : Controlling permissions is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
-dotnet_diagnostic.S4834.severity = warning
-
-# Title    : "ValueTask" should be consumed correctly
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
-dotnet_diagnostic.S5034.severity = warning
-
-# Title    : Expanding archive files without controlling resource consumption is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
-dotnet_diagnostic.S5042.severity = warning
-
-# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
-dotnet_diagnostic.S5122.severity = warning
-
-# Title    : Using clear-text protocols is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
-dotnet_diagnostic.S5332.severity = warning
-
-# Title    : Using publicly writable directories is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
-dotnet_diagnostic.S5443.severity = warning
-
-# Title    : Insecure temporary file creation methods should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
-dotnet_diagnostic.S5445.severity = warning
-
-# Title    : Encryption algorithms should be used with secure mode and padding scheme
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
-dotnet_diagnostic.S5542.severity = warning
-
-# Title    : Cipher algorithms should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
-dotnet_diagnostic.S5547.severity = warning
-
-# Title    : JWT should be signed and verified with strong cipher algorithms
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
-dotnet_diagnostic.S5659.severity = warning
-
-# Title    : Allowing requests with excessive content length is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
-dotnet_diagnostic.S5693.severity = warning
-
-# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
-dotnet_diagnostic.S5753.severity = warning
-
-# Title    : Deserializing objects without performing data validation is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
-dotnet_diagnostic.S5766.severity = warning
-
-# Title    : Types allowed to be deserialized should be restricted
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
-dotnet_diagnostic.S5773.severity = warning
-
-# Title    : Regular expressions should be syntactically valid
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5856
-dotnet_diagnostic.S5856.severity = warning
 
 # Title    : Use a testable date/time provider
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
 # Redundant: R9A022
-dotnet_diagnostic.S6354.severity = none
-
-# Title    : Azure Functions should be stateless
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
-dotnet_diagnostic.S6419.severity = warning
-
-# Title    : Client instances should not be recreated on each Azure Function invocation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
-dotnet_diagnostic.S6420.severity = warning
-
-# Title    : Azure Functions should use Structured Error Handling
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
-dotnet_diagnostic.S6421.severity = warning
-
-# Title    : Calls to "async" methods should not be blocking in Azure Functions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
-dotnet_diagnostic.S6422.severity = warning
-
-# Title    : Azure Functions should log all failures
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
-dotnet_diagnostic.S6423.severity = warning
-
-# Title    : Interfaces for durable entities should satisfy the restrictions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
-dotnet_diagnostic.S6424.severity = warning
-
-# Title    : Not specifying a timeout for regular expressions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
-dotnet_diagnostic.S6444.severity = warning
 
 # Title    : Blocks should not be synchronized on local variables
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6507
 # Comment  : Too many false positives
-dotnet_diagnostic.S6507.severity = none
-
-# Title    : "ExcludeFromCodeCoverage" attributes should include a justification
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6513
-dotnet_diagnostic.S6513.severity = suggestion
-
-# Title    : Avoid using "DateTime.Now" for benchmarking or timing operations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6561
-dotnet_diagnostic.S6561.severity = warning
 
 # Title    : Always set the "DateTimeKind" when creating new "DateTime" instances
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6562
 # Comment  : Noise
-dotnet_diagnostic.S6562.severity = none
-
-# Title    : Use UTC when recording DateTime instants
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6563
-dotnet_diagnostic.S6563.severity = none
 
 # Title    : Use "DateTimeOffset" instead of "DateTime"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6566
 # Comment  : Noise
-dotnet_diagnostic.S6566.severity = none
-
-# Title    : Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6575
-dotnet_diagnostic.S6575.severity = warning
-
-# Title    : Use a format provider when parsing date and time
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6580
-dotnet_diagnostic.S6580.severity = warning
-
-# Title    : Don't hardcode the format when turning dates and times to strings
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6585
-dotnet_diagnostic.S6585.severity = none
-
-# Title    : Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6588
-dotnet_diagnostic.S6588.severity = warning
-
-# Title    : "Find" method should be used instead of the "FirstOrDefault" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6602
-dotnet_diagnostic.S6602.severity = warning
-
-# Title    : The collection-specific "TrueForAll" method should be used instead of the "All" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6603
-dotnet_diagnostic.S6603.severity = warning
-
-# Title    : Collection-specific "Exists" method should be used instead of the "Any" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6605
-dotnet_diagnostic.S6605.severity = warning
-
-# Title    : The collection should be filtered before sorting by using "Where" before "OrderBy"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6607
-dotnet_diagnostic.S6607.severity = warning
-
-# Title    : Prefer indexing instead of "Enumerable" methods on types implementing "IList"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6608
-dotnet_diagnostic.S6608.severity = warning
-
-# Title    : "Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6609
-dotnet_diagnostic.S6609.severity = warning
-
-# Title    : "StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6610
-dotnet_diagnostic.S6610.severity = warning
-
-# Title    : The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6612
-dotnet_diagnostic.S6612.severity = warning
-
-# Title    : "First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6613
-dotnet_diagnostic.S6613.severity = warning
-
-# Title    : "Contains" should be used instead of "Any" for simple equality checks
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6617
-dotnet_diagnostic.S6617.severity = warning
-
-# Title    : "string.Create" should be used instead of "FormattableString"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6618
-dotnet_diagnostic.S6618.severity = warning
-
-# Title    : Using unsafe code blocks is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6640
-dotnet_diagnostic.S6640.severity = warning
-
-# Title    : Literal suffixes should be upper case
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
-dotnet_diagnostic.S818.severity = warning
-
-# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
-dotnet_diagnostic.S881.severity = suggestion
-
-# Title    : "goto" statement should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
-dotnet_diagnostic.S907.severity = warning
 
 # Title    : Parameter names should match base declaration and other partial definitions
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
 # Redundant: CA1725
-dotnet_diagnostic.S927.severity = none
 
 # Title    : Copy-paste token calculator
 # Category : 

--- a/src/Analyzers/Microsoft.Analyzers.Extra/CallAnalysis/Fixers/LegacyLoggingFixer.FixDetails.cs
+++ b/src/Analyzers/Microsoft.Analyzers.Extra/CallAnalysis/Fixers/LegacyLoggingFixer.FixDetails.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -297,9 +297,7 @@ public sealed partial class LegacyLoggingFixer
             {
                 if (braceOccurrenceCount > 0 && message[scanIndex] != brace)
                 {
-#pragma warning disable S109 // Magic numbers should not be used
                     if (braceOccurrenceCount % 2 == 0)
-#pragma warning restore S109 // Magic numbers should not be used
                     {
                         // Even number of '{' or '}' found. Proceed search with next occurrence of '{' or '}'.
                         braceOccurrenceCount = 0;

--- a/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/Json/JsonArray.cs
+++ b/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/Json/JsonArray.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Forked from StyleCop.Analyzers repo.
@@ -127,7 +127,6 @@ internal sealed class JsonArray : IEnumerable<JsonValue>
     [ExcludeFromCodeCoverage]
     private sealed class JsonArrayDebugView
     {
-        [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Used by debugger.")]
         public JsonArrayDebugView(JsonArray array)
         {
             Items = array._items.ToArray();

--- a/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/Json/JsonObject.cs
+++ b/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/Json/JsonObject.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Forked from StyleCop.Analyzers repo.
@@ -149,7 +149,6 @@ internal sealed class JsonObject : IEnumerable<KeyValuePair<string, JsonValue>>,
     {
         private readonly JsonObject _object;
 
-        [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Used by debugger.")]
         public JsonObjectDebugView(JsonObject jsonObject)
         {
             _object = jsonObject;

--- a/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/Json/JsonReader.cs
+++ b/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/Json/JsonReader.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Forked from StyleCop.Analyzers repo.
@@ -218,7 +218,6 @@ internal sealed class JsonReader
     private int ReadHexDigit()
     {
         var errorPosition = _scanner.Position;
-#pragma warning disable S109 // Magic numbers should not be used
         return char.ToUpperInvariant(_scanner.Read()) switch
         {
             '0' => 0,
@@ -254,7 +253,7 @@ internal sealed class JsonReader
 
         return (char)value;
     }
-#pragma warning restore S109 // Magic numbers should not be used
+
     private JsonObject ReadObject()
     {
         return ReadObject([]);

--- a/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/Json/JsonValue.cs
+++ b/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/Json/JsonValue.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Forked from StyleCop.Analyzers repo.
@@ -16,8 +16,6 @@ namespace Microsoft.Extensions.LocalAnalyzers.Json;
 /// </summary>
 [DebuggerDisplay("{ToString(),nq}", Type = "JsonValue({Type})")]
 [DebuggerTypeProxy(typeof(JsonValueDebugView))]
-[SuppressMessage("Major Bug", "S1244:Floating point numbers should not be tested for equality",
-    Justification = "Would require unnecessary refactor.")]
 internal readonly struct JsonValue : IEquatable<JsonValue>
 {
     /// <summary>
@@ -153,9 +151,7 @@ internal readonly struct JsonValue : IEquatable<JsonValue>
     /// Gets a value indicating whether this JsonValue is an Integer.
     /// </summary>
     /// <value>A value indicating whether this JsonValue is an Integer.</value>
-#pragma warning disable S2589 // Boolean expressions should not be gratuitous
     public bool IsInteger => IsNumber && unchecked((int)_value) == _value;
-#pragma warning restore S2589 // Boolean expressions should not be gratuitous
 
     /// <summary>
     /// Gets a value indicating whether this JsonValue is a Number.
@@ -256,7 +252,6 @@ internal readonly struct JsonValue : IEquatable<JsonValue>
     /// Gets this value as an JsonObject.
     /// </summary>
     /// <value>This value as an JsonObject.</value>
-#pragma warning disable S1168 // Empty arrays and collections should be returned instead of null
     public JsonObject? AsJsonObject => IsJsonObject ? (JsonObject?)_reference : null;
 
     /// <summary>
@@ -264,7 +259,6 @@ internal readonly struct JsonValue : IEquatable<JsonValue>
     /// </summary>
     /// <value>This value as an JsonArray.</value>
     public JsonArray? AsJsonArray => IsJsonArray ? (JsonArray?)_reference : null;
-#pragma warning restore S1168 // Empty arrays and collections should be returned instead of null
 
     /// <summary>
     /// Gets this value as a system.DateTime.
@@ -595,14 +589,12 @@ internal readonly struct JsonValue : IEquatable<JsonValue>
     {
         private readonly JsonValue _jsonValue;
 
-        [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Used by debugger.")]
         public JsonValueDebugView(JsonValue jsonValue)
         {
             _jsonValue = jsonValue;
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-#pragma warning disable S1168 // Empty arrays and collections should be returned instead of null
         public JsonObject? ObjectView => _jsonValue.IsJsonObject
                     ? (JsonObject?)_jsonValue._reference
                     : null;
@@ -611,7 +603,6 @@ internal readonly struct JsonValue : IEquatable<JsonValue>
         public JsonArray? ArrayView => _jsonValue.IsJsonArray
                     ? (JsonArray?)_jsonValue._reference
                     : null;
-#pragma warning restore S1168 // Empty arrays and collections should be returned instead of null
 
         public JsonValueType Type => _jsonValue.Type;
 

--- a/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/Utils.cs
+++ b/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/Utils.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -23,11 +23,9 @@ internal static class Utils
 
         var substrings = typeSignature.Split(_colon);
 
-#pragma warning disable S109 // Magic numbers should not be used
         return substrings.Length == 2
             ? substrings[1].Split(_comma).Select(x => x.Trim()).ToArray()
             : substrings[2].Split(_comma).Select(x => x.Trim()).ToArray();
-#pragma warning restore S109 // Magic numbers should not be used
     }
 
     public static string StripBaseAndConstraints(string typeSignature)

--- a/src/Generators/.editorconfig
+++ b/src/Generators/.editorconfig
@@ -480,7 +480,7 @@ dotnet_diagnostic.CA1507.severity = warning
 # Title    : Avoid dead conditional code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
-dotnet_diagnostic.CA1508.severity = warning
+dotnet_diagnostic.CA1508.severity = none
 
 # Title    : Invalid entry in code metrics rule specification file
 # Category : Maintainability
@@ -2889,2294 +2889,391 @@ dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
 # Redundant: IDE1006
-dotnet_diagnostic.S100.severity = none
-
-# Title    : Method overrides should not change parameter defaults
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
-dotnet_diagnostic.S1006.severity = warning
 
 # Title    : Types should be named in PascalCase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
 # Redundant: IDE1006
-dotnet_diagnostic.S101.severity = none
-
-# Title    : Lines should not be too long
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
-dotnet_diagnostic.S103.severity = warning
-
-# Title    : Files should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
-dotnet_diagnostic.S104.severity = warning
 
 # Title    : Finalizers should not throw exceptions
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
 # Redundant: CA1065
-dotnet_diagnostic.S1048.severity = none
 
 # Title    : Tabulation characters should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
 # Redundant: SA1027
-dotnet_diagnostic.S105.severity = none
-
-# Title    : Standard outputs should not be used directly to log anything
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
-dotnet_diagnostic.S106.severity = warning
-
-# Title    : Collapsible "if" statements should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
-dotnet_diagnostic.S1066.severity = none
-
-# Title    : Expressions should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
-dotnet_diagnostic.S1067.severity = warning
-
-# Title    : Methods should not have too many parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
-dotnet_diagnostic.S107.severity = warning
-
-# Title    : URIs should not be hardcoded
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
-dotnet_diagnostic.S1075.severity = warning
-
-# Title    : Nested blocks of code should not be left empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
-dotnet_diagnostic.S108.severity = warning
-
-# Title    : Magic numbers should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
-dotnet_diagnostic.S109.severity = warning
-
-# Title    : Inheritance tree of classes should not be too deep
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
-dotnet_diagnostic.S110.severity = warning
 
 # Title    : Fields should not have public accessibility
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
 # Redundant: CA1051
-dotnet_diagnostic.S1104.severity = none
 
 # Title    : A close curly brace should be located at the beginning of a line
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
 # Redundant: SA1500
-dotnet_diagnostic.S1109.severity = none
 
 # Title    : Redundant pairs of parentheses should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
 # Redundant: SA1119
-dotnet_diagnostic.S1110.severity = none
 
 # Title    : Empty statements should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
 # Redundant: SA1106
-dotnet_diagnostic.S1116.severity = none
-
-# Title    : Local variables should not shadow class fields or properties
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
-dotnet_diagnostic.S1117.severity = warning
 
 # Title    : Utility classes should not have public constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
 # Redundant: CA1052
-dotnet_diagnostic.S1118.severity = none
 
 # Title    : General exceptions should never be thrown
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
 # Redundant: CA2219
-dotnet_diagnostic.S112.severity = none
-
-# Title    : Assignments should not be made from within sub-expressions
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
-dotnet_diagnostic.S1121.severity = warning
 
 # Title    : "Obsolete" attributes should include explanations
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
 # Redundant: CA1041
-dotnet_diagnostic.S1123.severity = none
-
-# Title    : Boolean literals should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
-dotnet_diagnostic.S1125.severity = warning
-
-# Title    : Unused "using" should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
-dotnet_diagnostic.S1128.severity = warning
-
-# Title    : Files should contain an empty newline at the end
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
-dotnet_diagnostic.S113.severity = none
-
-# Title    : Deprecated code should be removed
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1133
-dotnet_diagnostic.S1133.severity = suggestion
-
-# Title    : Track uses of "FIXME" tags
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
-dotnet_diagnostic.S1134.severity = warning
-
-# Title    : Track uses of "TODO" tags
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
-dotnet_diagnostic.S1135.severity = warning
-
-# Title    : Unused private types or members should be removed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
-dotnet_diagnostic.S1144.severity = warning
-
-# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
-dotnet_diagnostic.S1145.severity = warning
-
-# Title    : Exit methods should not be called
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
-dotnet_diagnostic.S1147.severity = warning
-
-# Title    : "switch case" clauses should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
-dotnet_diagnostic.S1151.severity = none
-
-# Title    : "Any()" should be used to test for emptiness
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
-dotnet_diagnostic.S1155.severity = warning
 
 # Title    : Exceptions should not be thrown in finally blocks
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
 # Redundant: CA2219
-dotnet_diagnostic.S1163.severity = none
-
-# Title    : Empty arrays and collections should be returned instead of null
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
-dotnet_diagnostic.S1168.severity = warning
 
 # Title    : Unused method parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
 # Redundant: IDE0060
-dotnet_diagnostic.S1172.severity = none
-
-# Title    : Overriding members should do more than simply call the same member in the base class
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
-dotnet_diagnostic.S1185.severity = warning
-
-# Title    : Methods should not be empty
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
-dotnet_diagnostic.S1186.severity = warning
-
-# Title    : String literals should not be duplicated
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
-dotnet_diagnostic.S1192.severity = suggestion
-
-# Title    : Nested code blocks should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
-dotnet_diagnostic.S1199.severity = warning
-
-# Title    : Classes should not be coupled to too many other classes
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
-dotnet_diagnostic.S1200.severity = none
 
 # Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
 # Redundant: CS0659
-dotnet_diagnostic.S1206.severity = none
 
 # Title    : Control structures should use curly braces
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
 # Redundant: SA1503
-dotnet_diagnostic.S121.severity = none
 
 # Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
 # Redundant: CA1036
-dotnet_diagnostic.S1210.severity = none
-
-# Title    : "GC.Collect" should not be called
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
-dotnet_diagnostic.S1215.severity = warning
-
-# Title    : Statements should be on separate lines
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
-dotnet_diagnostic.S122.severity = none
-
-# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
-dotnet_diagnostic.S1226.severity = warning
-
-# Title    : break statements should not be used except for switch cases
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
-dotnet_diagnostic.S1227.severity = none
-
-# Title    : Floating point numbers should not be tested for equality
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
-dotnet_diagnostic.S1244.severity = error
-
-# Title    : Sections of code should not be commented out
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
-dotnet_diagnostic.S125.severity = warning
-
-# Title    : "if ... else if" constructs should end with "else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
-dotnet_diagnostic.S126.severity = none
-
-# Title    : A "while" loop should be used instead of a "for" loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
-dotnet_diagnostic.S1264.severity = warning
-
-# Title    : "for" loop stop conditions should be invariant
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
-dotnet_diagnostic.S127.severity = warning
-
-# Title    : "switch" statements should have at least 3 "case" clauses
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
-dotnet_diagnostic.S1301.severity = none
 
 # Title    : Track uses of in-source issue suppressions
 # Category : Info Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
 # Comment  : Suppressions are frequently necessary.
-dotnet_diagnostic.S1309.severity = none
-
-# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
-dotnet_diagnostic.S131.severity = none
-
-# Title    : Using hardcoded IP addresses is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
-dotnet_diagnostic.S1313.severity = warning
-
-# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
-dotnet_diagnostic.S134.severity = none
-
-# Title    : Functions should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
-dotnet_diagnostic.S138.severity = none
-
-# Title    : Culture should be specified for "string" operations
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
-dotnet_diagnostic.S1449.severity = warning
-
-# Title    : Private fields only used as local variables in methods should become local variables
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
-dotnet_diagnostic.S1450.severity = warning
 
 # Title    : Track lack of copyright and license headers
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
 # Redundant: IDE0073
-dotnet_diagnostic.S1451.severity = none
-
-# Title    : "switch" statements should not have too many "case" clauses
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
-dotnet_diagnostic.S1479.severity = warning
 
 # Title    : Unused local variables should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
 # Redundant: CS0168
-dotnet_diagnostic.S1481.severity = none
-
-# Title    : Methods and properties should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
-dotnet_diagnostic.S1541.severity = none
-
-# Title    : Tests should not be ignored
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
-dotnet_diagnostic.S1607.severity = warning
-
-# Title    : Strings should not be concatenated using '+' in a loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
-dotnet_diagnostic.S1643.severity = warning
-
-# Title    : Variables should not be self-assigned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
-dotnet_diagnostic.S1656.severity = warning
-
-# Title    : Multiple variables should not be declared on the same line
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
-dotnet_diagnostic.S1659.severity = warning
-
-# Title    : An abstract class should have both abstract and concrete methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
-dotnet_diagnostic.S1694.severity = warning
-
-# Title    : NullReferenceException should not be caught
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
-dotnet_diagnostic.S1696.severity = warning
-
-# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
-dotnet_diagnostic.S1697.severity = warning
-
-# Title    : "==" should not be used when "Equals" is overridden
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
-dotnet_diagnostic.S1698.severity = warning
-
-# Title    : Constructors should only call non-overridable methods
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
-dotnet_diagnostic.S1699.severity = warning
-
-# Title    : Loops with at most one iteration should be refactored
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
-dotnet_diagnostic.S1751.severity = warning
-
-# Title    : Identical expressions should not be used on both sides of operators
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
-dotnet_diagnostic.S1764.severity = warning
-
-# Title    : "switch" statements should not be nested
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
-dotnet_diagnostic.S1821.severity = none
-
-# Title    : Objects should not be created to be dropped immediately without being used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
-dotnet_diagnostic.S1848.severity = warning
 
 # Title    : Unused assignments should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
 # Redundant: IDE0059
-dotnet_diagnostic.S1854.severity = none
-
-# Title    : "ToString()" calls should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
-dotnet_diagnostic.S1858.severity = warning
-
-# Title    : Related "if/else if" statements should not have the same condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
-dotnet_diagnostic.S1862.severity = warning
-
-# Title    : Two branches in a conditional structure should not have exactly the same implementation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
-dotnet_diagnostic.S1871.severity = warning
 
 # Title    : Redundant casts should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
 # Redundant: IDE0004
-dotnet_diagnostic.S1905.severity = none
-
-# Title    : Inheritance list should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
-dotnet_diagnostic.S1939.severity = warning
-
-# Title    : Boolean checks should not be inverted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
-dotnet_diagnostic.S1940.severity = warning
-
-# Title    : Invalid casts should be avoided
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
-dotnet_diagnostic.S1944.severity = warning
-
-# Title    : "for" loop increment clauses should modify the loops' counters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
-dotnet_diagnostic.S1994.severity = warning
 
 # Title    : Hashes should include an unpredictable salt
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S2053.severity = none
-
-# Title    : Hard-coded credentials are security-sensitive
-# Category : Blocker Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
-dotnet_diagnostic.S2068.severity = warning
 
 # Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
 # Redundant: CA5350
-dotnet_diagnostic.S2070.severity = none
-
-# Title    : Formatting SQL queries is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
-dotnet_diagnostic.S2077.severity = warning
-
-# Title    : Creating cookies without the "secure" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
-dotnet_diagnostic.S2092.severity = warning
-
-# Title    : Classes should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2094
-dotnet_diagnostic.S2094.severity = none
-
-# Title    : Collections should not be passed as arguments to their own methods
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
-dotnet_diagnostic.S2114.severity = warning
-
-# Title    : A secure password should be used when connecting to a database
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
-dotnet_diagnostic.S2115.severity = warning
-
-# Title    : Values should not be uselessly incremented
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
-dotnet_diagnostic.S2123.severity = warning
-
-# Title    : Underscores should be used to make large numbers readable
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
-dotnet_diagnostic.S2148.severity = warning
-
-# Title    : "sealed" classes should not have "protected" members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
-dotnet_diagnostic.S2156.severity = warning
-
-# Title    : Classes named like "Exception" should extend "Exception" or a subclass
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2166
-dotnet_diagnostic.S2166.severity = warning
-
-# Title    : Short-circuit logic should be used in boolean contexts
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
-dotnet_diagnostic.S2178.severity = warning
-
-# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
-dotnet_diagnostic.S2183.severity = warning
-
-# Title    : Results of integer division should not be assigned to floating point variables
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
-dotnet_diagnostic.S2184.severity = warning
-
-# Title    : Test classes should contain at least one test case
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
-dotnet_diagnostic.S2187.severity = warning
-
-# Title    : Loops and recursions should not be infinite
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
-dotnet_diagnostic.S2190.severity = warning
-
-# Title    : Modulus results should not be checked for direct equality
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
-dotnet_diagnostic.S2197.severity = warning
-
-# Title    : Unnecessary mathematical comparisons should not be made
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2198
-dotnet_diagnostic.S2198.severity = warning
 
 # Title    : Methods without side effects should not have their return values ignored
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
 # Redundant: CA1806
-dotnet_diagnostic.S2201.severity = none
-
-# Title    : Runtime type checking should be simplified
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
-dotnet_diagnostic.S2219.severity = warning
-
-# Title    : "Exception" should not be caught
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
-dotnet_diagnostic.S2221.severity = none
-
-# Title    : Locks should be released on all paths
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
-dotnet_diagnostic.S2222.severity = warning
-
-# Title    : Non-constant static fields should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
-dotnet_diagnostic.S2223.severity = warning
-
-# Title    : "ToString()" method should not return null
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
-dotnet_diagnostic.S2225.severity = warning
-
-# Title    : Console logging should not be used
-# Category : Minor Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
-dotnet_diagnostic.S2228.severity = warning
-
-# Title    : Arguments should be passed in the same order as the method parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
-dotnet_diagnostic.S2234.severity = warning
-
-# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
-dotnet_diagnostic.S2245.severity = warning
-
-# Title    : A "for" loop update clause should move the counter in the right direction
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
-dotnet_diagnostic.S2251.severity = warning
-
-# Title    : For-loop conditions should be true at least once
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
-dotnet_diagnostic.S2252.severity = warning
-
-# Title    : Writing cookies is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
-dotnet_diagnostic.S2255.severity = warning
-
-# Title    : Using non-standard cryptographic algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
-dotnet_diagnostic.S2257.severity = warning
 
 # Title    : Null pointers should not be dereferenced
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
 # Comment  : Redundant, covered by modern C# compiler
-dotnet_diagnostic.S2259.severity = none
-
-# Title    : Composite format strings should not lead to unexpected behavior at runtime
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
-dotnet_diagnostic.S2275.severity = warning
-
-# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
-dotnet_diagnostic.S2278.severity = warning
-
-# Title    : Field-like events should not be virtual
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
-dotnet_diagnostic.S2290.severity = warning
-
-# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
-dotnet_diagnostic.S2291.severity = warning
 
 # Title    : Trivial properties should be auto-implemented
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
 # Redundant: IDE0032
-dotnet_diagnostic.S2292.severity = none
-
-# Title    : "nameof" should be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
-dotnet_diagnostic.S2302.severity = warning
-
-# Title    : "async" and "await" should not be used as identifiers
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
-dotnet_diagnostic.S2306.severity = warning
 
 # Title    : Methods and properties that don't access instance data should be static
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
 # Redundant: CA1822
-dotnet_diagnostic.S2325.severity = none
 
 # Title    : Unused type parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
 # Comment  : Valid pattern used in a number of places
-dotnet_diagnostic.S2326.severity = none
-
-# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
-dotnet_diagnostic.S2327.severity = warning
-
-# Title    : "GetHashCode" should not reference mutable fields
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
-dotnet_diagnostic.S2328.severity = warning
-
-# Title    : Array covariance should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
-dotnet_diagnostic.S2330.severity = warning
-
-# Title    : Redundant modifiers should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
-dotnet_diagnostic.S2333.severity = warning
-
-# Title    : Public constant members should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
-dotnet_diagnostic.S2339.severity = none
-
-# Title    : Enumeration types should comply with a naming convention
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
-dotnet_diagnostic.S2342.severity = none
-
-# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
-dotnet_diagnostic.S2344.severity = warning
-
-# Title    : Flags enumerations should explicitly initialize all their members
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
-dotnet_diagnostic.S2345.severity = warning
 
 # Title    : Flags enumerations zero-value members should be named "None"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
 # Redundant: CA1008
-dotnet_diagnostic.S2346.severity = none
 
 # Title    : Fields should be private
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
 # Redundant: CA1051
-dotnet_diagnostic.S2357.severity = none
-
-# Title    : Optional parameters should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
-dotnet_diagnostic.S2360.severity = none
-
-# Title    : Properties should not make collection or array copies
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
-dotnet_diagnostic.S2365.severity = warning
-
-# Title    : Public methods should not have multidimensional array parameters
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
-dotnet_diagnostic.S2368.severity = warning
-
-# Title    : Exceptions should not be thrown from property getters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
-dotnet_diagnostic.S2372.severity = warning
-
-# Title    : Write-only properties should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
-dotnet_diagnostic.S2376.severity = warning
-
-# Title    : Mutable fields should not be "public static"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
-dotnet_diagnostic.S2386.severity = warning
-
-# Title    : Child class fields should not shadow parent class fields
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
-dotnet_diagnostic.S2387.severity = warning
 
 # Title    : Types and methods should not have too many generic parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
 # Redundant: CA1005
-dotnet_diagnostic.S2436.severity = none
-
-# Title    : Unnecessary bit operations should not be performed
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
-dotnet_diagnostic.S2437.severity = warning
 
 # Title    : Blocks should be synchronized on read-only fields
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2445
 # Comment  : Noise
-dotnet_diagnostic.S2445.severity = none
-
-# Title    : Whitespace and control characters in string literals should be explicit
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
-dotnet_diagnostic.S2479.severity = warning
-
-# Title    : Generic exceptions should not be ignored
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
-dotnet_diagnostic.S2486.severity = warning
-
-# Title    : Shared resources should not be used for locking
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
-dotnet_diagnostic.S2551.severity = warning
 
 # Title    : Conditionally executed code should be reachable
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
 # Redundant: CA1508
-dotnet_diagnostic.S2583.severity = none
 
 # Title    : Boolean expressions should not be gratuitous
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
 # Comment  : Too many false positives.
-dotnet_diagnostic.S2589.severity = none
-
-# Title    : Setting loose file permissions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
-dotnet_diagnostic.S2612.severity = warning
-
-# Title    : The length returned from a stream read should be checked
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
-dotnet_diagnostic.S2674.severity = warning
-
-# Title    : Multiline blocks should be enclosed in curly braces
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
-dotnet_diagnostic.S2681.severity = warning
-
-# Title    : "NaN" should not be used in comparisons
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
-dotnet_diagnostic.S2688.severity = warning
-
-# Title    : "IndexOf" checks should not be for positive numbers
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
-dotnet_diagnostic.S2692.severity = warning
-
-# Title    : Instance members should not write to "static" fields
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
-dotnet_diagnostic.S2696.severity = warning
-
-# Title    : Tests should include assertions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
-dotnet_diagnostic.S2699.severity = warning
-
-# Title    : Literal boolean values should not be used in assertions
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
-dotnet_diagnostic.S2701.severity = warning
-
-# Title    : "catch" clauses should do more than rethrow
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
-dotnet_diagnostic.S2737.severity = warning
-
-# Title    : Static fields should not be used in generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
-dotnet_diagnostic.S2743.severity = none
-
-# Title    : XML parsers should not be vulnerable to XXE attacks
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
-dotnet_diagnostic.S2755.severity = warning
-
-# Title    : Non-existent operators like "=+" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
-dotnet_diagnostic.S2757.severity = warning
-
-# Title    : The ternary operator should not return the same value regardless of the condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
-dotnet_diagnostic.S2758.severity = warning
-
-# Title    : Sequential tests should not check the same condition
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
-dotnet_diagnostic.S2760.severity = warning
-
-# Title    : Doubled prefix operators "!!" and "~~" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
-dotnet_diagnostic.S2761.severity = warning
-
-# Title    : SQL keywords should be delimited by whitespace
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
-dotnet_diagnostic.S2857.severity = warning
-
-# Title    : "Thread.Sleep" should not be used in tests
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2925
-dotnet_diagnostic.S2925.severity = none
 
 # Title    : "IDisposables" should be disposed
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
 # Redundant: CA2000
-dotnet_diagnostic.S2930.severity = none
 
 # Title    : Classes with "IDisposable" members should implement "IDisposable"
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
 # Redundant: CA1001
-dotnet_diagnostic.S2931.severity = none
 
 # Title    : Fields that are only assigned in the constructor should be "readonly"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
 # Redundant: IDE0044
-dotnet_diagnostic.S2933.severity = none
-
-# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
-dotnet_diagnostic.S2934.severity = warning
-
-# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
-dotnet_diagnostic.S2952.severity = warning
-
-# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
-dotnet_diagnostic.S2953.severity = warning
-
-# Title    : Generic parameters not constrained to reference types should not be compared to "null"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
-dotnet_diagnostic.S2955.severity = warning
-
-# Title    : Assertions should be complete
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2970
-dotnet_diagnostic.S2970.severity = warning
-
-# Title    : "IEnumerable" LINQs should be simplified
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
-dotnet_diagnostic.S2971.severity = warning
-
-# Title    : "Object.ReferenceEquals" should not be used for value types
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
-dotnet_diagnostic.S2995.severity = warning
-
-# Title    : "ThreadStatic" fields should not be initialized
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
-dotnet_diagnostic.S2996.severity = warning
-
-# Title    : "IDisposables" created in a "using" statement should not be returned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
-dotnet_diagnostic.S2997.severity = warning
-
-# Title    : "ThreadStatic" should not be used on non-static fields
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
-dotnet_diagnostic.S3005.severity = warning
-
-# Title    : Static fields should not be updated in constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
-dotnet_diagnostic.S3010.severity = warning
-
-# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
-dotnet_diagnostic.S3011.severity = warning
 
 # Title    : Members should not be initialized to default values
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
 # Redundant: CA1805
-dotnet_diagnostic.S3052.severity = none
-
-# Title    : Types should not have members with visibility set higher than the type's visibility
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
-dotnet_diagnostic.S3059.severity = none
-
-# Title    : "is" should not be used with "this"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
-dotnet_diagnostic.S3060.severity = warning
-
-# Title    : "StringBuilder" data should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3063
-dotnet_diagnostic.S3063.severity = warning
 
 # Title    : "async" methods should not return "void"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
 # Redundant: VSTHRD100
-dotnet_diagnostic.S3168.severity = none
-
-# Title    : Multiple "OrderBy" calls should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
-dotnet_diagnostic.S3169.severity = warning
-
-# Title    : Delegates should not be subtracted
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
-dotnet_diagnostic.S3172.severity = warning
-
-# Title    : "interface" instances should not be cast to concrete types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
-dotnet_diagnostic.S3215.severity = warning
 
 # Title    : "ConfigureAwait(false)" should be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
 # Redundant: CA2007
-dotnet_diagnostic.S3216.severity = none
-
-# Title    : "Explicit" conversions of "foreach" loops should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
-dotnet_diagnostic.S3217.severity = warning
-
-# Title    : Inner class members should not shadow outer class "static" or type members
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
-dotnet_diagnostic.S3218.severity = warning
-
-# Title    : Method calls should not resolve ambiguously to overloads with "params"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
-dotnet_diagnostic.S3220.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
-dotnet_diagnostic.S3234.severity = warning
-
-# Title    : Redundant parentheses should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
-dotnet_diagnostic.S3235.severity = warning
-
-# Title    : Caller information arguments should not be provided explicitly
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
-dotnet_diagnostic.S3236.severity = warning
-
-# Title    : "value" contextual keyword should be used
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
-dotnet_diagnostic.S3237.severity = warning
 
 # Title    : The simplest possible condition syntax should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
 # Redundant: IDE0054
-dotnet_diagnostic.S3240.severity = none
-
-# Title    : Methods should not return values that are never used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
-dotnet_diagnostic.S3241.severity = warning
 
 # Title    : Method parameters should be declared with base types
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
 # Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
-dotnet_diagnostic.S3242.severity = none
-
-# Title    : Anonymous delegates should not be used to unsubscribe from Events
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
-dotnet_diagnostic.S3244.severity = warning
-
-# Title    : Generic type parameters should be co/contravariant when possible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
-dotnet_diagnostic.S3246.severity = warning
-
-# Title    : Duplicate casts should not be made
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
-dotnet_diagnostic.S3247.severity = warning
-
-# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
-dotnet_diagnostic.S3249.severity = warning
-
-# Title    : Implementations should be provided for "partial" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
-dotnet_diagnostic.S3251.severity = warning
-
-# Title    : Constructor and destructor declarations should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
-dotnet_diagnostic.S3253.severity = warning
-
-# Title    : Default parameter values should not be passed as arguments
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
-dotnet_diagnostic.S3254.severity = warning
-
-# Title    : "string.IsNullOrEmpty" should be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
-dotnet_diagnostic.S3256.severity = warning
 
 # Title    : Declarations and initializations should be as concise as possible
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
 # Comment  : Too many false positives
-dotnet_diagnostic.S3257.severity = none
 
 # Title    : Non-derived "private" classes and records should be "sealed"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
 # Redundant: R9A013
-dotnet_diagnostic.S3260.severity = none
-
-# Title    : Namespaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
-dotnet_diagnostic.S3261.severity = warning
-
-# Title    : "params" should be used on overrides
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
-dotnet_diagnostic.S3262.severity = warning
-
-# Title    : Static fields should appear in the order they must be initialized 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
-dotnet_diagnostic.S3263.severity = warning
-
-# Title    : Events should be invoked
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
-dotnet_diagnostic.S3264.severity = warning
-
-# Title    : Non-flags enums should not be used in bitwise operations
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
-dotnet_diagnostic.S3265.severity = warning
-
-# Title    : Loops should be simplified with "LINQ" expressions
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
-dotnet_diagnostic.S3267.severity = none
 
 # Title    : Cipher Block Chaining IVs should be unpredictable
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S3329.severity = none
-
-# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
-dotnet_diagnostic.S3330.severity = warning
-
-# Title    : Caller information parameters should come at the end of the parameter list
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
-dotnet_diagnostic.S3343.severity = warning
-
-# Title    : Expressions used in "Debug.Assert" should not produce side effects
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
-dotnet_diagnostic.S3346.severity = warning
-
-# Title    : Unchanged local variables should be "const"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
-dotnet_diagnostic.S3353.severity = warning
-
-# Title    : Ternary operators should not be nested
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
-dotnet_diagnostic.S3358.severity = warning
-
-# Title    : Date and time should not be used as a type for primary keys
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3363
-dotnet_diagnostic.S3363.severity = warning
-
-# Title    : "this" should not be exposed from constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
-dotnet_diagnostic.S3366.severity = warning
 
 # Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
 # Redundant: CA1710
-dotnet_diagnostic.S3376.severity = none
-
-# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
-dotnet_diagnostic.S3397.severity = warning
-
-# Title    : "private" methods called only by inner classes should be moved to those classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3398
-dotnet_diagnostic.S3398.severity = warning
-
-# Title    : Methods should not return constants
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
-dotnet_diagnostic.S3400.severity = warning
-
-# Title    : Assertion arguments should be passed in the correct order
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
-dotnet_diagnostic.S3415.severity = warning
-
-# Title    : Method overloads with default parameter values should not overlap
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
-dotnet_diagnostic.S3427.severity = warning
-
-# Title    : "[ExpectedException]" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
-dotnet_diagnostic.S3431.severity = warning
-
-# Title    : Test method signatures should be correct
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
-dotnet_diagnostic.S3433.severity = warning
-
-# Title    : Variables should not be checked against the values they're about to be assigned
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
-dotnet_diagnostic.S3440.severity = warning
-
-# Title    : Redundant property names should be omitted in anonymous classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
-dotnet_diagnostic.S3441.severity = warning
-
-# Title    : "abstract" classes should not have "public" constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
-dotnet_diagnostic.S3442.severity = warning
-
-# Title    : Type should not be examined on "System.Type" instances
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
-dotnet_diagnostic.S3443.severity = warning
-
-# Title    : Interfaces should not simply inherit from base interfaces with colliding members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
-dotnet_diagnostic.S3444.severity = warning
-
-# Title    : Exceptions should not be explicitly rethrown
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
-dotnet_diagnostic.S3445.severity = warning
-
-# Title    : "[Optional]" should not be used on "ref" or "out" parameters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
-dotnet_diagnostic.S3447.severity = warning
-
-# Title    : Right operands of shift operators should be integers
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
-dotnet_diagnostic.S3449.severity = warning
-
-# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
-dotnet_diagnostic.S3450.severity = warning
-
-# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
-dotnet_diagnostic.S3451.severity = warning
-
-# Title    : Classes should not have only "private" constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
-dotnet_diagnostic.S3453.severity = warning
-
-# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
-dotnet_diagnostic.S3456.severity = warning
-
-# Title    : Composite format strings should be used correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
-dotnet_diagnostic.S3457.severity = warning
-
-# Title    : Empty "case" clauses that fall through to the "default" should be omitted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
-dotnet_diagnostic.S3458.severity = warning
-
-# Title    : Unassigned members should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
-dotnet_diagnostic.S3459.severity = warning
-
-# Title    : Type inheritance should not be recursive
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
-dotnet_diagnostic.S3464.severity = warning
-
-# Title    : Optional parameters should be passed to "base" calls
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
-dotnet_diagnostic.S3466.severity = warning
-
-# Title    : Empty "default" clauses should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
-dotnet_diagnostic.S3532.severity = warning
-
-# Title    : "ServiceContract" and "OperationContract" attributes should be used together
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
-dotnet_diagnostic.S3597.severity = warning
-
-# Title    : One-way "OperationContract" methods should have "void" return type
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
-dotnet_diagnostic.S3598.severity = warning
-
-# Title    : "params" should not be introduced on overrides
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
-dotnet_diagnostic.S3600.severity = warning
-
-# Title    : Methods with "Pure" attribute should return a value 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
-dotnet_diagnostic.S3603.severity = warning
-
-# Title    : Member initializer values should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
-dotnet_diagnostic.S3604.severity = warning
-
-# Title    : Nullable type comparison should not be redundant
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
-dotnet_diagnostic.S3610.severity = warning
-
-# Title    : Jump statements should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
-dotnet_diagnostic.S3626.severity = warning
-
-# Title    : Empty nullable value should not be accessed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
-dotnet_diagnostic.S3655.severity = warning
-
-# Title    : Exception constructors should not throw exceptions
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
-dotnet_diagnostic.S3693.severity = warning
-
-# Title    : Track use of "NotImplementedException"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
-dotnet_diagnostic.S3717.severity = warning
 
 # Title    : Cognitive Complexity of methods should not be too high
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
 # Comment  : Code gets complicated
-dotnet_diagnostic.S3776.severity = none
-
-# Title    : "SafeHandle.DangerousGetHandle" should not be called
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
-dotnet_diagnostic.S3869.severity = warning
 
 # Title    : Exception types should be "public"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
 # Redundant: CA1064
-dotnet_diagnostic.S3871.severity = none
-
-# Title    : Parameter names should not duplicate the names of their methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
-dotnet_diagnostic.S3872.severity = warning
 
 # Title    : "out" and "ref" parameters should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
 # Redundant: CA1021
-dotnet_diagnostic.S3874.severity = none
-
-# Title    : "operator==" should not be overloaded on reference types
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
-dotnet_diagnostic.S3875.severity = warning
-
-# Title    : Strings or integral types should be used for indexers
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
-dotnet_diagnostic.S3876.severity = warning
-
-# Title    : Exceptions should not be thrown from unexpected methods
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
-dotnet_diagnostic.S3877.severity = warning
-
-# Title    : Arrays should not be created for params parameters
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3878
-dotnet_diagnostic.S3878.severity = suggestion
-
-# Title    : Finalizers should not be empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
-dotnet_diagnostic.S3880.severity = warning
-
-# Title    : "IDisposable" should be implemented correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
-dotnet_diagnostic.S3881.severity = none
-
-# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
-dotnet_diagnostic.S3884.severity = warning
-
-# Title    : "Assembly.Load" should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
-dotnet_diagnostic.S3885.severity = warning
-
-# Title    : Mutable, non-private fields should not be "readonly"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
-dotnet_diagnostic.S3887.severity = warning
-
-# Title    : "Thread.Resume" and "Thread.Suspend" should not be used
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
-dotnet_diagnostic.S3889.severity = warning
-
-# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
-dotnet_diagnostic.S3897.severity = warning
-
-# Title    : Value types should implement "IEquatable<T>"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
-dotnet_diagnostic.S3898.severity = none
 
 # Title    : Arguments of public methods should be validated against null
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
 # Redundant: CA1062
-dotnet_diagnostic.S3900.severity = none
-
-# Title    : "Assembly.GetExecutingAssembly" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
-dotnet_diagnostic.S3902.severity = warning
 
 # Title    : Types should be defined in named namespaces
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
 # Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
-dotnet_diagnostic.S3903.severity = none
-
-# Title    : Assemblies should have version information
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
-dotnet_diagnostic.S3904.severity = warning
-
-# Title    : Event Handlers should have the correct signature
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
-dotnet_diagnostic.S3906.severity = warning
-
-# Title    : Generic event handlers should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
-dotnet_diagnostic.S3908.severity = warning
 
 # Title    : Collections should implement the generic interface
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
 # Redundant: CA1010
-dotnet_diagnostic.S3909.severity = none
-
-# Title    : All branches in a conditional structure should not have exactly the same implementation
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
-dotnet_diagnostic.S3923.severity = warning
 
 # Title    : "ISerializable" should be implemented correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
 # Comment  : TODO - is ISerializable still relevant?
-dotnet_diagnostic.S3925.severity = none
-
-# Title    : Deserialization methods should be provided for "OptionalField" members
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
-dotnet_diagnostic.S3926.severity = warning
-
-# Title    : Serialization event handlers should be implemented correctly
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
-dotnet_diagnostic.S3927.severity = warning
-
-# Title    : Parameter names used into ArgumentException constructors should match an existing one 
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
-dotnet_diagnostic.S3928.severity = warning
-
-# Title    : Number patterns should be regular
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
-dotnet_diagnostic.S3937.severity = warning
-
-# Title    : Calculations should not overflow
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
-dotnet_diagnostic.S3949.severity = suggestion
 
 # Title    : "Generic.List" instances should not be part of public APIs
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
 # Redundant: CA1002
-dotnet_diagnostic.S3956.severity = none
 
 # Title    : "static readonly" constants should be "const" instead
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
 # Redundant: CA1802
-dotnet_diagnostic.S3962.severity = none
 
 # Title    : "static" fields should be initialized inline
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
 # Redundant: CA1810 and CA2207
-dotnet_diagnostic.S3963.severity = none
-
-# Title    : Objects should not be disposed more than once
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
-dotnet_diagnostic.S3966.severity = warning
-
-# Title    : Multidimensional arrays should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
-dotnet_diagnostic.S3967.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
-dotnet_diagnostic.S3971.severity = warning
-
-# Title    : Conditionals should start on new lines
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
-dotnet_diagnostic.S3972.severity = warning
-
-# Title    : A conditionally executed single line should be denoted by indentation
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
-dotnet_diagnostic.S3973.severity = warning
-
-# Title    : Collection sizes and array length comparisons should make sense
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
-dotnet_diagnostic.S3981.severity = warning
-
-# Title    : Exceptions should not be created without being thrown
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
-dotnet_diagnostic.S3984.severity = warning
 
 # Title    : Assemblies should be marked as CLS compliant
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
 # Redundant: CA1014
-dotnet_diagnostic.S3990.severity = none
 
 # Title    : Assemblies should explicitly specify COM visibility
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
 # Redundant: CA1017
-dotnet_diagnostic.S3992.severity = none
 
 # Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
 # Redundant: CA1018
-dotnet_diagnostic.S3993.severity = none
-
-# Title    : URI Parameters should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
-dotnet_diagnostic.S3994.severity = none
-
-# Title    : URI return values should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
-dotnet_diagnostic.S3995.severity = warning
-
-# Title    : URI properties should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
-dotnet_diagnostic.S3996.severity = warning
-
-# Title    : String URI overloads should call "System.Uri" overloads
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
-dotnet_diagnostic.S3997.severity = warning
-
-# Title    : Threads should not lock on objects with weak identity
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
-dotnet_diagnostic.S3998.severity = warning
-
-# Title    : Pointers to unmanaged memory should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
-dotnet_diagnostic.S4000.severity = warning
-
-# Title    : Disposable types should declare finalizers
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
-dotnet_diagnostic.S4002.severity = warning
 
 # Title    : Collection properties should be readonly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
 # Redundant: CA2227
-dotnet_diagnostic.S4004.severity = none
 
 # Title    : "System.Uri" arguments should be used instead of strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
 # Redundant: CA2234
-dotnet_diagnostic.S4005.severity = none
-
-# Title    : Inherited member visibility should not be decreased
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
-dotnet_diagnostic.S4015.severity = warning
-
-# Title    : Enumeration members should not be named "Reserved"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
-dotnet_diagnostic.S4016.severity = warning
-
-# Title    : Method signatures should not contain nested generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
-dotnet_diagnostic.S4017.severity = none
-
-# Title    : All type parameters should be used in the parameter list to enable type inference
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
-dotnet_diagnostic.S4018.severity = none
-
-# Title    : Base class methods should not be hidden
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
-dotnet_diagnostic.S4019.severity = warning
-
-# Title    : Enumerations should have "Int32" storage
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
-dotnet_diagnostic.S4022.severity = warning
-
-# Title    : Interfaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
-dotnet_diagnostic.S4023.severity = none
-
-# Title    : Child class fields should not differ from parent class fields only by capitalization
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
-dotnet_diagnostic.S4025.severity = warning
-
-# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
-dotnet_diagnostic.S4026.severity = warning
 
 # Title    : Exceptions should provide standard constructors
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
 # Redundant: CA1032
-dotnet_diagnostic.S4027.severity = none
-
-# Title    : Classes implementing "IEquatable<T>" should be sealed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
-dotnet_diagnostic.S4035.severity = warning
-
-# Title    : Searching OS commands in PATH is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
-dotnet_diagnostic.S4036.severity = warning
-
-# Title    : Interface methods should be callable by derived types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
-dotnet_diagnostic.S4039.severity = warning
 
 # Title    : Strings should be normalized to uppercase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
 # Redundant: CA1308
-dotnet_diagnostic.S4040.severity = none
-
-# Title    : Type names should not match namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
-dotnet_diagnostic.S4041.severity = warning
-
-# Title    : Generics should be used when appropriate
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
-dotnet_diagnostic.S4047.severity = warning
 
 # Title    : Properties should be preferred
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
 # Redundant: CA1024
-dotnet_diagnostic.S4049.severity = none
-
-# Title    : Operators should be overloaded consistently
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
-dotnet_diagnostic.S4050.severity = warning
-
-# Title    : Types should not extend outdated base types
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
-dotnet_diagnostic.S4052.severity = warning
-
-# Title    : Literals should not be passed as localized parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
-dotnet_diagnostic.S4055.severity = none
 
 # Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
 # Redundant: CA1305
-dotnet_diagnostic.S4056.severity = none
-
-# Title    : Locales should be set for data types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
-dotnet_diagnostic.S4057.severity = warning
 
 # Title    : Overloads with a "StringComparison" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
 # Redundant: CA1310
-dotnet_diagnostic.S4058.severity = none
-
-# Title    : Property names should not match get methods
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
-dotnet_diagnostic.S4059.severity = warning
 
 # Title    : Non-abstract attributes should be sealed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
 # Redundant: CA1813
-dotnet_diagnostic.S4060.severity = none
-
-# Title    : "params" should be used instead of "varargs"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
-dotnet_diagnostic.S4061.severity = warning
 
 # Title    : Operator overloads should have named alternatives
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
 # Redundant: CA2225
-dotnet_diagnostic.S4069.severity = none
 
 # Title    : Non-flags enums should not be marked with "FlagsAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
 # Redundant: CA2217
-dotnet_diagnostic.S4070.severity = none
-
-# Title    : Method overloads should be grouped together
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
-dotnet_diagnostic.S4136.severity = warning
-
-# Title    : Duplicate values should not be passed as arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
-dotnet_diagnostic.S4142.severity = warning
-
-# Title    : Collection elements should not be replaced unconditionally
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
-dotnet_diagnostic.S4143.severity = warning
-
-# Title    : Methods should not have identical implementations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
-dotnet_diagnostic.S4144.severity = warning
 
 # Title    : Empty collections should not be accessed or iterated
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
 # Comment  : Too many false positives
-dotnet_diagnostic.S4158.severity = none
-
-# Title    : Classes should implement their "ExportAttribute" interfaces
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
-dotnet_diagnostic.S4159.severity = warning
-
-# Title    : Native methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
-dotnet_diagnostic.S4200.severity = warning
-
-# Title    : Null checks should not be used with "is"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
-dotnet_diagnostic.S4201.severity = warning
-
-# Title    : Windows Forms entry points should be marked with STAThread
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
-dotnet_diagnostic.S4210.severity = warning
-
-# Title    : Members should not have conflicting transparency annotations
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
-dotnet_diagnostic.S4211.severity = warning
-
-# Title    : Serialization constructors should be secured
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
-dotnet_diagnostic.S4212.severity = warning
-
-# Title    : "P/Invoke" methods should not be visible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
-dotnet_diagnostic.S4214.severity = warning
-
-# Title    : Events should have proper arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
-dotnet_diagnostic.S4220.severity = warning
-
-# Title    : Extension methods should not extend "object"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
-dotnet_diagnostic.S4225.severity = warning
-
-# Title    : Extensions should be in separate namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
-dotnet_diagnostic.S4226.severity = none
-
-# Title    : "ConstructorArgument" parameters should exist in constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
-dotnet_diagnostic.S4260.severity = warning
-
-# Title    : Methods should be named according to their synchronicities
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
-dotnet_diagnostic.S4261.severity = none
-
-# Title    : Getters and setters should access the expected fields
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
-dotnet_diagnostic.S4275.severity = warning
-
-# Title    : "Shared" parts should not be created with "new"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
-dotnet_diagnostic.S4277.severity = warning
-
-# Title    : Weak SSL/TLS protocols should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
-dotnet_diagnostic.S4423.severity = warning
-
-# Title    : Cryptographic keys should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
-dotnet_diagnostic.S4426.severity = warning
-
-# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
-dotnet_diagnostic.S4428.severity = warning
-
-# Title    : AES encryption algorithm should be used with secured mode
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
-dotnet_diagnostic.S4432.severity = warning
-
-# Title    : LDAP connections should be authenticated
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
-dotnet_diagnostic.S4433.severity = warning
-
-# Title    : Parameter validation in yielding methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
-dotnet_diagnostic.S4456.severity = warning
-
-# Title    : Parameter validation in "async"/"await" methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
-dotnet_diagnostic.S4457.severity = warning
 
 # Title    : Calls to "async" methods should not be blocking
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
 # Redundant: VSTHRD002
-dotnet_diagnostic.S4462.severity = none
 
 # Title    : Unread "private" fields should be removed
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
 # Redundant: IDE0052
-dotnet_diagnostic.S4487.severity = none
-
-# Title    : Disabling CSRF protections is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
-dotnet_diagnostic.S4502.severity = warning
-
-# Title    : Delivering code in production with debug features activated is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
-dotnet_diagnostic.S4507.severity = warning
-
-# Title    : "default" clauses should be first or last
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
-dotnet_diagnostic.S4524.severity = warning
-
-# Title    : "DebuggerDisplayAttribute" strings should reference existing members
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4545
-dotnet_diagnostic.S4545.severity = warning
-
-# Title    : ASP.NET HTTP request validation feature should not be disabled
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
-dotnet_diagnostic.S4564.severity = warning
-
-# Title    : "new Guid()" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
-dotnet_diagnostic.S4581.severity = warning
-
-# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
-dotnet_diagnostic.S4583.severity = warning
-
-# Title    : Non-async "Task/Task<T>" methods should not return null
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
-dotnet_diagnostic.S4586.severity = warning
-
-# Title    : Start index should be used instead of calling Substring
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
-dotnet_diagnostic.S4635.severity = warning
-
-# Title    : Comments should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4663
-dotnet_diagnostic.S4663.severity = suggestion
-
-# Title    : Using regular expressions is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
-dotnet_diagnostic.S4784.severity = warning
-
-# Title    : Encrypting data is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
-dotnet_diagnostic.S4787.severity = warning
-
-# Title    : Using weak hashing algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
-dotnet_diagnostic.S4790.severity = warning
-
-# Title    : Configuring loggers is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
-dotnet_diagnostic.S4792.severity = warning
-
-# Title    : Using Sockets is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
-dotnet_diagnostic.S4818.severity = warning
-
-# Title    : Using command line arguments is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
-dotnet_diagnostic.S4823.severity = warning
-
-# Title    : Reading the Standard Input is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
-dotnet_diagnostic.S4829.severity = warning
 
 # Title    : Server certificates should be verified during SSL/TLS connections
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
 # Redundant: CA5359
-dotnet_diagnostic.S4830.severity = none
-
-# Title    : Controlling permissions is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
-dotnet_diagnostic.S4834.severity = warning
-
-# Title    : "ValueTask" should be consumed correctly
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
-dotnet_diagnostic.S5034.severity = warning
-
-# Title    : Expanding archive files without controlling resource consumption is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
-dotnet_diagnostic.S5042.severity = warning
-
-# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
-dotnet_diagnostic.S5122.severity = warning
-
-# Title    : Using clear-text protocols is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
-dotnet_diagnostic.S5332.severity = warning
-
-# Title    : Using publicly writable directories is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
-dotnet_diagnostic.S5443.severity = warning
-
-# Title    : Insecure temporary file creation methods should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
-dotnet_diagnostic.S5445.severity = warning
-
-# Title    : Encryption algorithms should be used with secure mode and padding scheme
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
-dotnet_diagnostic.S5542.severity = warning
-
-# Title    : Cipher algorithms should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
-dotnet_diagnostic.S5547.severity = warning
-
-# Title    : JWT should be signed and verified with strong cipher algorithms
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
-dotnet_diagnostic.S5659.severity = warning
-
-# Title    : Allowing requests with excessive content length is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
-dotnet_diagnostic.S5693.severity = warning
-
-# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
-dotnet_diagnostic.S5753.severity = warning
-
-# Title    : Deserializing objects without performing data validation is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
-dotnet_diagnostic.S5766.severity = warning
-
-# Title    : Types allowed to be deserialized should be restricted
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
-dotnet_diagnostic.S5773.severity = warning
-
-# Title    : Regular expressions should be syntactically valid
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5856
-dotnet_diagnostic.S5856.severity = warning
 
 # Title    : Use a testable date/time provider
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
 # Redundant: R9A022
-dotnet_diagnostic.S6354.severity = none
-
-# Title    : Azure Functions should be stateless
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
-dotnet_diagnostic.S6419.severity = warning
-
-# Title    : Client instances should not be recreated on each Azure Function invocation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
-dotnet_diagnostic.S6420.severity = warning
-
-# Title    : Azure Functions should use Structured Error Handling
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
-dotnet_diagnostic.S6421.severity = warning
-
-# Title    : Calls to "async" methods should not be blocking in Azure Functions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
-dotnet_diagnostic.S6422.severity = warning
-
-# Title    : Azure Functions should log all failures
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
-dotnet_diagnostic.S6423.severity = warning
-
-# Title    : Interfaces for durable entities should satisfy the restrictions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
-dotnet_diagnostic.S6424.severity = warning
-
-# Title    : Not specifying a timeout for regular expressions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
-dotnet_diagnostic.S6444.severity = warning
 
 # Title    : Blocks should not be synchronized on local variables
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6507
 # Comment  : Too many false positives
-dotnet_diagnostic.S6507.severity = none
-
-# Title    : "ExcludeFromCodeCoverage" attributes should include a justification
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6513
-dotnet_diagnostic.S6513.severity = suggestion
-
-# Title    : Avoid using "DateTime.Now" for benchmarking or timing operations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6561
-dotnet_diagnostic.S6561.severity = warning
 
 # Title    : Always set the "DateTimeKind" when creating new "DateTime" instances
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6562
 # Comment  : Noise
-dotnet_diagnostic.S6562.severity = none
-
-# Title    : Use UTC when recording DateTime instants
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6563
-dotnet_diagnostic.S6563.severity = none
 
 # Title    : Use "DateTimeOffset" instead of "DateTime"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6566
 # Comment  : Noise
-dotnet_diagnostic.S6566.severity = none
-
-# Title    : Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6575
-dotnet_diagnostic.S6575.severity = warning
-
-# Title    : Use a format provider when parsing date and time
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6580
-dotnet_diagnostic.S6580.severity = warning
-
-# Title    : Don't hardcode the format when turning dates and times to strings
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6585
-dotnet_diagnostic.S6585.severity = none
-
-# Title    : Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6588
-dotnet_diagnostic.S6588.severity = warning
-
-# Title    : "Find" method should be used instead of the "FirstOrDefault" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6602
-dotnet_diagnostic.S6602.severity = warning
-
-# Title    : The collection-specific "TrueForAll" method should be used instead of the "All" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6603
-dotnet_diagnostic.S6603.severity = warning
-
-# Title    : Collection-specific "Exists" method should be used instead of the "Any" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6605
-dotnet_diagnostic.S6605.severity = warning
-
-# Title    : The collection should be filtered before sorting by using "Where" before "OrderBy"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6607
-dotnet_diagnostic.S6607.severity = warning
-
-# Title    : Prefer indexing instead of "Enumerable" methods on types implementing "IList"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6608
-dotnet_diagnostic.S6608.severity = warning
-
-# Title    : "Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6609
-dotnet_diagnostic.S6609.severity = warning
-
-# Title    : "StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6610
-dotnet_diagnostic.S6610.severity = warning
-
-# Title    : The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6612
-dotnet_diagnostic.S6612.severity = warning
-
-# Title    : "First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6613
-dotnet_diagnostic.S6613.severity = warning
-
-# Title    : "Contains" should be used instead of "Any" for simple equality checks
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6617
-dotnet_diagnostic.S6617.severity = warning
-
-# Title    : "string.Create" should be used instead of "FormattableString"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6618
-dotnet_diagnostic.S6618.severity = warning
-
-# Title    : Using unsafe code blocks is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6640
-dotnet_diagnostic.S6640.severity = warning
-
-# Title    : Literal suffixes should be upper case
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
-dotnet_diagnostic.S818.severity = warning
-
-# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
-dotnet_diagnostic.S881.severity = suggestion
-
-# Title    : "goto" statement should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
-dotnet_diagnostic.S907.severity = warning
 
 # Title    : Parameter names should match base declaration and other partial definitions
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
 # Redundant: CA1725
-dotnet_diagnostic.S927.severity = none
 
 # Title    : Copy-paste token calculator
 # Category : 

--- a/src/Generators/Microsoft.Gen.BuildMetadata/Emitter.cs
+++ b/src/Generators/Microsoft.Gen.BuildMetadata/Emitter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
@@ -6,7 +6,6 @@ using Microsoft.Gen.Shared;
 
 namespace Microsoft.Gen.BuildMetadata;
 
-[SuppressMessage("Format", "S1199", Justification = "For better visualization of how the generated code will look like.")]
 internal sealed class Emitter : EmitterBase
 {
     private const string DependencyInjectionNamespace = "global::Microsoft.Extensions.DependencyInjection.";
@@ -122,9 +121,7 @@ internal sealed class Emitter : EmitterBase
                 OutCloseBrace();
                 OutLn();
 
-#pragma warning disable S103 // Lines should not be too long
                 OutLn($"public static {ConfigurationNamespace}IConfigurationBuilder AddBuildMetadata(this {ConfigurationNamespace}IConfigurationBuilder builder, string sectionName = DefaultSectionName)");
-#pragma warning restore S103 // Lines should not be too long
                 OutOpenBrace();
                 {
                     OutNullGuards();

--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Utils.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Utils.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -64,7 +64,6 @@ internal sealed partial class Emitter : EmitterBase
         {
             level = lm.Level switch
             {
-#pragma warning disable S109 // Magic numbers should not be used
                 0 => "global::Microsoft.Extensions.Logging.LogLevel.Trace",
                 1 => "global::Microsoft.Extensions.Logging.LogLevel.Debug",
                 2 => "global::Microsoft.Extensions.Logging.LogLevel.Information",
@@ -73,7 +72,6 @@ internal sealed partial class Emitter : EmitterBase
                 5 => "global::Microsoft.Extensions.Logging.LogLevel.Critical",
                 6 => "global::Microsoft.Extensions.Logging.LogLevel.None",
                 _ => $"(global::Microsoft.Extensions.Logging.LogLevel){lm.Level}",
-#pragma warning restore S109 // Magic numbers should not be used
             };
         }
 
@@ -91,7 +89,6 @@ internal sealed partial class Emitter : EmitterBase
 
         return lm.Level switch
         {
-#pragma warning disable S109 // Magic numbers should not be used
             0 => "Trace",
             1 => "Debug",
             2 => "Information",
@@ -100,7 +97,6 @@ internal sealed partial class Emitter : EmitterBase
             5 => "Critical",
             6 => "None",
             _ => $"{lm.Level}",
-#pragma warning restore S109 // Magic numbers should not be used
         };
     }
 
@@ -126,9 +122,7 @@ internal sealed partial class Emitter : EmitterBase
                 return name;
             }
 
-#pragma warning disable S1643 // Strings should not be concatenated using '+' in a loop
             name += "_";
-#pragma warning restore S1643 // Strings should not be concatenated using '+' in a loop
         }
     }
 

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.LogProperties.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.LogProperties.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -9,8 +9,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Gen.Logging.Model;
 using Microsoft.Gen.Shared;
-
-#pragma warning disable S1067 // Expressions should not be too complex
 
 namespace Microsoft.Gen.Logging.Parsing;
 
@@ -218,7 +216,6 @@ internal partial class Parser
 
                     if (property.Type.IsValueType && !property.Type.IsNullableOfT())
                     {
-#pragma warning disable S125
                         // deal with an oddity in Roslyn. If you have this case:
                         //
                         // class Gen<T>
@@ -234,7 +231,6 @@ internal partial class Parser
                         // then Roslyn claims that MyInt has nullable annotations. Yet, doing x.MyInt?.ToString isn't valid.
                         // So we explicitly check whether the value is indeed a Nullable<T>.
                         lp.IsNullable = false;
-#pragma warning restore S125
                     }
 
                     // Check if this property hides a base property

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.TagProvider.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.TagProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
@@ -91,7 +91,6 @@ internal partial class Parser
             {
                 visitedLoop = true;
 
-#pragma warning disable S1067 // Expressions should not be too complex
                 if (method.IsStatic
                     && method.ReturnsVoid
                     && !method.IsGenericMethod
@@ -100,7 +99,6 @@ internal partial class Parser
                     && method.Parameters[1].RefKind == RefKind.None
                     && SymbolEqualityComparer.Default.Equals(tagCollectorType, method.Parameters[0].Type)
                     && IsAssignableTo(complexObjType, method.Parameters[1].Type))
-#pragma warning restore S1067 // Expressions should not be too complex
                 {
                     if (IsProviderMethodVisible(method))
                     {

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -153,7 +153,6 @@ internal sealed partial class Parser
                             lp.TagProvider = null;
                         }
 
-#pragma warning disable S1067 // Expressions should not be too complex
                         if (lp.IsNormalParameter
                             && (logPropertiesAttribute is null)
                             && (tagProviderAttribute is null)
@@ -162,7 +161,6 @@ internal sealed partial class Parser
                         {
                             Diag(DiagDescriptors.DefaultToString, paramSymbol.GetLocation(), paramSymbol.Type, paramSymbol.Name);
                         }
-#pragma warning restore S1067 // Expressions should not be too complex
 
                         bool forceAsTemplateParam = false;
 
@@ -456,14 +454,12 @@ internal sealed partial class Parser
             }
 
             var msg = lm.Message;
-#pragma warning disable S1067 // Expressions should not be too complex
             if (msg.StartsWith("INFORMATION:", StringComparison.OrdinalIgnoreCase)
                 || msg.StartsWith("INFO:", StringComparison.OrdinalIgnoreCase)
                 || msg.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase)
                 || msg.StartsWith("WARN:", StringComparison.OrdinalIgnoreCase)
                 || msg.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase)
                 || msg.StartsWith("ERR:", StringComparison.OrdinalIgnoreCase))
-#pragma warning restore S1067 // Expressions should not be too complex
             {
                 Diag(DiagDescriptors.RedundantQualifierInMessage, attrLoc, methodSymbol.Name);
             }
@@ -701,7 +697,6 @@ internal sealed partial class Parser
         INamedTypeSymbol? currentClassType = classType;
         bool onMostDerivedType = true;
 
-#pragma warning disable S125 // Sections of code should not be commented out
         /*
          We keep track of the names of all non-logger fields, since they prevent referring to logger
          primary constructor parameters with the same name. Example:
@@ -713,7 +708,6 @@ internal sealed partial class Parser
              public partial void M1(); // The ILogger primary constructor parameter cannot be used here.
          }
         */
-#pragma warning restore S125 // Sections of code should not be commented out
 
         HashSet<string> shadowedNames = new(StringComparer.Ordinal);
 

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolLoader.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolLoader.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -64,7 +64,6 @@ internal static class SymbolLoader
         var dataClassificationAttribute = compilation.GetBestTypeByMetadataName(DataClassificationAttribute);
         var noDataClassificationAttribute = compilation.GetBestTypeByMetadataName(NoDataClassificationAttribute);
 
-#pragma warning disable S1067 // Expressions should not be too complex
         if (loggerSymbol == null
             || logLevelSymbol == null
             || loggerMessageAttributeSymbol == null
@@ -77,7 +76,6 @@ internal static class SymbolLoader
             // nothing to do if these types aren't available
             return null;
         }
-#pragma warning restore S1067 // Expressions should not be too complex
 
         var exceptionSymbol = compilation.GetBestTypeByMetadataName(ExceptionType);
         if (exceptionSymbol == null)

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/TemplateProcessor.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/TemplateProcessor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -160,10 +160,8 @@ internal static class TemplateProcessor
 
                 int bracesCount = scanIndex - scanIndexBeforeSkip;
 
-#pragma warning disable S109 // Magic numbers should not be used
                 // if it is an even number of braces, just skip them, otherwise, we found an unescaped brace
                 if (bracesCount % 2 != 0)
-#pragma warning restore S109 // Magic numbers should not be used
                 {
                     if (currentBrace == searchedBrace)
                     {

--- a/src/Generators/Microsoft.Gen.Metrics/Parser.cs
+++ b/src/Generators/Microsoft.Gen.Metrics/Parser.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -860,7 +860,6 @@ internal sealed class Parser
     }
 
     // we can deal with this warning later
-#pragma warning disable S107 // Methods should not have too many parameters
     private List<StrongTypeConfig> WalkObjectModel(
         ISymbol parentSymbol,
         ISet<ITypeSymbol> typesChain,
@@ -870,7 +869,6 @@ internal sealed class Parser
         Dictionary<string, string> tagDescriptionDictionary,
         SymbolHolder symbols,
         bool isClass)
-#pragma warning restore S107 // Methods should not have too many parameters
     {
         var tagConfigs = new List<StrongTypeConfig>();
 

--- a/src/LegacySupport/.editorconfig
+++ b/src/LegacySupport/.editorconfig
@@ -480,7 +480,7 @@ dotnet_diagnostic.CA1507.severity = warning
 # Title    : Avoid dead conditional code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
-dotnet_diagnostic.CA1508.severity = warning
+dotnet_diagnostic.CA1508.severity = none
 
 # Title    : Invalid entry in code metrics rule specification file
 # Category : Maintainability
@@ -2889,2294 +2889,391 @@ dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
 # Redundant: IDE1006
-dotnet_diagnostic.S100.severity = none
-
-# Title    : Method overrides should not change parameter defaults
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
-dotnet_diagnostic.S1006.severity = warning
 
 # Title    : Types should be named in PascalCase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
 # Redundant: IDE1006
-dotnet_diagnostic.S101.severity = none
-
-# Title    : Lines should not be too long
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
-dotnet_diagnostic.S103.severity = warning
-
-# Title    : Files should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
-dotnet_diagnostic.S104.severity = warning
 
 # Title    : Finalizers should not throw exceptions
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
 # Redundant: CA1065
-dotnet_diagnostic.S1048.severity = none
 
 # Title    : Tabulation characters should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
 # Redundant: SA1027
-dotnet_diagnostic.S105.severity = none
-
-# Title    : Standard outputs should not be used directly to log anything
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
-dotnet_diagnostic.S106.severity = warning
-
-# Title    : Collapsible "if" statements should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
-dotnet_diagnostic.S1066.severity = none
-
-# Title    : Expressions should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
-dotnet_diagnostic.S1067.severity = warning
-
-# Title    : Methods should not have too many parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
-dotnet_diagnostic.S107.severity = warning
-
-# Title    : URIs should not be hardcoded
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
-dotnet_diagnostic.S1075.severity = warning
-
-# Title    : Nested blocks of code should not be left empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
-dotnet_diagnostic.S108.severity = warning
-
-# Title    : Magic numbers should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
-dotnet_diagnostic.S109.severity = warning
-
-# Title    : Inheritance tree of classes should not be too deep
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
-dotnet_diagnostic.S110.severity = warning
 
 # Title    : Fields should not have public accessibility
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
 # Redundant: CA1051
-dotnet_diagnostic.S1104.severity = none
 
 # Title    : A close curly brace should be located at the beginning of a line
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
 # Redundant: SA1500
-dotnet_diagnostic.S1109.severity = none
 
 # Title    : Redundant pairs of parentheses should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
 # Redundant: SA1119
-dotnet_diagnostic.S1110.severity = none
 
 # Title    : Empty statements should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
 # Redundant: SA1106
-dotnet_diagnostic.S1116.severity = none
-
-# Title    : Local variables should not shadow class fields or properties
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
-dotnet_diagnostic.S1117.severity = warning
 
 # Title    : Utility classes should not have public constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
 # Redundant: CA1052
-dotnet_diagnostic.S1118.severity = none
 
 # Title    : General exceptions should never be thrown
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
 # Redundant: CA2219
-dotnet_diagnostic.S112.severity = none
-
-# Title    : Assignments should not be made from within sub-expressions
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
-dotnet_diagnostic.S1121.severity = warning
 
 # Title    : "Obsolete" attributes should include explanations
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
 # Redundant: CA1041
-dotnet_diagnostic.S1123.severity = none
-
-# Title    : Boolean literals should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
-dotnet_diagnostic.S1125.severity = warning
-
-# Title    : Unused "using" should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
-dotnet_diagnostic.S1128.severity = warning
-
-# Title    : Files should contain an empty newline at the end
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
-dotnet_diagnostic.S113.severity = none
-
-# Title    : Deprecated code should be removed
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1133
-dotnet_diagnostic.S1133.severity = suggestion
-
-# Title    : Track uses of "FIXME" tags
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
-dotnet_diagnostic.S1134.severity = warning
-
-# Title    : Track uses of "TODO" tags
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
-dotnet_diagnostic.S1135.severity = warning
-
-# Title    : Unused private types or members should be removed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
-dotnet_diagnostic.S1144.severity = warning
-
-# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
-dotnet_diagnostic.S1145.severity = warning
-
-# Title    : Exit methods should not be called
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
-dotnet_diagnostic.S1147.severity = warning
-
-# Title    : "switch case" clauses should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
-dotnet_diagnostic.S1151.severity = none
-
-# Title    : "Any()" should be used to test for emptiness
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
-dotnet_diagnostic.S1155.severity = warning
 
 # Title    : Exceptions should not be thrown in finally blocks
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
 # Redundant: CA2219
-dotnet_diagnostic.S1163.severity = none
-
-# Title    : Empty arrays and collections should be returned instead of null
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
-dotnet_diagnostic.S1168.severity = warning
 
 # Title    : Unused method parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
 # Redundant: IDE0060
-dotnet_diagnostic.S1172.severity = none
-
-# Title    : Overriding members should do more than simply call the same member in the base class
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
-dotnet_diagnostic.S1185.severity = warning
-
-# Title    : Methods should not be empty
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
-dotnet_diagnostic.S1186.severity = warning
-
-# Title    : String literals should not be duplicated
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
-dotnet_diagnostic.S1192.severity = suggestion
-
-# Title    : Nested code blocks should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
-dotnet_diagnostic.S1199.severity = warning
-
-# Title    : Classes should not be coupled to too many other classes
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
-dotnet_diagnostic.S1200.severity = none
 
 # Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
 # Redundant: CS0659
-dotnet_diagnostic.S1206.severity = none
 
 # Title    : Control structures should use curly braces
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
 # Redundant: SA1503
-dotnet_diagnostic.S121.severity = none
 
 # Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
 # Redundant: CA1036
-dotnet_diagnostic.S1210.severity = none
-
-# Title    : "GC.Collect" should not be called
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
-dotnet_diagnostic.S1215.severity = warning
-
-# Title    : Statements should be on separate lines
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
-dotnet_diagnostic.S122.severity = none
-
-# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
-dotnet_diagnostic.S1226.severity = warning
-
-# Title    : break statements should not be used except for switch cases
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
-dotnet_diagnostic.S1227.severity = none
-
-# Title    : Floating point numbers should not be tested for equality
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
-dotnet_diagnostic.S1244.severity = error
-
-# Title    : Sections of code should not be commented out
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
-dotnet_diagnostic.S125.severity = warning
-
-# Title    : "if ... else if" constructs should end with "else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
-dotnet_diagnostic.S126.severity = none
-
-# Title    : A "while" loop should be used instead of a "for" loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
-dotnet_diagnostic.S1264.severity = warning
-
-# Title    : "for" loop stop conditions should be invariant
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
-dotnet_diagnostic.S127.severity = warning
-
-# Title    : "switch" statements should have at least 3 "case" clauses
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
-dotnet_diagnostic.S1301.severity = none
 
 # Title    : Track uses of in-source issue suppressions
 # Category : Info Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
 # Comment  : Suppressions are frequently necessary.
-dotnet_diagnostic.S1309.severity = none
-
-# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
-dotnet_diagnostic.S131.severity = none
-
-# Title    : Using hardcoded IP addresses is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
-dotnet_diagnostic.S1313.severity = warning
-
-# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
-dotnet_diagnostic.S134.severity = none
-
-# Title    : Functions should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
-dotnet_diagnostic.S138.severity = none
-
-# Title    : Culture should be specified for "string" operations
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
-dotnet_diagnostic.S1449.severity = warning
-
-# Title    : Private fields only used as local variables in methods should become local variables
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
-dotnet_diagnostic.S1450.severity = warning
 
 # Title    : Track lack of copyright and license headers
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
 # Redundant: IDE0073
-dotnet_diagnostic.S1451.severity = none
-
-# Title    : "switch" statements should not have too many "case" clauses
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
-dotnet_diagnostic.S1479.severity = warning
 
 # Title    : Unused local variables should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
 # Redundant: CS0168
-dotnet_diagnostic.S1481.severity = none
-
-# Title    : Methods and properties should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
-dotnet_diagnostic.S1541.severity = none
-
-# Title    : Tests should not be ignored
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
-dotnet_diagnostic.S1607.severity = warning
-
-# Title    : Strings should not be concatenated using '+' in a loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
-dotnet_diagnostic.S1643.severity = warning
-
-# Title    : Variables should not be self-assigned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
-dotnet_diagnostic.S1656.severity = warning
-
-# Title    : Multiple variables should not be declared on the same line
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
-dotnet_diagnostic.S1659.severity = warning
-
-# Title    : An abstract class should have both abstract and concrete methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
-dotnet_diagnostic.S1694.severity = warning
-
-# Title    : NullReferenceException should not be caught
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
-dotnet_diagnostic.S1696.severity = warning
-
-# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
-dotnet_diagnostic.S1697.severity = warning
-
-# Title    : "==" should not be used when "Equals" is overridden
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
-dotnet_diagnostic.S1698.severity = warning
-
-# Title    : Constructors should only call non-overridable methods
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
-dotnet_diagnostic.S1699.severity = warning
-
-# Title    : Loops with at most one iteration should be refactored
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
-dotnet_diagnostic.S1751.severity = warning
-
-# Title    : Identical expressions should not be used on both sides of operators
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
-dotnet_diagnostic.S1764.severity = warning
-
-# Title    : "switch" statements should not be nested
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
-dotnet_diagnostic.S1821.severity = none
-
-# Title    : Objects should not be created to be dropped immediately without being used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
-dotnet_diagnostic.S1848.severity = warning
 
 # Title    : Unused assignments should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
 # Redundant: IDE0059
-dotnet_diagnostic.S1854.severity = none
-
-# Title    : "ToString()" calls should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
-dotnet_diagnostic.S1858.severity = warning
-
-# Title    : Related "if/else if" statements should not have the same condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
-dotnet_diagnostic.S1862.severity = warning
-
-# Title    : Two branches in a conditional structure should not have exactly the same implementation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
-dotnet_diagnostic.S1871.severity = warning
 
 # Title    : Redundant casts should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
 # Redundant: IDE0004
-dotnet_diagnostic.S1905.severity = none
-
-# Title    : Inheritance list should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
-dotnet_diagnostic.S1939.severity = warning
-
-# Title    : Boolean checks should not be inverted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
-dotnet_diagnostic.S1940.severity = warning
-
-# Title    : Invalid casts should be avoided
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
-dotnet_diagnostic.S1944.severity = warning
-
-# Title    : "for" loop increment clauses should modify the loops' counters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
-dotnet_diagnostic.S1994.severity = warning
 
 # Title    : Hashes should include an unpredictable salt
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S2053.severity = none
-
-# Title    : Hard-coded credentials are security-sensitive
-# Category : Blocker Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
-dotnet_diagnostic.S2068.severity = warning
 
 # Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
 # Redundant: CA5350
-dotnet_diagnostic.S2070.severity = none
-
-# Title    : Formatting SQL queries is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
-dotnet_diagnostic.S2077.severity = warning
-
-# Title    : Creating cookies without the "secure" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
-dotnet_diagnostic.S2092.severity = warning
-
-# Title    : Classes should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2094
-dotnet_diagnostic.S2094.severity = none
-
-# Title    : Collections should not be passed as arguments to their own methods
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
-dotnet_diagnostic.S2114.severity = warning
-
-# Title    : A secure password should be used when connecting to a database
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
-dotnet_diagnostic.S2115.severity = warning
-
-# Title    : Values should not be uselessly incremented
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
-dotnet_diagnostic.S2123.severity = warning
-
-# Title    : Underscores should be used to make large numbers readable
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
-dotnet_diagnostic.S2148.severity = warning
-
-# Title    : "sealed" classes should not have "protected" members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
-dotnet_diagnostic.S2156.severity = warning
-
-# Title    : Classes named like "Exception" should extend "Exception" or a subclass
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2166
-dotnet_diagnostic.S2166.severity = warning
-
-# Title    : Short-circuit logic should be used in boolean contexts
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
-dotnet_diagnostic.S2178.severity = warning
-
-# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
-dotnet_diagnostic.S2183.severity = warning
-
-# Title    : Results of integer division should not be assigned to floating point variables
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
-dotnet_diagnostic.S2184.severity = warning
-
-# Title    : Test classes should contain at least one test case
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
-dotnet_diagnostic.S2187.severity = warning
-
-# Title    : Loops and recursions should not be infinite
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
-dotnet_diagnostic.S2190.severity = warning
-
-# Title    : Modulus results should not be checked for direct equality
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
-dotnet_diagnostic.S2197.severity = warning
-
-# Title    : Unnecessary mathematical comparisons should not be made
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2198
-dotnet_diagnostic.S2198.severity = warning
 
 # Title    : Methods without side effects should not have their return values ignored
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
 # Redundant: CA1806
-dotnet_diagnostic.S2201.severity = none
-
-# Title    : Runtime type checking should be simplified
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
-dotnet_diagnostic.S2219.severity = warning
-
-# Title    : "Exception" should not be caught
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
-dotnet_diagnostic.S2221.severity = none
-
-# Title    : Locks should be released on all paths
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
-dotnet_diagnostic.S2222.severity = warning
-
-# Title    : Non-constant static fields should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
-dotnet_diagnostic.S2223.severity = warning
-
-# Title    : "ToString()" method should not return null
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
-dotnet_diagnostic.S2225.severity = warning
-
-# Title    : Console logging should not be used
-# Category : Minor Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
-dotnet_diagnostic.S2228.severity = warning
-
-# Title    : Arguments should be passed in the same order as the method parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
-dotnet_diagnostic.S2234.severity = warning
-
-# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
-dotnet_diagnostic.S2245.severity = warning
-
-# Title    : A "for" loop update clause should move the counter in the right direction
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
-dotnet_diagnostic.S2251.severity = warning
-
-# Title    : For-loop conditions should be true at least once
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
-dotnet_diagnostic.S2252.severity = warning
-
-# Title    : Writing cookies is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
-dotnet_diagnostic.S2255.severity = warning
-
-# Title    : Using non-standard cryptographic algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
-dotnet_diagnostic.S2257.severity = warning
 
 # Title    : Null pointers should not be dereferenced
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
 # Comment  : Redundant, covered by modern C# compiler
-dotnet_diagnostic.S2259.severity = none
-
-# Title    : Composite format strings should not lead to unexpected behavior at runtime
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
-dotnet_diagnostic.S2275.severity = warning
-
-# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
-dotnet_diagnostic.S2278.severity = warning
-
-# Title    : Field-like events should not be virtual
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
-dotnet_diagnostic.S2290.severity = warning
-
-# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
-dotnet_diagnostic.S2291.severity = warning
 
 # Title    : Trivial properties should be auto-implemented
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
 # Redundant: IDE0032
-dotnet_diagnostic.S2292.severity = none
-
-# Title    : "nameof" should be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
-dotnet_diagnostic.S2302.severity = warning
-
-# Title    : "async" and "await" should not be used as identifiers
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
-dotnet_diagnostic.S2306.severity = warning
 
 # Title    : Methods and properties that don't access instance data should be static
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
 # Redundant: CA1822
-dotnet_diagnostic.S2325.severity = none
 
 # Title    : Unused type parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
 # Comment  : Valid pattern used in a number of places
-dotnet_diagnostic.S2326.severity = none
-
-# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
-dotnet_diagnostic.S2327.severity = warning
-
-# Title    : "GetHashCode" should not reference mutable fields
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
-dotnet_diagnostic.S2328.severity = warning
-
-# Title    : Array covariance should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
-dotnet_diagnostic.S2330.severity = warning
-
-# Title    : Redundant modifiers should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
-dotnet_diagnostic.S2333.severity = warning
-
-# Title    : Public constant members should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
-dotnet_diagnostic.S2339.severity = none
-
-# Title    : Enumeration types should comply with a naming convention
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
-dotnet_diagnostic.S2342.severity = none
-
-# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
-dotnet_diagnostic.S2344.severity = warning
-
-# Title    : Flags enumerations should explicitly initialize all their members
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
-dotnet_diagnostic.S2345.severity = warning
 
 # Title    : Flags enumerations zero-value members should be named "None"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
 # Redundant: CA1008
-dotnet_diagnostic.S2346.severity = none
 
 # Title    : Fields should be private
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
 # Redundant: CA1051
-dotnet_diagnostic.S2357.severity = none
-
-# Title    : Optional parameters should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
-dotnet_diagnostic.S2360.severity = none
-
-# Title    : Properties should not make collection or array copies
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
-dotnet_diagnostic.S2365.severity = warning
-
-# Title    : Public methods should not have multidimensional array parameters
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
-dotnet_diagnostic.S2368.severity = warning
-
-# Title    : Exceptions should not be thrown from property getters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
-dotnet_diagnostic.S2372.severity = warning
-
-# Title    : Write-only properties should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
-dotnet_diagnostic.S2376.severity = warning
-
-# Title    : Mutable fields should not be "public static"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
-dotnet_diagnostic.S2386.severity = warning
-
-# Title    : Child class fields should not shadow parent class fields
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
-dotnet_diagnostic.S2387.severity = warning
 
 # Title    : Types and methods should not have too many generic parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
 # Redundant: CA1005
-dotnet_diagnostic.S2436.severity = none
-
-# Title    : Unnecessary bit operations should not be performed
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
-dotnet_diagnostic.S2437.severity = warning
 
 # Title    : Blocks should be synchronized on read-only fields
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2445
 # Comment  : Noise
-dotnet_diagnostic.S2445.severity = none
-
-# Title    : Whitespace and control characters in string literals should be explicit
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
-dotnet_diagnostic.S2479.severity = warning
-
-# Title    : Generic exceptions should not be ignored
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
-dotnet_diagnostic.S2486.severity = warning
-
-# Title    : Shared resources should not be used for locking
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
-dotnet_diagnostic.S2551.severity = warning
 
 # Title    : Conditionally executed code should be reachable
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
 # Redundant: CA1508
-dotnet_diagnostic.S2583.severity = none
 
 # Title    : Boolean expressions should not be gratuitous
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
 # Comment  : Too many false positives.
-dotnet_diagnostic.S2589.severity = none
-
-# Title    : Setting loose file permissions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
-dotnet_diagnostic.S2612.severity = warning
-
-# Title    : The length returned from a stream read should be checked
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
-dotnet_diagnostic.S2674.severity = warning
-
-# Title    : Multiline blocks should be enclosed in curly braces
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
-dotnet_diagnostic.S2681.severity = warning
-
-# Title    : "NaN" should not be used in comparisons
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
-dotnet_diagnostic.S2688.severity = warning
-
-# Title    : "IndexOf" checks should not be for positive numbers
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
-dotnet_diagnostic.S2692.severity = warning
-
-# Title    : Instance members should not write to "static" fields
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
-dotnet_diagnostic.S2696.severity = warning
-
-# Title    : Tests should include assertions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
-dotnet_diagnostic.S2699.severity = warning
-
-# Title    : Literal boolean values should not be used in assertions
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
-dotnet_diagnostic.S2701.severity = warning
-
-# Title    : "catch" clauses should do more than rethrow
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
-dotnet_diagnostic.S2737.severity = warning
-
-# Title    : Static fields should not be used in generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
-dotnet_diagnostic.S2743.severity = none
-
-# Title    : XML parsers should not be vulnerable to XXE attacks
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
-dotnet_diagnostic.S2755.severity = warning
-
-# Title    : Non-existent operators like "=+" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
-dotnet_diagnostic.S2757.severity = warning
-
-# Title    : The ternary operator should not return the same value regardless of the condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
-dotnet_diagnostic.S2758.severity = warning
-
-# Title    : Sequential tests should not check the same condition
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
-dotnet_diagnostic.S2760.severity = warning
-
-# Title    : Doubled prefix operators "!!" and "~~" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
-dotnet_diagnostic.S2761.severity = warning
-
-# Title    : SQL keywords should be delimited by whitespace
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
-dotnet_diagnostic.S2857.severity = warning
-
-# Title    : "Thread.Sleep" should not be used in tests
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2925
-dotnet_diagnostic.S2925.severity = none
 
 # Title    : "IDisposables" should be disposed
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
 # Redundant: CA2000
-dotnet_diagnostic.S2930.severity = none
 
 # Title    : Classes with "IDisposable" members should implement "IDisposable"
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
 # Redundant: CA1001
-dotnet_diagnostic.S2931.severity = none
 
 # Title    : Fields that are only assigned in the constructor should be "readonly"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
 # Redundant: IDE0044
-dotnet_diagnostic.S2933.severity = none
-
-# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
-dotnet_diagnostic.S2934.severity = warning
-
-# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
-dotnet_diagnostic.S2952.severity = warning
-
-# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
-dotnet_diagnostic.S2953.severity = warning
-
-# Title    : Generic parameters not constrained to reference types should not be compared to "null"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
-dotnet_diagnostic.S2955.severity = warning
-
-# Title    : Assertions should be complete
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2970
-dotnet_diagnostic.S2970.severity = warning
-
-# Title    : "IEnumerable" LINQs should be simplified
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
-dotnet_diagnostic.S2971.severity = warning
-
-# Title    : "Object.ReferenceEquals" should not be used for value types
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
-dotnet_diagnostic.S2995.severity = warning
-
-# Title    : "ThreadStatic" fields should not be initialized
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
-dotnet_diagnostic.S2996.severity = warning
-
-# Title    : "IDisposables" created in a "using" statement should not be returned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
-dotnet_diagnostic.S2997.severity = warning
-
-# Title    : "ThreadStatic" should not be used on non-static fields
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
-dotnet_diagnostic.S3005.severity = warning
-
-# Title    : Static fields should not be updated in constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
-dotnet_diagnostic.S3010.severity = warning
-
-# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
-dotnet_diagnostic.S3011.severity = warning
 
 # Title    : Members should not be initialized to default values
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
 # Redundant: CA1805
-dotnet_diagnostic.S3052.severity = none
-
-# Title    : Types should not have members with visibility set higher than the type's visibility
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
-dotnet_diagnostic.S3059.severity = none
-
-# Title    : "is" should not be used with "this"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
-dotnet_diagnostic.S3060.severity = warning
-
-# Title    : "StringBuilder" data should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3063
-dotnet_diagnostic.S3063.severity = warning
 
 # Title    : "async" methods should not return "void"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
 # Redundant: VSTHRD100
-dotnet_diagnostic.S3168.severity = none
-
-# Title    : Multiple "OrderBy" calls should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
-dotnet_diagnostic.S3169.severity = warning
-
-# Title    : Delegates should not be subtracted
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
-dotnet_diagnostic.S3172.severity = warning
-
-# Title    : "interface" instances should not be cast to concrete types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
-dotnet_diagnostic.S3215.severity = warning
 
 # Title    : "ConfigureAwait(false)" should be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
 # Redundant: CA2007
-dotnet_diagnostic.S3216.severity = none
-
-# Title    : "Explicit" conversions of "foreach" loops should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
-dotnet_diagnostic.S3217.severity = warning
-
-# Title    : Inner class members should not shadow outer class "static" or type members
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
-dotnet_diagnostic.S3218.severity = warning
-
-# Title    : Method calls should not resolve ambiguously to overloads with "params"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
-dotnet_diagnostic.S3220.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
-dotnet_diagnostic.S3234.severity = warning
-
-# Title    : Redundant parentheses should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
-dotnet_diagnostic.S3235.severity = warning
-
-# Title    : Caller information arguments should not be provided explicitly
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
-dotnet_diagnostic.S3236.severity = warning
-
-# Title    : "value" contextual keyword should be used
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
-dotnet_diagnostic.S3237.severity = warning
 
 # Title    : The simplest possible condition syntax should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
 # Redundant: IDE0054
-dotnet_diagnostic.S3240.severity = none
-
-# Title    : Methods should not return values that are never used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
-dotnet_diagnostic.S3241.severity = warning
 
 # Title    : Method parameters should be declared with base types
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
 # Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
-dotnet_diagnostic.S3242.severity = none
-
-# Title    : Anonymous delegates should not be used to unsubscribe from Events
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
-dotnet_diagnostic.S3244.severity = warning
-
-# Title    : Generic type parameters should be co/contravariant when possible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
-dotnet_diagnostic.S3246.severity = warning
-
-# Title    : Duplicate casts should not be made
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
-dotnet_diagnostic.S3247.severity = warning
-
-# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
-dotnet_diagnostic.S3249.severity = warning
-
-# Title    : Implementations should be provided for "partial" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
-dotnet_diagnostic.S3251.severity = warning
-
-# Title    : Constructor and destructor declarations should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
-dotnet_diagnostic.S3253.severity = warning
-
-# Title    : Default parameter values should not be passed as arguments
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
-dotnet_diagnostic.S3254.severity = warning
-
-# Title    : "string.IsNullOrEmpty" should be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
-dotnet_diagnostic.S3256.severity = warning
 
 # Title    : Declarations and initializations should be as concise as possible
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
 # Comment  : Too many false positives
-dotnet_diagnostic.S3257.severity = none
 
 # Title    : Non-derived "private" classes and records should be "sealed"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
 # Redundant: R9A013
-dotnet_diagnostic.S3260.severity = none
-
-# Title    : Namespaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
-dotnet_diagnostic.S3261.severity = warning
-
-# Title    : "params" should be used on overrides
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
-dotnet_diagnostic.S3262.severity = warning
-
-# Title    : Static fields should appear in the order they must be initialized 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
-dotnet_diagnostic.S3263.severity = warning
-
-# Title    : Events should be invoked
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
-dotnet_diagnostic.S3264.severity = warning
-
-# Title    : Non-flags enums should not be used in bitwise operations
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
-dotnet_diagnostic.S3265.severity = warning
-
-# Title    : Loops should be simplified with "LINQ" expressions
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
-dotnet_diagnostic.S3267.severity = none
 
 # Title    : Cipher Block Chaining IVs should be unpredictable
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S3329.severity = none
-
-# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
-dotnet_diagnostic.S3330.severity = warning
-
-# Title    : Caller information parameters should come at the end of the parameter list
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
-dotnet_diagnostic.S3343.severity = warning
-
-# Title    : Expressions used in "Debug.Assert" should not produce side effects
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
-dotnet_diagnostic.S3346.severity = warning
-
-# Title    : Unchanged local variables should be "const"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
-dotnet_diagnostic.S3353.severity = warning
-
-# Title    : Ternary operators should not be nested
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
-dotnet_diagnostic.S3358.severity = warning
-
-# Title    : Date and time should not be used as a type for primary keys
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3363
-dotnet_diagnostic.S3363.severity = warning
-
-# Title    : "this" should not be exposed from constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
-dotnet_diagnostic.S3366.severity = warning
 
 # Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
 # Redundant: CA1710
-dotnet_diagnostic.S3376.severity = none
-
-# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
-dotnet_diagnostic.S3397.severity = warning
-
-# Title    : "private" methods called only by inner classes should be moved to those classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3398
-dotnet_diagnostic.S3398.severity = warning
-
-# Title    : Methods should not return constants
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
-dotnet_diagnostic.S3400.severity = warning
-
-# Title    : Assertion arguments should be passed in the correct order
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
-dotnet_diagnostic.S3415.severity = warning
-
-# Title    : Method overloads with default parameter values should not overlap
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
-dotnet_diagnostic.S3427.severity = warning
-
-# Title    : "[ExpectedException]" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
-dotnet_diagnostic.S3431.severity = warning
-
-# Title    : Test method signatures should be correct
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
-dotnet_diagnostic.S3433.severity = warning
-
-# Title    : Variables should not be checked against the values they're about to be assigned
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
-dotnet_diagnostic.S3440.severity = warning
-
-# Title    : Redundant property names should be omitted in anonymous classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
-dotnet_diagnostic.S3441.severity = warning
-
-# Title    : "abstract" classes should not have "public" constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
-dotnet_diagnostic.S3442.severity = warning
-
-# Title    : Type should not be examined on "System.Type" instances
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
-dotnet_diagnostic.S3443.severity = warning
-
-# Title    : Interfaces should not simply inherit from base interfaces with colliding members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
-dotnet_diagnostic.S3444.severity = warning
-
-# Title    : Exceptions should not be explicitly rethrown
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
-dotnet_diagnostic.S3445.severity = warning
-
-# Title    : "[Optional]" should not be used on "ref" or "out" parameters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
-dotnet_diagnostic.S3447.severity = warning
-
-# Title    : Right operands of shift operators should be integers
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
-dotnet_diagnostic.S3449.severity = warning
-
-# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
-dotnet_diagnostic.S3450.severity = warning
-
-# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
-dotnet_diagnostic.S3451.severity = warning
-
-# Title    : Classes should not have only "private" constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
-dotnet_diagnostic.S3453.severity = warning
-
-# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
-dotnet_diagnostic.S3456.severity = warning
-
-# Title    : Composite format strings should be used correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
-dotnet_diagnostic.S3457.severity = warning
-
-# Title    : Empty "case" clauses that fall through to the "default" should be omitted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
-dotnet_diagnostic.S3458.severity = warning
-
-# Title    : Unassigned members should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
-dotnet_diagnostic.S3459.severity = warning
-
-# Title    : Type inheritance should not be recursive
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
-dotnet_diagnostic.S3464.severity = warning
-
-# Title    : Optional parameters should be passed to "base" calls
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
-dotnet_diagnostic.S3466.severity = warning
-
-# Title    : Empty "default" clauses should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
-dotnet_diagnostic.S3532.severity = warning
-
-# Title    : "ServiceContract" and "OperationContract" attributes should be used together
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
-dotnet_diagnostic.S3597.severity = warning
-
-# Title    : One-way "OperationContract" methods should have "void" return type
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
-dotnet_diagnostic.S3598.severity = warning
-
-# Title    : "params" should not be introduced on overrides
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
-dotnet_diagnostic.S3600.severity = warning
-
-# Title    : Methods with "Pure" attribute should return a value 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
-dotnet_diagnostic.S3603.severity = warning
-
-# Title    : Member initializer values should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
-dotnet_diagnostic.S3604.severity = warning
-
-# Title    : Nullable type comparison should not be redundant
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
-dotnet_diagnostic.S3610.severity = warning
-
-# Title    : Jump statements should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
-dotnet_diagnostic.S3626.severity = warning
-
-# Title    : Empty nullable value should not be accessed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
-dotnet_diagnostic.S3655.severity = warning
-
-# Title    : Exception constructors should not throw exceptions
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
-dotnet_diagnostic.S3693.severity = warning
-
-# Title    : Track use of "NotImplementedException"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
-dotnet_diagnostic.S3717.severity = warning
 
 # Title    : Cognitive Complexity of methods should not be too high
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
 # Comment  : Code gets complicated
-dotnet_diagnostic.S3776.severity = none
-
-# Title    : "SafeHandle.DangerousGetHandle" should not be called
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
-dotnet_diagnostic.S3869.severity = warning
 
 # Title    : Exception types should be "public"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
 # Redundant: CA1064
-dotnet_diagnostic.S3871.severity = none
-
-# Title    : Parameter names should not duplicate the names of their methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
-dotnet_diagnostic.S3872.severity = warning
 
 # Title    : "out" and "ref" parameters should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
 # Redundant: CA1021
-dotnet_diagnostic.S3874.severity = none
-
-# Title    : "operator==" should not be overloaded on reference types
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
-dotnet_diagnostic.S3875.severity = warning
-
-# Title    : Strings or integral types should be used for indexers
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
-dotnet_diagnostic.S3876.severity = warning
-
-# Title    : Exceptions should not be thrown from unexpected methods
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
-dotnet_diagnostic.S3877.severity = warning
-
-# Title    : Arrays should not be created for params parameters
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3878
-dotnet_diagnostic.S3878.severity = suggestion
-
-# Title    : Finalizers should not be empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
-dotnet_diagnostic.S3880.severity = warning
-
-# Title    : "IDisposable" should be implemented correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
-dotnet_diagnostic.S3881.severity = none
-
-# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
-dotnet_diagnostic.S3884.severity = warning
-
-# Title    : "Assembly.Load" should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
-dotnet_diagnostic.S3885.severity = warning
-
-# Title    : Mutable, non-private fields should not be "readonly"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
-dotnet_diagnostic.S3887.severity = warning
-
-# Title    : "Thread.Resume" and "Thread.Suspend" should not be used
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
-dotnet_diagnostic.S3889.severity = warning
-
-# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
-dotnet_diagnostic.S3897.severity = warning
-
-# Title    : Value types should implement "IEquatable<T>"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
-dotnet_diagnostic.S3898.severity = none
 
 # Title    : Arguments of public methods should be validated against null
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
 # Redundant: CA1062
-dotnet_diagnostic.S3900.severity = none
-
-# Title    : "Assembly.GetExecutingAssembly" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
-dotnet_diagnostic.S3902.severity = warning
 
 # Title    : Types should be defined in named namespaces
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
 # Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
-dotnet_diagnostic.S3903.severity = none
-
-# Title    : Assemblies should have version information
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
-dotnet_diagnostic.S3904.severity = warning
-
-# Title    : Event Handlers should have the correct signature
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
-dotnet_diagnostic.S3906.severity = warning
-
-# Title    : Generic event handlers should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
-dotnet_diagnostic.S3908.severity = warning
 
 # Title    : Collections should implement the generic interface
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
 # Redundant: CA1010
-dotnet_diagnostic.S3909.severity = none
-
-# Title    : All branches in a conditional structure should not have exactly the same implementation
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
-dotnet_diagnostic.S3923.severity = warning
 
 # Title    : "ISerializable" should be implemented correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
 # Comment  : TODO - is ISerializable still relevant?
-dotnet_diagnostic.S3925.severity = none
-
-# Title    : Deserialization methods should be provided for "OptionalField" members
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
-dotnet_diagnostic.S3926.severity = warning
-
-# Title    : Serialization event handlers should be implemented correctly
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
-dotnet_diagnostic.S3927.severity = warning
-
-# Title    : Parameter names used into ArgumentException constructors should match an existing one 
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
-dotnet_diagnostic.S3928.severity = warning
-
-# Title    : Number patterns should be regular
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
-dotnet_diagnostic.S3937.severity = warning
-
-# Title    : Calculations should not overflow
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
-dotnet_diagnostic.S3949.severity = suggestion
 
 # Title    : "Generic.List" instances should not be part of public APIs
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
 # Redundant: CA1002
-dotnet_diagnostic.S3956.severity = none
 
 # Title    : "static readonly" constants should be "const" instead
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
 # Redundant: CA1802
-dotnet_diagnostic.S3962.severity = none
 
 # Title    : "static" fields should be initialized inline
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
 # Redundant: CA1810 and CA2207
-dotnet_diagnostic.S3963.severity = none
-
-# Title    : Objects should not be disposed more than once
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
-dotnet_diagnostic.S3966.severity = warning
-
-# Title    : Multidimensional arrays should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
-dotnet_diagnostic.S3967.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
-dotnet_diagnostic.S3971.severity = warning
-
-# Title    : Conditionals should start on new lines
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
-dotnet_diagnostic.S3972.severity = warning
-
-# Title    : A conditionally executed single line should be denoted by indentation
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
-dotnet_diagnostic.S3973.severity = warning
-
-# Title    : Collection sizes and array length comparisons should make sense
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
-dotnet_diagnostic.S3981.severity = warning
-
-# Title    : Exceptions should not be created without being thrown
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
-dotnet_diagnostic.S3984.severity = warning
 
 # Title    : Assemblies should be marked as CLS compliant
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
 # Redundant: CA1014
-dotnet_diagnostic.S3990.severity = none
 
 # Title    : Assemblies should explicitly specify COM visibility
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
 # Redundant: CA1017
-dotnet_diagnostic.S3992.severity = none
 
 # Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
 # Redundant: CA1018
-dotnet_diagnostic.S3993.severity = none
-
-# Title    : URI Parameters should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
-dotnet_diagnostic.S3994.severity = none
-
-# Title    : URI return values should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
-dotnet_diagnostic.S3995.severity = warning
-
-# Title    : URI properties should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
-dotnet_diagnostic.S3996.severity = warning
-
-# Title    : String URI overloads should call "System.Uri" overloads
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
-dotnet_diagnostic.S3997.severity = warning
-
-# Title    : Threads should not lock on objects with weak identity
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
-dotnet_diagnostic.S3998.severity = warning
-
-# Title    : Pointers to unmanaged memory should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
-dotnet_diagnostic.S4000.severity = warning
-
-# Title    : Disposable types should declare finalizers
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
-dotnet_diagnostic.S4002.severity = warning
 
 # Title    : Collection properties should be readonly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
 # Redundant: CA2227
-dotnet_diagnostic.S4004.severity = none
 
 # Title    : "System.Uri" arguments should be used instead of strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
 # Redundant: CA2234
-dotnet_diagnostic.S4005.severity = none
-
-# Title    : Inherited member visibility should not be decreased
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
-dotnet_diagnostic.S4015.severity = warning
-
-# Title    : Enumeration members should not be named "Reserved"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
-dotnet_diagnostic.S4016.severity = warning
-
-# Title    : Method signatures should not contain nested generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
-dotnet_diagnostic.S4017.severity = none
-
-# Title    : All type parameters should be used in the parameter list to enable type inference
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
-dotnet_diagnostic.S4018.severity = none
-
-# Title    : Base class methods should not be hidden
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
-dotnet_diagnostic.S4019.severity = warning
-
-# Title    : Enumerations should have "Int32" storage
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
-dotnet_diagnostic.S4022.severity = warning
-
-# Title    : Interfaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
-dotnet_diagnostic.S4023.severity = none
-
-# Title    : Child class fields should not differ from parent class fields only by capitalization
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
-dotnet_diagnostic.S4025.severity = warning
-
-# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
-dotnet_diagnostic.S4026.severity = warning
 
 # Title    : Exceptions should provide standard constructors
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
 # Redundant: CA1032
-dotnet_diagnostic.S4027.severity = none
-
-# Title    : Classes implementing "IEquatable<T>" should be sealed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
-dotnet_diagnostic.S4035.severity = warning
-
-# Title    : Searching OS commands in PATH is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
-dotnet_diagnostic.S4036.severity = warning
-
-# Title    : Interface methods should be callable by derived types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
-dotnet_diagnostic.S4039.severity = warning
 
 # Title    : Strings should be normalized to uppercase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
 # Redundant: CA1308
-dotnet_diagnostic.S4040.severity = none
-
-# Title    : Type names should not match namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
-dotnet_diagnostic.S4041.severity = warning
-
-# Title    : Generics should be used when appropriate
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
-dotnet_diagnostic.S4047.severity = warning
 
 # Title    : Properties should be preferred
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
 # Redundant: CA1024
-dotnet_diagnostic.S4049.severity = none
-
-# Title    : Operators should be overloaded consistently
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
-dotnet_diagnostic.S4050.severity = warning
-
-# Title    : Types should not extend outdated base types
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
-dotnet_diagnostic.S4052.severity = warning
-
-# Title    : Literals should not be passed as localized parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
-dotnet_diagnostic.S4055.severity = none
 
 # Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
 # Redundant: CA1305
-dotnet_diagnostic.S4056.severity = none
-
-# Title    : Locales should be set for data types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
-dotnet_diagnostic.S4057.severity = warning
 
 # Title    : Overloads with a "StringComparison" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
 # Redundant: CA1310
-dotnet_diagnostic.S4058.severity = none
-
-# Title    : Property names should not match get methods
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
-dotnet_diagnostic.S4059.severity = warning
 
 # Title    : Non-abstract attributes should be sealed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
 # Redundant: CA1813
-dotnet_diagnostic.S4060.severity = none
-
-# Title    : "params" should be used instead of "varargs"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
-dotnet_diagnostic.S4061.severity = warning
 
 # Title    : Operator overloads should have named alternatives
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
 # Redundant: CA2225
-dotnet_diagnostic.S4069.severity = none
 
 # Title    : Non-flags enums should not be marked with "FlagsAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
 # Redundant: CA2217
-dotnet_diagnostic.S4070.severity = none
-
-# Title    : Method overloads should be grouped together
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
-dotnet_diagnostic.S4136.severity = warning
-
-# Title    : Duplicate values should not be passed as arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
-dotnet_diagnostic.S4142.severity = warning
-
-# Title    : Collection elements should not be replaced unconditionally
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
-dotnet_diagnostic.S4143.severity = warning
-
-# Title    : Methods should not have identical implementations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
-dotnet_diagnostic.S4144.severity = warning
 
 # Title    : Empty collections should not be accessed or iterated
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
 # Comment  : Too many false positives
-dotnet_diagnostic.S4158.severity = none
-
-# Title    : Classes should implement their "ExportAttribute" interfaces
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
-dotnet_diagnostic.S4159.severity = warning
-
-# Title    : Native methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
-dotnet_diagnostic.S4200.severity = warning
-
-# Title    : Null checks should not be used with "is"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
-dotnet_diagnostic.S4201.severity = warning
-
-# Title    : Windows Forms entry points should be marked with STAThread
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
-dotnet_diagnostic.S4210.severity = warning
-
-# Title    : Members should not have conflicting transparency annotations
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
-dotnet_diagnostic.S4211.severity = warning
-
-# Title    : Serialization constructors should be secured
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
-dotnet_diagnostic.S4212.severity = warning
-
-# Title    : "P/Invoke" methods should not be visible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
-dotnet_diagnostic.S4214.severity = warning
-
-# Title    : Events should have proper arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
-dotnet_diagnostic.S4220.severity = warning
-
-# Title    : Extension methods should not extend "object"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
-dotnet_diagnostic.S4225.severity = warning
-
-# Title    : Extensions should be in separate namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
-dotnet_diagnostic.S4226.severity = none
-
-# Title    : "ConstructorArgument" parameters should exist in constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
-dotnet_diagnostic.S4260.severity = warning
-
-# Title    : Methods should be named according to their synchronicities
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
-dotnet_diagnostic.S4261.severity = none
-
-# Title    : Getters and setters should access the expected fields
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
-dotnet_diagnostic.S4275.severity = warning
-
-# Title    : "Shared" parts should not be created with "new"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
-dotnet_diagnostic.S4277.severity = warning
-
-# Title    : Weak SSL/TLS protocols should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
-dotnet_diagnostic.S4423.severity = warning
-
-# Title    : Cryptographic keys should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
-dotnet_diagnostic.S4426.severity = warning
-
-# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
-dotnet_diagnostic.S4428.severity = warning
-
-# Title    : AES encryption algorithm should be used with secured mode
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
-dotnet_diagnostic.S4432.severity = warning
-
-# Title    : LDAP connections should be authenticated
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
-dotnet_diagnostic.S4433.severity = warning
-
-# Title    : Parameter validation in yielding methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
-dotnet_diagnostic.S4456.severity = warning
-
-# Title    : Parameter validation in "async"/"await" methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
-dotnet_diagnostic.S4457.severity = warning
 
 # Title    : Calls to "async" methods should not be blocking
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
 # Redundant: VSTHRD002
-dotnet_diagnostic.S4462.severity = none
 
 # Title    : Unread "private" fields should be removed
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
 # Redundant: IDE0052
-dotnet_diagnostic.S4487.severity = none
-
-# Title    : Disabling CSRF protections is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
-dotnet_diagnostic.S4502.severity = warning
-
-# Title    : Delivering code in production with debug features activated is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
-dotnet_diagnostic.S4507.severity = warning
-
-# Title    : "default" clauses should be first or last
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
-dotnet_diagnostic.S4524.severity = warning
-
-# Title    : "DebuggerDisplayAttribute" strings should reference existing members
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4545
-dotnet_diagnostic.S4545.severity = warning
-
-# Title    : ASP.NET HTTP request validation feature should not be disabled
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
-dotnet_diagnostic.S4564.severity = warning
-
-# Title    : "new Guid()" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
-dotnet_diagnostic.S4581.severity = warning
-
-# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
-dotnet_diagnostic.S4583.severity = warning
-
-# Title    : Non-async "Task/Task<T>" methods should not return null
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
-dotnet_diagnostic.S4586.severity = warning
-
-# Title    : Start index should be used instead of calling Substring
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
-dotnet_diagnostic.S4635.severity = warning
-
-# Title    : Comments should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4663
-dotnet_diagnostic.S4663.severity = suggestion
-
-# Title    : Using regular expressions is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
-dotnet_diagnostic.S4784.severity = warning
-
-# Title    : Encrypting data is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
-dotnet_diagnostic.S4787.severity = warning
-
-# Title    : Using weak hashing algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
-dotnet_diagnostic.S4790.severity = warning
-
-# Title    : Configuring loggers is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
-dotnet_diagnostic.S4792.severity = warning
-
-# Title    : Using Sockets is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
-dotnet_diagnostic.S4818.severity = warning
-
-# Title    : Using command line arguments is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
-dotnet_diagnostic.S4823.severity = warning
-
-# Title    : Reading the Standard Input is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
-dotnet_diagnostic.S4829.severity = warning
 
 # Title    : Server certificates should be verified during SSL/TLS connections
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
 # Redundant: CA5359
-dotnet_diagnostic.S4830.severity = none
-
-# Title    : Controlling permissions is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
-dotnet_diagnostic.S4834.severity = warning
-
-# Title    : "ValueTask" should be consumed correctly
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
-dotnet_diagnostic.S5034.severity = warning
-
-# Title    : Expanding archive files without controlling resource consumption is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
-dotnet_diagnostic.S5042.severity = warning
-
-# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
-dotnet_diagnostic.S5122.severity = warning
-
-# Title    : Using clear-text protocols is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
-dotnet_diagnostic.S5332.severity = warning
-
-# Title    : Using publicly writable directories is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
-dotnet_diagnostic.S5443.severity = warning
-
-# Title    : Insecure temporary file creation methods should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
-dotnet_diagnostic.S5445.severity = warning
-
-# Title    : Encryption algorithms should be used with secure mode and padding scheme
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
-dotnet_diagnostic.S5542.severity = warning
-
-# Title    : Cipher algorithms should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
-dotnet_diagnostic.S5547.severity = warning
-
-# Title    : JWT should be signed and verified with strong cipher algorithms
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
-dotnet_diagnostic.S5659.severity = warning
-
-# Title    : Allowing requests with excessive content length is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
-dotnet_diagnostic.S5693.severity = warning
-
-# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
-dotnet_diagnostic.S5753.severity = warning
-
-# Title    : Deserializing objects without performing data validation is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
-dotnet_diagnostic.S5766.severity = warning
-
-# Title    : Types allowed to be deserialized should be restricted
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
-dotnet_diagnostic.S5773.severity = warning
-
-# Title    : Regular expressions should be syntactically valid
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5856
-dotnet_diagnostic.S5856.severity = warning
 
 # Title    : Use a testable date/time provider
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
 # Redundant: R9A022
-dotnet_diagnostic.S6354.severity = none
-
-# Title    : Azure Functions should be stateless
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
-dotnet_diagnostic.S6419.severity = warning
-
-# Title    : Client instances should not be recreated on each Azure Function invocation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
-dotnet_diagnostic.S6420.severity = warning
-
-# Title    : Azure Functions should use Structured Error Handling
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
-dotnet_diagnostic.S6421.severity = warning
-
-# Title    : Calls to "async" methods should not be blocking in Azure Functions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
-dotnet_diagnostic.S6422.severity = warning
-
-# Title    : Azure Functions should log all failures
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
-dotnet_diagnostic.S6423.severity = warning
-
-# Title    : Interfaces for durable entities should satisfy the restrictions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
-dotnet_diagnostic.S6424.severity = warning
-
-# Title    : Not specifying a timeout for regular expressions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
-dotnet_diagnostic.S6444.severity = warning
 
 # Title    : Blocks should not be synchronized on local variables
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6507
 # Comment  : Too many false positives
-dotnet_diagnostic.S6507.severity = none
-
-# Title    : "ExcludeFromCodeCoverage" attributes should include a justification
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6513
-dotnet_diagnostic.S6513.severity = suggestion
-
-# Title    : Avoid using "DateTime.Now" for benchmarking or timing operations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6561
-dotnet_diagnostic.S6561.severity = warning
 
 # Title    : Always set the "DateTimeKind" when creating new "DateTime" instances
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6562
 # Comment  : Noise
-dotnet_diagnostic.S6562.severity = none
-
-# Title    : Use UTC when recording DateTime instants
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6563
-dotnet_diagnostic.S6563.severity = none
 
 # Title    : Use "DateTimeOffset" instead of "DateTime"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6566
 # Comment  : Noise
-dotnet_diagnostic.S6566.severity = none
-
-# Title    : Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6575
-dotnet_diagnostic.S6575.severity = warning
-
-# Title    : Use a format provider when parsing date and time
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6580
-dotnet_diagnostic.S6580.severity = warning
-
-# Title    : Don't hardcode the format when turning dates and times to strings
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6585
-dotnet_diagnostic.S6585.severity = none
-
-# Title    : Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6588
-dotnet_diagnostic.S6588.severity = warning
-
-# Title    : "Find" method should be used instead of the "FirstOrDefault" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6602
-dotnet_diagnostic.S6602.severity = warning
-
-# Title    : The collection-specific "TrueForAll" method should be used instead of the "All" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6603
-dotnet_diagnostic.S6603.severity = warning
-
-# Title    : Collection-specific "Exists" method should be used instead of the "Any" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6605
-dotnet_diagnostic.S6605.severity = warning
-
-# Title    : The collection should be filtered before sorting by using "Where" before "OrderBy"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6607
-dotnet_diagnostic.S6607.severity = warning
-
-# Title    : Prefer indexing instead of "Enumerable" methods on types implementing "IList"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6608
-dotnet_diagnostic.S6608.severity = warning
-
-# Title    : "Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6609
-dotnet_diagnostic.S6609.severity = warning
-
-# Title    : "StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6610
-dotnet_diagnostic.S6610.severity = warning
-
-# Title    : The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6612
-dotnet_diagnostic.S6612.severity = warning
-
-# Title    : "First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6613
-dotnet_diagnostic.S6613.severity = warning
-
-# Title    : "Contains" should be used instead of "Any" for simple equality checks
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6617
-dotnet_diagnostic.S6617.severity = warning
-
-# Title    : "string.Create" should be used instead of "FormattableString"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6618
-dotnet_diagnostic.S6618.severity = warning
-
-# Title    : Using unsafe code blocks is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6640
-dotnet_diagnostic.S6640.severity = warning
-
-# Title    : Literal suffixes should be upper case
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
-dotnet_diagnostic.S818.severity = warning
-
-# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
-dotnet_diagnostic.S881.severity = suggestion
-
-# Title    : "goto" statement should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
-dotnet_diagnostic.S907.severity = warning
 
 # Title    : Parameter names should match base declaration and other partial definitions
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
 # Redundant: CA1725
-dotnet_diagnostic.S927.severity = none
 
 # Title    : Copy-paste token calculator
 # Category : 

--- a/src/LegacySupport/BitOperations/BitOperations.cs
+++ b/src/LegacySupport/BitOperations/BitOperations.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable S109 // Magic numbers should not be used
-
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 

--- a/src/LegacySupport/DiagnosticAttributes/NullableAttributes.cs
+++ b/src/LegacySupport/DiagnosticAttributes/NullableAttributes.cs
@@ -13,7 +13,6 @@
 #pragma warning disable SA1623
 #pragma warning disable SA1642
 #pragma warning disable SA1649
-#pragma warning disable S3903
 #pragma warning disable IDE0021 // Use block body for constructors
 #pragma warning disable CA1019
 

--- a/src/LegacySupport/ExperimentalAttribute/ExperimentalAttribute.cs
+++ b/src/LegacySupport/ExperimentalAttribute/ExperimentalAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if !NET8_0_OR_GREATER
@@ -48,9 +48,7 @@ internal sealed class ExperimentalAttribute : Attribute
     /// </summary>
     /// <value>The format string that represents a URL to corresponding documentation.</value>
     /// <remarks>An example format string is <c>https://contoso.com/obsoletion-warnings/{0}</c>.</remarks>
-#pragma warning disable S3996 // URI properties should not be strings
     public string? UrlFormat { get; set; }
-#pragma warning restore S3996 // URI properties should not be strings
 }
 
 #endif

--- a/src/LegacySupport/IsExternalInit/IsExternalInit.cs
+++ b/src/LegacySupport/IsExternalInit/IsExternalInit.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable IDE0079
-#pragma warning disable S3903
 
 /* This enables support for C# 9/10 records on older frameworks */
 

--- a/src/LegacySupport/NullabilityInfoContext/NullabilityInfoContext.cs
+++ b/src/LegacySupport/NullabilityInfoContext/NullabilityInfoContext.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if !NET6_0_OR_GREATER
@@ -8,9 +8,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 #pragma warning disable SA1204 // Static elements should appear before instance elements
-#pragma warning disable S109 // Magic numbers should not be used
-#pragma warning disable S1067 // Expressions should not be too complex
-#pragma warning disable S4136 // Method overloads should be grouped together
 #pragma warning disable SA1202 // Elements should be ordered by access
 #pragma warning disable IDE1006 // Naming Styles
 

--- a/src/LegacySupport/NullabilityInfoContext/NullabilityInfoHelpers.cs
+++ b/src/LegacySupport/NullabilityInfoContext/NullabilityInfoHelpers.cs
@@ -1,11 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if !NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 
 #pragma warning disable IDE1006 // Naming Styles
-#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 
 namespace System.Reflection
 {

--- a/src/LegacySupport/ObsoleteAttribute/ObsoleteAttribute.cs
+++ b/src/LegacySupport/ObsoleteAttribute/ObsoleteAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if !NET5_0_OR_GREATER
@@ -16,7 +16,6 @@ namespace System;
 /// ObsoleteAttribute.cs</see> without any changes, all resulting warnings ignored accordingly.
 /// </remarks>
 #pragma warning disable CA1019 // Define accessors for attribute arguments
-#pragma warning disable S3996 // URI properties should not be strings
 [ExcludeFromCodeCoverage]
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum |
     AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Method |

--- a/src/LegacySupport/PlatformAttributes/PlatformAttributes.cs
+++ b/src/LegacySupport/PlatformAttributes/PlatformAttributes.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable S1694
-#pragma warning disable S3996
 #pragma warning disable SA1128
 #pragma warning disable SA1402
 #pragma warning disable SA1513

--- a/src/LegacySupport/StringHash/StringHash.cs
+++ b/src/LegacySupport/StringHash/StringHash.cs
@@ -3,7 +3,6 @@
 
 #pragma warning disable IDE0079
 #pragma warning disable CPR103
-#pragma warning disable S3903
 
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/LegacySupport/SystemIndex/Index.cs
+++ b/src/LegacySupport/SystemIndex/Index.cs
@@ -5,12 +5,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 #pragma warning disable CS0436 // Type conflicts with imported type
-#pragma warning disable S3427 // Method overloads with default parameter values should not overlap 
 #pragma warning disable SA1642 // Constructor summary documentation should begin with standard text
 #pragma warning disable IDE0011 // Add braces
 #pragma warning disable SA1623 // Property summary documentation should match accessors
 #pragma warning disable IDE0023 // Use block body for conversion operator
-#pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
 #pragma warning disable LA0001 // Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
 #pragma warning disable CA1305 // Specify IFormatProvider
 

--- a/src/LegacySupport/TrimAttributes/DynamicDependencyAttribute.cs
+++ b/src/LegacySupport/TrimAttributes/DynamicDependencyAttribute.cs
@@ -8,7 +8,6 @@
 #pragma warning disable SA1512
 #pragma warning disable SA1623
 #pragma warning disable SA1642
-#pragma warning disable S3903
 
 namespace System.Diagnostics.CodeAnalysis;
 

--- a/src/LegacySupport/TrimAttributes/DynamicallyAccessedMemberTypes.cs
+++ b/src/LegacySupport/TrimAttributes/DynamicallyAccessedMemberTypes.cs
@@ -5,7 +5,6 @@
 #pragma warning disable CA2217
 #pragma warning disable SA1413
 #pragma warning disable SA1512
-#pragma warning disable S4070
 
 namespace System.Diagnostics.CodeAnalysis;
 

--- a/src/LegacySupport/TrimAttributes/DynamicallyAccessedMembersAttribute.cs
+++ b/src/LegacySupport/TrimAttributes/DynamicallyAccessedMembersAttribute.cs
@@ -8,7 +8,6 @@
 #pragma warning disable SA1512
 #pragma warning disable SA1623
 #pragma warning disable SA1642
-#pragma warning disable S3903
 
 namespace System.Diagnostics.CodeAnalysis;
 

--- a/src/LegacySupport/TrimAttributes/RequiresAssemblyFilesAttribute.cs
+++ b/src/LegacySupport/TrimAttributes/RequiresAssemblyFilesAttribute.cs
@@ -8,8 +8,6 @@
 #pragma warning disable SA1512
 #pragma warning disable SA1623
 #pragma warning disable SA1642
-#pragma warning disable S3903
-#pragma warning disable S3996
 
 namespace System.Diagnostics.CodeAnalysis;
 

--- a/src/LegacySupport/TrimAttributes/RequiresDynamicCodeAttribute.cs
+++ b/src/LegacySupport/TrimAttributes/RequiresDynamicCodeAttribute.cs
@@ -8,8 +8,6 @@
 #pragma warning disable SA1512
 #pragma warning disable SA1623
 #pragma warning disable SA1642
-#pragma warning disable S3903
-#pragma warning disable S3996
 
 namespace System.Diagnostics.CodeAnalysis;
 

--- a/src/LegacySupport/TrimAttributes/RequiresUnreferencedCodeAttribute.cs
+++ b/src/LegacySupport/TrimAttributes/RequiresUnreferencedCodeAttribute.cs
@@ -8,8 +8,6 @@
 #pragma warning disable SA1512
 #pragma warning disable SA1623
 #pragma warning disable SA1642
-#pragma warning disable S3903
-#pragma warning disable S3996
 
 namespace System.Diagnostics.CodeAnalysis;
 

--- a/src/LegacySupport/TrimAttributes/UnconditionalSuppressMessageAttribute.cs
+++ b/src/LegacySupport/TrimAttributes/UnconditionalSuppressMessageAttribute.cs
@@ -8,7 +8,6 @@
 #pragma warning disable SA1512
 #pragma warning disable SA1623
 #pragma warning disable SA1642
-#pragma warning disable S3903
 
 namespace System.Diagnostics.CodeAnalysis;
 

--- a/src/Libraries/.editorconfig
+++ b/src/Libraries/.editorconfig
@@ -497,7 +497,7 @@ dotnet_diagnostic.CA1507.severity = warning
 # Title    : Avoid dead conditional code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
-dotnet_diagnostic.CA1508.severity = suggestion
+dotnet_diagnostic.CA1508.severity = none
 
 # Title    : Invalid entry in code metrics rule specification file
 # Category : Maintainability
@@ -2915,2309 +2915,391 @@ dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
 # Redundant: IDE1006
-dotnet_diagnostic.S100.severity = none
-
-# Title    : Method overrides should not change parameter defaults
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
-dotnet_diagnostic.S1006.severity = warning
 
 # Title    : Types should be named in PascalCase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
 # Redundant: IDE1006
-dotnet_diagnostic.S101.severity = none
-
-# Title    : Lines should not be too long
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
-dotnet_diagnostic.S103.severity = suggestion
-
-# Title    : Files should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
-dotnet_diagnostic.S104.severity = none
 
 # Title    : Finalizers should not throw exceptions
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
 # Redundant: CA1065
-dotnet_diagnostic.S1048.severity = none
 
 # Title    : Tabulation characters should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
 # Redundant: SA1027
-dotnet_diagnostic.S105.severity = none
-
-# Title    : Standard outputs should not be used directly to log anything
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
-dotnet_diagnostic.S106.severity = warning
-
-# Title    : Collapsible "if" statements should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
-dotnet_diagnostic.S1066.severity = none
-
-# Title    : Expressions should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
-dotnet_diagnostic.S1067.severity = suggestion
-
-# Title    : Methods should not have too many parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
-dotnet_diagnostic.S107.severity = none
-
-# Title    : URIs should not be hardcoded
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
-dotnet_diagnostic.S1075.severity = warning
-
-# Title    : Nested blocks of code should not be left empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
-dotnet_diagnostic.S108.severity = warning
-
-# Title    : Magic numbers should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
-dotnet_diagnostic.S109.severity = suggestion
-
-# Title    : Inheritance tree of classes should not be too deep
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
-dotnet_diagnostic.S110.severity = warning
 
 # Title    : Fields should not have public accessibility
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
 # Redundant: CA1051
-dotnet_diagnostic.S1104.severity = none
 
 # Title    : A close curly brace should be located at the beginning of a line
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
 # Redundant: SA1500
-dotnet_diagnostic.S1109.severity = none
 
 # Title    : Redundant pairs of parentheses should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
 # Redundant: SA1119
-dotnet_diagnostic.S1110.severity = none
 
 # Title    : Empty statements should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
 # Redundant: SA1106
-dotnet_diagnostic.S1116.severity = none
-
-# Title    : Local variables should not shadow class fields or properties
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
-dotnet_diagnostic.S1117.severity = warning
 
 # Title    : Utility classes should not have public constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
 # Redundant: CA1052
-dotnet_diagnostic.S1118.severity = none
 
 # Title    : General exceptions should never be thrown
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
 # Redundant: CA2219
-dotnet_diagnostic.S112.severity = none
-
-# Title    : Assignments should not be made from within sub-expressions
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
-dotnet_diagnostic.S1121.severity = suggestion
 
 # Title    : "Obsolete" attributes should include explanations
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
 # Redundant: CA1041
-dotnet_diagnostic.S1123.severity = none
-
-# Title    : Boolean literals should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
-dotnet_diagnostic.S1125.severity = warning
-
-# Title    : Unused "using" should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
-dotnet_diagnostic.S1128.severity = warning
-
-# Title    : Files should contain an empty newline at the end
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
-dotnet_diagnostic.S113.severity = none
-
-# Title    : Deprecated code should be removed
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1133
-dotnet_diagnostic.S1133.severity = suggestion
-
-# Title    : Track uses of "FIXME" tags
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
-dotnet_diagnostic.S1134.severity = warning
-
-# Title    : Track uses of "TODO" tags
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
-dotnet_diagnostic.S1135.severity = warning
-
-# Title    : Unused private types or members should be removed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
-dotnet_diagnostic.S1144.severity = warning
-
-# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
-dotnet_diagnostic.S1145.severity = warning
-
-# Title    : Exit methods should not be called
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
-dotnet_diagnostic.S1147.severity = warning
-
-# Title    : "switch case" clauses should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
-dotnet_diagnostic.S1151.severity = none
-
-# Title    : "Any()" should be used to test for emptiness
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
-dotnet_diagnostic.S1155.severity = warning
 
 # Title    : Exceptions should not be thrown in finally blocks
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
 # Redundant: CA2219
-dotnet_diagnostic.S1163.severity = none
-
-# Title    : Empty arrays and collections should be returned instead of null
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
-dotnet_diagnostic.S1168.severity = warning
 
 # Title    : Unused method parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
 # Redundant: IDE0060
-dotnet_diagnostic.S1172.severity = none
-
-# Title    : Overriding members should do more than simply call the same member in the base class
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
-dotnet_diagnostic.S1185.severity = warning
-
-# Title    : Methods should not be empty
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
-dotnet_diagnostic.S1186.severity = warning
-
-# Title    : String literals should not be duplicated
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
-dotnet_diagnostic.S1192.severity = suggestion
-
-# Title    : Nested code blocks should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
-dotnet_diagnostic.S1199.severity = warning
-
-# Title    : Classes should not be coupled to too many other classes
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
-dotnet_diagnostic.S1200.severity = none
 
 # Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
 # Redundant: CS0659
-dotnet_diagnostic.S1206.severity = none
 
 # Title    : Control structures should use curly braces
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
 # Redundant: SA1503
-dotnet_diagnostic.S121.severity = none
 
 # Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
 # Redundant: CA1036
-dotnet_diagnostic.S1210.severity = none
-
-# Title    : "GC.Collect" should not be called
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
-dotnet_diagnostic.S1215.severity = warning
-
-# Title    : Statements should be on separate lines
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
-dotnet_diagnostic.S122.severity = none
-
-# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
-dotnet_diagnostic.S1226.severity = warning
-
-# Title    : break statements should not be used except for switch cases
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
-dotnet_diagnostic.S1227.severity = none
-
-# Title    : Floating point numbers should not be tested for equality
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
-dotnet_diagnostic.S1244.severity = error
-
-# Title    : Sections of code should not be commented out
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
-dotnet_diagnostic.S125.severity = warning
-
-# Title    : "if ... else if" constructs should end with "else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
-dotnet_diagnostic.S126.severity = none
-
-# Title    : A "while" loop should be used instead of a "for" loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
-dotnet_diagnostic.S1264.severity = warning
-
-# Title    : "for" loop stop conditions should be invariant
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
-dotnet_diagnostic.S127.severity = warning
-
-# Title    : "switch" statements should have at least 3 "case" clauses
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
-dotnet_diagnostic.S1301.severity = none
 
 # Title    : Track uses of in-source issue suppressions
 # Category : Info Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
 # Comment  : Suppressions are frequently necessary.
-dotnet_diagnostic.S1309.severity = none
-
-# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
-dotnet_diagnostic.S131.severity = none
-
-# Title    : Using hardcoded IP addresses is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
-dotnet_diagnostic.S1313.severity = warning
-
-# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
-dotnet_diagnostic.S134.severity = none
-
-# Title    : Functions should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
-dotnet_diagnostic.S138.severity = none
-
-# Title    : Culture should be specified for "string" operations
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
-dotnet_diagnostic.S1449.severity = warning
-
-# Title    : Private fields only used as local variables in methods should become local variables
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
-dotnet_diagnostic.S1450.severity = warning
 
 # Title    : Track lack of copyright and license headers
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
 # Redundant: IDE0073
-dotnet_diagnostic.S1451.severity = none
-
-# Title    : "switch" statements should not have too many "case" clauses
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
-dotnet_diagnostic.S1479.severity = warning
 
 # Title    : Unused local variables should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
 # Redundant: CS0168
-dotnet_diagnostic.S1481.severity = none
-
-# Title    : Methods and properties should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
-dotnet_diagnostic.S1541.severity = none
-
-# Title    : Tests should not be ignored
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
-dotnet_diagnostic.S1607.severity = warning
-
-# Title    : Strings should not be concatenated using '+' in a loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
-dotnet_diagnostic.S1643.severity = warning
-
-# Title    : Variables should not be self-assigned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
-dotnet_diagnostic.S1656.severity = warning
-
-# Title    : Multiple variables should not be declared on the same line
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
-dotnet_diagnostic.S1659.severity = suggestion
-
-# Title    : An abstract class should have both abstract and concrete methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
-dotnet_diagnostic.S1694.severity = suggestion
-
-# Title    : NullReferenceException should not be caught
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
-dotnet_diagnostic.S1696.severity = warning
-
-# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
-dotnet_diagnostic.S1697.severity = warning
-
-# Title    : "==" should not be used when "Equals" is overridden
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
-dotnet_diagnostic.S1698.severity = warning
-
-# Title    : Constructors should only call non-overridable methods
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
-dotnet_diagnostic.S1699.severity = warning
-
-# Title    : Loops with at most one iteration should be refactored
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
-dotnet_diagnostic.S1751.severity = warning
-
-# Title    : Identical expressions should not be used on both sides of operators
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
-dotnet_diagnostic.S1764.severity = warning
-
-# Title    : "switch" statements should not be nested
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
-dotnet_diagnostic.S1821.severity = none
-
-# Title    : Objects should not be created to be dropped immediately without being used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
-dotnet_diagnostic.S1848.severity = warning
 
 # Title    : Unused assignments should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
 # Redundant: IDE0059
-dotnet_diagnostic.S1854.severity = none
-
-# Title    : "ToString()" calls should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
-dotnet_diagnostic.S1858.severity = warning
-
-# Title    : Related "if/else if" statements should not have the same condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
-dotnet_diagnostic.S1862.severity = warning
-
-# Title    : Two branches in a conditional structure should not have exactly the same implementation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
-dotnet_diagnostic.S1871.severity = warning
 
 # Title    : Redundant casts should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
 # Redundant: IDE0004
-dotnet_diagnostic.S1905.severity = none
-
-# Title    : Inheritance list should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
-dotnet_diagnostic.S1939.severity = warning
-
-# Title    : Boolean checks should not be inverted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
-dotnet_diagnostic.S1940.severity = warning
-
-# Title    : Invalid casts should be avoided
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
-dotnet_diagnostic.S1944.severity = warning
-
-# Title    : "for" loop increment clauses should modify the loops' counters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
-dotnet_diagnostic.S1994.severity = suggestion
 
 # Title    : Hashes should include an unpredictable salt
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S2053.severity = none
-
-# Title    : Hard-coded credentials are security-sensitive
-# Category : Blocker Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
-dotnet_diagnostic.S2068.severity = warning
 
 # Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
 # Redundant: CA5350
-dotnet_diagnostic.S2070.severity = none
-
-# Title    : Formatting SQL queries is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
-dotnet_diagnostic.S2077.severity = warning
-
-# Title    : Creating cookies without the "secure" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
-dotnet_diagnostic.S2092.severity = warning
-
-# Title    : Classes should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2094
-dotnet_diagnostic.S2094.severity = none
-
-# Title    : Collections should not be passed as arguments to their own methods
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
-dotnet_diagnostic.S2114.severity = warning
-
-# Title    : A secure password should be used when connecting to a database
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
-dotnet_diagnostic.S2115.severity = warning
-
-# Title    : Values should not be uselessly incremented
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
-dotnet_diagnostic.S2123.severity = warning
-
-# Title    : Underscores should be used to make large numbers readable
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
-dotnet_diagnostic.S2148.severity = warning
-
-# Title    : "sealed" classes should not have "protected" members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
-dotnet_diagnostic.S2156.severity = warning
-
-# Title    : Classes named like "Exception" should extend "Exception" or a subclass
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2166
-dotnet_diagnostic.S2166.severity = warning
-
-# Title    : Short-circuit logic should be used in boolean contexts
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
-dotnet_diagnostic.S2178.severity = warning
-
-# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
-dotnet_diagnostic.S2183.severity = warning
-
-# Title    : Results of integer division should not be assigned to floating point variables
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
-dotnet_diagnostic.S2184.severity = warning
-
-# Title    : Test classes should contain at least one test case
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
-dotnet_diagnostic.S2187.severity = warning
-
-# Title    : Loops and recursions should not be infinite
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
-dotnet_diagnostic.S2190.severity = warning
-
-# Title    : Modulus results should not be checked for direct equality
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
-dotnet_diagnostic.S2197.severity = warning
-
-# Title    : Unnecessary mathematical comparisons should not be made
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2198
-dotnet_diagnostic.S2198.severity = warning
 
 # Title    : Methods without side effects should not have their return values ignored
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
 # Redundant: CA1806
-dotnet_diagnostic.S2201.severity = none
-
-# Title    : Runtime type checking should be simplified
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
-dotnet_diagnostic.S2219.severity = warning
-
-# Title    : "Exception" should not be caught
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
-dotnet_diagnostic.S2221.severity = none
-
-# Title    : Locks should be released on all paths
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
-dotnet_diagnostic.S2222.severity = warning
-
-# Title    : Non-constant static fields should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
-dotnet_diagnostic.S2223.severity = warning
-
-# Title    : "ToString()" method should not return null
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
-dotnet_diagnostic.S2225.severity = warning
-
-# Title    : Console logging should not be used
-# Category : Minor Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
-dotnet_diagnostic.S2228.severity = warning
-
-# Title    : Arguments should be passed in the same order as the method parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
-dotnet_diagnostic.S2234.severity = warning
-
-# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
-dotnet_diagnostic.S2245.severity = warning
-
-# Title    : A "for" loop update clause should move the counter in the right direction
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
-dotnet_diagnostic.S2251.severity = warning
-
-# Title    : For-loop conditions should be true at least once
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
-dotnet_diagnostic.S2252.severity = warning
-
-# Title    : Writing cookies is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
-dotnet_diagnostic.S2255.severity = warning
-
-# Title    : Using non-standard cryptographic algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
-dotnet_diagnostic.S2257.severity = warning
 
 # Title    : Null pointers should not be dereferenced
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
 # Comment  : Redundant, covered by modern C# compiler
-dotnet_diagnostic.S2259.severity = none
-
-# Title    : Composite format strings should not lead to unexpected behavior at runtime
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
-dotnet_diagnostic.S2275.severity = warning
-
-# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
-dotnet_diagnostic.S2278.severity = warning
-
-# Title    : Field-like events should not be virtual
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
-dotnet_diagnostic.S2290.severity = warning
-
-# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
-dotnet_diagnostic.S2291.severity = warning
 
 # Title    : Trivial properties should be auto-implemented
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
 # Redundant: IDE0032
-dotnet_diagnostic.S2292.severity = none
-
-# Title    : "nameof" should be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
-dotnet_diagnostic.S2302.severity = warning
-
-# Title    : "async" and "await" should not be used as identifiers
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
-dotnet_diagnostic.S2306.severity = warning
 
 # Title    : Methods and properties that don't access instance data should be static
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
 # Redundant: CA1822
-dotnet_diagnostic.S2325.severity = none
 
 # Title    : Unused type parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
 # Comment  : Valid pattern used in a number of places
-dotnet_diagnostic.S2326.severity = none
-
-# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
-dotnet_diagnostic.S2327.severity = warning
-
-# Title    : "GetHashCode" should not reference mutable fields
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
-dotnet_diagnostic.S2328.severity = warning
-
-# Title    : Array covariance should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
-dotnet_diagnostic.S2330.severity = warning
-
-# Title    : Redundant modifiers should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
-dotnet_diagnostic.S2333.severity = suggestion
-
-# Title    : Public constant members should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
-dotnet_diagnostic.S2339.severity = none
-
-# Title    : Enumeration types should comply with a naming convention
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
-dotnet_diagnostic.S2342.severity = none
-
-# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
-dotnet_diagnostic.S2344.severity = warning
-
-# Title    : Flags enumerations should explicitly initialize all their members
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
-dotnet_diagnostic.S2345.severity = warning
 
 # Title    : Flags enumerations zero-value members should be named "None"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
 # Redundant: CA1008
-dotnet_diagnostic.S2346.severity = none
 
 # Title    : Fields should be private
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
 # Redundant: CA1051
-dotnet_diagnostic.S2357.severity = none
-
-# Title    : Optional parameters should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
-dotnet_diagnostic.S2360.severity = none
-
-# Title    : Properties should not make collection or array copies
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
-dotnet_diagnostic.S2365.severity = warning
-
-# Title    : Public methods should not have multidimensional array parameters
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
-dotnet_diagnostic.S2368.severity = warning
-
-# Title    : Exceptions should not be thrown from property getters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
-dotnet_diagnostic.S2372.severity = warning
-
-# Title    : Write-only properties should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
-dotnet_diagnostic.S2376.severity = warning
-
-# Title    : Mutable fields should not be "public static"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
-dotnet_diagnostic.S2386.severity = warning
-
-# Title    : Child class fields should not shadow parent class fields
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
-dotnet_diagnostic.S2387.severity = warning
 
 # Title    : Types and methods should not have too many generic parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
 # Redundant: CA1005
-dotnet_diagnostic.S2436.severity = none
-
-# Title    : Unnecessary bit operations should not be performed
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
-dotnet_diagnostic.S2437.severity = warning
 
 # Title    : Blocks should be synchronized on read-only fields
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2445
 # Comment  : Noise
-dotnet_diagnostic.S2445.severity = none
-
-# Title    : Whitespace and control characters in string literals should be explicit
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
-dotnet_diagnostic.S2479.severity = warning
-
-# Title    : Generic exceptions should not be ignored
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
-dotnet_diagnostic.S2486.severity = warning
-
-# Title    : Shared resources should not be used for locking
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
-dotnet_diagnostic.S2551.severity = warning
 
 # Title    : Conditionally executed code should be reachable
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
 # Redundant: CA1508
-dotnet_diagnostic.S2583.severity = none
 
 # Title    : Boolean expressions should not be gratuitous
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
 # Comment  : Too many false positives.
-dotnet_diagnostic.S2589.severity = none
-
-# Title    : Setting loose file permissions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
-dotnet_diagnostic.S2612.severity = warning
-
-# Title    : The length returned from a stream read should be checked
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
-dotnet_diagnostic.S2674.severity = warning
-
-# Title    : Multiline blocks should be enclosed in curly braces
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
-dotnet_diagnostic.S2681.severity = warning
-
-# Title    : "NaN" should not be used in comparisons
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
-dotnet_diagnostic.S2688.severity = warning
-
-# Title    : "IndexOf" checks should not be for positive numbers
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
-dotnet_diagnostic.S2692.severity = warning
-
-# Title    : Instance members should not write to "static" fields
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
-dotnet_diagnostic.S2696.severity = warning
-
-# Title    : Tests should include assertions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
-dotnet_diagnostic.S2699.severity = warning
-
-# Title    : Literal boolean values should not be used in assertions
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
-dotnet_diagnostic.S2701.severity = warning
-
-# Title    : "catch" clauses should do more than rethrow
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
-dotnet_diagnostic.S2737.severity = warning
-
-# Title    : Static fields should not be used in generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
-dotnet_diagnostic.S2743.severity = none
-
-# Title    : XML parsers should not be vulnerable to XXE attacks
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
-dotnet_diagnostic.S2755.severity = warning
-
-# Title    : Non-existent operators like "=+" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
-dotnet_diagnostic.S2757.severity = warning
-
-# Title    : The ternary operator should not return the same value regardless of the condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
-dotnet_diagnostic.S2758.severity = warning
-
-# Title    : Sequential tests should not check the same condition
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
-dotnet_diagnostic.S2760.severity = warning
-
-# Title    : Doubled prefix operators "!!" and "~~" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
-dotnet_diagnostic.S2761.severity = warning
-
-# Title    : SQL keywords should be delimited by whitespace
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
-dotnet_diagnostic.S2857.severity = warning
-
-# Title    : "Thread.Sleep" should not be used in tests
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2925
-dotnet_diagnostic.S2925.severity = none
 
 # Title    : "IDisposables" should be disposed
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
 # Redundant: CA2000
-dotnet_diagnostic.S2930.severity = none
 
 # Title    : Classes with "IDisposable" members should implement "IDisposable"
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
 # Redundant: CA1001
-dotnet_diagnostic.S2931.severity = none
 
 # Title    : Fields that are only assigned in the constructor should be "readonly"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
 # Redundant: IDE0044
-dotnet_diagnostic.S2933.severity = none
-
-# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
-dotnet_diagnostic.S2934.severity = warning
-
-# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
-dotnet_diagnostic.S2952.severity = warning
-
-# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
-dotnet_diagnostic.S2953.severity = warning
-
-# Title    : Generic parameters not constrained to reference types should not be compared to "null"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
-dotnet_diagnostic.S2955.severity = warning
-
-# Title    : Assertions should be complete
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2970
-dotnet_diagnostic.S2970.severity = warning
-
-# Title    : "IEnumerable" LINQs should be simplified
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
-dotnet_diagnostic.S2971.severity = warning
-
-# Title    : "Object.ReferenceEquals" should not be used for value types
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
-dotnet_diagnostic.S2995.severity = warning
-
-# Title    : "ThreadStatic" fields should not be initialized
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
-dotnet_diagnostic.S2996.severity = warning
-
-# Title    : "IDisposables" created in a "using" statement should not be returned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
-dotnet_diagnostic.S2997.severity = warning
-
-# Title    : "ThreadStatic" should not be used on non-static fields
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
-dotnet_diagnostic.S3005.severity = warning
-
-# Title    : Static fields should not be updated in constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
-dotnet_diagnostic.S3010.severity = warning
-
-# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
-dotnet_diagnostic.S3011.severity = warning
 
 # Title    : Members should not be initialized to default values
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
 # Redundant: CA1805
-dotnet_diagnostic.S3052.severity = none
-
-# Title    : Types should not have members with visibility set higher than the type's visibility
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
-dotnet_diagnostic.S3059.severity = none
-
-# Title    : "is" should not be used with "this"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
-dotnet_diagnostic.S3060.severity = warning
-
-# Title    : "StringBuilder" data should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3063
-dotnet_diagnostic.S3063.severity = warning
 
 # Title    : "async" methods should not return "void"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
 # Redundant: VSTHRD100
-dotnet_diagnostic.S3168.severity = none
-
-# Title    : Multiple "OrderBy" calls should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
-dotnet_diagnostic.S3169.severity = warning
-
-# Title    : Delegates should not be subtracted
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
-dotnet_diagnostic.S3172.severity = warning
-
-# Title    : "interface" instances should not be cast to concrete types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
-dotnet_diagnostic.S3215.severity = warning
 
 # Title    : "ConfigureAwait(false)" should be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
 # Redundant: CA2007
-dotnet_diagnostic.S3216.severity = none
-
-# Title    : "Explicit" conversions of "foreach" loops should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
-dotnet_diagnostic.S3217.severity = warning
-
-# Title    : Inner class members should not shadow outer class "static" or type members
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
-dotnet_diagnostic.S3218.severity = warning
-
-# Title    : Method calls should not resolve ambiguously to overloads with "params"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
-dotnet_diagnostic.S3220.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
-dotnet_diagnostic.S3234.severity = warning
-
-# Title    : Redundant parentheses should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
-dotnet_diagnostic.S3235.severity = warning
-
-# Title    : Caller information arguments should not be provided explicitly
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
-dotnet_diagnostic.S3236.severity = warning
-
-# Title    : "value" contextual keyword should be used
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
-dotnet_diagnostic.S3237.severity = warning
 
 # Title    : The simplest possible condition syntax should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
 # Redundant: IDE0054
-dotnet_diagnostic.S3240.severity = none
-
-# Title    : Methods should not return values that are never used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
-dotnet_diagnostic.S3241.severity = warning
 
 # Title    : Method parameters should be declared with base types
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
 # Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
-dotnet_diagnostic.S3242.severity = none
-
-# Title    : Anonymous delegates should not be used to unsubscribe from Events
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
-dotnet_diagnostic.S3244.severity = warning
-
-# Title    : Generic type parameters should be co/contravariant when possible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
-dotnet_diagnostic.S3246.severity = warning
-
-# Title    : Duplicate casts should not be made
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
-dotnet_diagnostic.S3247.severity = none
-
-# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
-dotnet_diagnostic.S3249.severity = warning
-
-# Title    : Implementations should be provided for "partial" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
-dotnet_diagnostic.S3251.severity = warning
-
-# Title    : Constructor and destructor declarations should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
-dotnet_diagnostic.S3253.severity = suggestion
-
-# Title    : Default parameter values should not be passed as arguments
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
-dotnet_diagnostic.S3254.severity = warning
-
-# Title    : "string.IsNullOrEmpty" should be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
-dotnet_diagnostic.S3256.severity = warning
 
 # Title    : Declarations and initializations should be as concise as possible
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
 # Comment  : Too many false positives
-dotnet_diagnostic.S3257.severity = none
 
 # Title    : Non-derived "private" classes and records should be "sealed"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
 # Redundant: R9A013
-dotnet_diagnostic.S3260.severity = none
-
-# Title    : Namespaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
-dotnet_diagnostic.S3261.severity = warning
-
-# Title    : "params" should be used on overrides
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
-dotnet_diagnostic.S3262.severity = warning
-
-# Title    : Static fields should appear in the order they must be initialized 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
-dotnet_diagnostic.S3263.severity = warning
-
-# Title    : Events should be invoked
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
-dotnet_diagnostic.S3264.severity = warning
-
-# Title    : Non-flags enums should not be used in bitwise operations
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
-dotnet_diagnostic.S3265.severity = warning
-
-# Title    : Loops should be simplified with "LINQ" expressions
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
-dotnet_diagnostic.S3267.severity = none
 
 # Title    : Cipher Block Chaining IVs should be unpredictable
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S3329.severity = none
-
-# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
-dotnet_diagnostic.S3330.severity = warning
-
-# Title    : Caller information parameters should come at the end of the parameter list
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
-dotnet_diagnostic.S3343.severity = warning
-
-# Title    : Expressions used in "Debug.Assert" should not produce side effects
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
-dotnet_diagnostic.S3346.severity = warning
-
-# Title    : Unchanged local variables should be "const"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
-dotnet_diagnostic.S3353.severity = warning
-
-# Title    : Ternary operators should not be nested
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
-dotnet_diagnostic.S3358.severity = suggestion
-
-# Title    : Date and time should not be used as a type for primary keys
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3363
-dotnet_diagnostic.S3363.severity = warning
-
-# Title    : "this" should not be exposed from constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
-dotnet_diagnostic.S3366.severity = warning
 
 # Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
 # Redundant: CA1710
-dotnet_diagnostic.S3376.severity = none
-
-# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
-dotnet_diagnostic.S3397.severity = warning
-
-# Title    : "private" methods called only by inner classes should be moved to those classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3398
-dotnet_diagnostic.S3398.severity = warning
-
-# Title    : Methods should not return constants
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
-dotnet_diagnostic.S3400.severity = warning
-
-# Title    : Assertion arguments should be passed in the correct order
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
-dotnet_diagnostic.S3415.severity = warning
-
-# Title    : Method overloads with default parameter values should not overlap
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
-dotnet_diagnostic.S3427.severity = warning
-
-# Title    : "[ExpectedException]" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
-dotnet_diagnostic.S3431.severity = warning
-
-# Title    : Test method signatures should be correct
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
-dotnet_diagnostic.S3433.severity = warning
-
-# Title    : Variables should not be checked against the values they're about to be assigned
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
-dotnet_diagnostic.S3440.severity = warning
-
-# Title    : Redundant property names should be omitted in anonymous classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
-dotnet_diagnostic.S3441.severity = warning
-
-# Title    : "abstract" classes should not have "public" constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
-dotnet_diagnostic.S3442.severity = warning
-
-# Title    : Type should not be examined on "System.Type" instances
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
-dotnet_diagnostic.S3443.severity = warning
-
-# Title    : Interfaces should not simply inherit from base interfaces with colliding members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
-dotnet_diagnostic.S3444.severity = warning
-
-# Title    : Exceptions should not be explicitly rethrown
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
-dotnet_diagnostic.S3445.severity = warning
-
-# Title    : "[Optional]" should not be used on "ref" or "out" parameters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
-dotnet_diagnostic.S3447.severity = warning
-
-# Title    : Right operands of shift operators should be integers
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
-dotnet_diagnostic.S3449.severity = warning
-
-# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
-dotnet_diagnostic.S3450.severity = warning
-
-# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
-dotnet_diagnostic.S3451.severity = warning
-
-# Title    : Classes should not have only "private" constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
-dotnet_diagnostic.S3453.severity = warning
-
-# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
-dotnet_diagnostic.S3456.severity = warning
-
-# Title    : Composite format strings should be used correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
-dotnet_diagnostic.S3457.severity = warning
-
-# Title    : Empty "case" clauses that fall through to the "default" should be omitted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
-dotnet_diagnostic.S3458.severity = warning
-
-# Title    : Unassigned members should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
-dotnet_diagnostic.S3459.severity = warning
-
-# Title    : Type inheritance should not be recursive
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
-dotnet_diagnostic.S3464.severity = warning
-
-# Title    : Optional parameters should be passed to "base" calls
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
-dotnet_diagnostic.S3466.severity = warning
-
-# Title    : Empty "default" clauses should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
-dotnet_diagnostic.S3532.severity = warning
-
-# Title    : "ServiceContract" and "OperationContract" attributes should be used together
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
-dotnet_diagnostic.S3597.severity = warning
-
-# Title    : One-way "OperationContract" methods should have "void" return type
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
-dotnet_diagnostic.S3598.severity = warning
-
-# Title    : "params" should not be introduced on overrides
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
-dotnet_diagnostic.S3600.severity = warning
-
-# Title    : Methods with "Pure" attribute should return a value 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
-dotnet_diagnostic.S3603.severity = warning
-
-# Title    : Member initializer values should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
-dotnet_diagnostic.S3604.severity = suggestion
-
-# Title    : Nullable type comparison should not be redundant
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
-dotnet_diagnostic.S3610.severity = warning
-
-# Title    : Jump statements should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
-dotnet_diagnostic.S3626.severity = warning
-
-# Title    : Empty nullable value should not be accessed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
-dotnet_diagnostic.S3655.severity = warning
-
-# Title    : Exception constructors should not throw exceptions
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
-dotnet_diagnostic.S3693.severity = warning
-
-# Title    : Track use of "NotImplementedException"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
-dotnet_diagnostic.S3717.severity = warning
 
 # Title    : Cognitive Complexity of methods should not be too high
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
 # Comment  : Code gets complicated
-dotnet_diagnostic.S3776.severity = none
-
-# Title    : "SafeHandle.DangerousGetHandle" should not be called
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
-dotnet_diagnostic.S3869.severity = warning
 
 # Title    : Exception types should be "public"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
 # Redundant: CA1064
-dotnet_diagnostic.S3871.severity = none
-
-# Title    : Parameter names should not duplicate the names of their methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
-dotnet_diagnostic.S3872.severity = warning
 
 # Title    : "out" and "ref" parameters should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
 # Redundant: CA1021
-dotnet_diagnostic.S3874.severity = none
-
-# Title    : "operator==" should not be overloaded on reference types
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
-dotnet_diagnostic.S3875.severity = warning
-
-# Title    : Strings or integral types should be used for indexers
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
-dotnet_diagnostic.S3876.severity = warning
-
-# Title    : Exceptions should not be thrown from unexpected methods
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
-dotnet_diagnostic.S3877.severity = warning
-
-# Title    : Arrays should not be created for params parameters
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3878
-dotnet_diagnostic.S3878.severity = suggestion
-
-# Title    : Finalizers should not be empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
-dotnet_diagnostic.S3880.severity = warning
-
-# Title    : "IDisposable" should be implemented correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
-dotnet_diagnostic.S3881.severity = none
-
-# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
-dotnet_diagnostic.S3884.severity = warning
-
-# Title    : "Assembly.Load" should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
-dotnet_diagnostic.S3885.severity = warning
-
-# Title    : Mutable, non-private fields should not be "readonly"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
-dotnet_diagnostic.S3887.severity = warning
-
-# Title    : "Thread.Resume" and "Thread.Suspend" should not be used
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
-dotnet_diagnostic.S3889.severity = warning
-
-# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
-dotnet_diagnostic.S3897.severity = warning
-
-# Title    : Value types should implement "IEquatable<T>"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
-dotnet_diagnostic.S3898.severity = none
 
 # Title    : Arguments of public methods should be validated against null
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
 # Redundant: CA1062
-dotnet_diagnostic.S3900.severity = none
-
-# Title    : "Assembly.GetExecutingAssembly" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
-dotnet_diagnostic.S3902.severity = warning
 
 # Title    : Types should be defined in named namespaces
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
 # Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
-dotnet_diagnostic.S3903.severity = none
-
-# Title    : Assemblies should have version information
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
-dotnet_diagnostic.S3904.severity = warning
-
-# Title    : Event Handlers should have the correct signature
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
-dotnet_diagnostic.S3906.severity = warning
-
-# Title    : Generic event handlers should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
-dotnet_diagnostic.S3908.severity = warning
 
 # Title    : Collections should implement the generic interface
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
 # Redundant: CA1010
-dotnet_diagnostic.S3909.severity = none
-
-# Title    : All branches in a conditional structure should not have exactly the same implementation
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
-dotnet_diagnostic.S3923.severity = warning
 
 # Title    : "ISerializable" should be implemented correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
 # Comment  : TODO - is ISerializable still relevant?
-dotnet_diagnostic.S3925.severity = none
-
-# Title    : Deserialization methods should be provided for "OptionalField" members
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
-dotnet_diagnostic.S3926.severity = warning
-
-# Title    : Serialization event handlers should be implemented correctly
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
-dotnet_diagnostic.S3927.severity = warning
-
-# Title    : Parameter names used into ArgumentException constructors should match an existing one 
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
-dotnet_diagnostic.S3928.severity = warning
-
-# Title    : Number patterns should be regular
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
-dotnet_diagnostic.S3937.severity = warning
-
-# Title    : Calculations should not overflow
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
-dotnet_diagnostic.S3949.severity = suggestion
 
 # Title    : "Generic.List" instances should not be part of public APIs
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
 # Redundant: CA1002
-dotnet_diagnostic.S3956.severity = none
 
 # Title    : "static readonly" constants should be "const" instead
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
 # Redundant: CA1802
-dotnet_diagnostic.S3962.severity = none
 
 # Title    : "static" fields should be initialized inline
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
 # Redundant: CA1810 and CA2207
-dotnet_diagnostic.S3963.severity = none
-
-# Title    : Objects should not be disposed more than once
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
-dotnet_diagnostic.S3966.severity = warning
-
-# Title    : Multidimensional arrays should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
-dotnet_diagnostic.S3967.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
-dotnet_diagnostic.S3971.severity = warning
-
-# Title    : Conditionals should start on new lines
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
-dotnet_diagnostic.S3972.severity = warning
-
-# Title    : A conditionally executed single line should be denoted by indentation
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
-dotnet_diagnostic.S3973.severity = warning
-
-# Title    : Collection sizes and array length comparisons should make sense
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
-dotnet_diagnostic.S3981.severity = warning
-
-# Title    : Exceptions should not be created without being thrown
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
-dotnet_diagnostic.S3984.severity = warning
 
 # Title    : Assemblies should be marked as CLS compliant
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
 # Redundant: CA1014
-dotnet_diagnostic.S3990.severity = none
 
 # Title    : Assemblies should explicitly specify COM visibility
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
 # Redundant: CA1017
-dotnet_diagnostic.S3992.severity = none
 
 # Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
 # Redundant: CA1018
-dotnet_diagnostic.S3993.severity = none
-
-# Title    : URI Parameters should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
-dotnet_diagnostic.S3994.severity = none
-
-# Title    : URI return values should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
-dotnet_diagnostic.S3995.severity = suggestion
-
-# Title    : URI properties should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
-dotnet_diagnostic.S3996.severity = suggestion
-
-# Title    : String URI overloads should call "System.Uri" overloads
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
-dotnet_diagnostic.S3997.severity = warning
-
-# Title    : Threads should not lock on objects with weak identity
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
-dotnet_diagnostic.S3998.severity = warning
-
-# Title    : Pointers to unmanaged memory should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
-dotnet_diagnostic.S4000.severity = warning
-
-# Title    : Disposable types should declare finalizers
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
-dotnet_diagnostic.S4002.severity = warning
 
 # Title    : Collection properties should be readonly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
 # Redundant: CA2227
-dotnet_diagnostic.S4004.severity = none
 
 # Title    : "System.Uri" arguments should be used instead of strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
 # Redundant: CA2234
-dotnet_diagnostic.S4005.severity = none
-
-# Title    : Inherited member visibility should not be decreased
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
-dotnet_diagnostic.S4015.severity = warning
-
-# Title    : Enumeration members should not be named "Reserved"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
-dotnet_diagnostic.S4016.severity = warning
-
-# Title    : Method signatures should not contain nested generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
-dotnet_diagnostic.S4017.severity = none
-
-# Title    : All type parameters should be used in the parameter list to enable type inference
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
-dotnet_diagnostic.S4018.severity = none
-
-# Title    : Base class methods should not be hidden
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
-dotnet_diagnostic.S4019.severity = warning
-
-# Title    : Enumerations should have "Int32" storage
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
-dotnet_diagnostic.S4022.severity = warning
-
-# Title    : Interfaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
-dotnet_diagnostic.S4023.severity = suggestion
-
-# Title    : Child class fields should not differ from parent class fields only by capitalization
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
-dotnet_diagnostic.S4025.severity = warning
-
-# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
-dotnet_diagnostic.S4026.severity = warning
 
 # Title    : Exceptions should provide standard constructors
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
 # Redundant: CA1032
-dotnet_diagnostic.S4027.severity = none
-
-# Title    : Classes implementing "IEquatable<T>" should be sealed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
-dotnet_diagnostic.S4035.severity = warning
-
-# Title    : Searching OS commands in PATH is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
-dotnet_diagnostic.S4036.severity = warning
-
-# Title    : Interface methods should be callable by derived types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
-dotnet_diagnostic.S4039.severity = warning
 
 # Title    : Strings should be normalized to uppercase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
 # Redundant: CA1308
-dotnet_diagnostic.S4040.severity = none
-
-# Title    : Type names should not match namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
-dotnet_diagnostic.S4041.severity = warning
-
-# Title    : Generics should be used when appropriate
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
-dotnet_diagnostic.S4047.severity = warning
 
 # Title    : Properties should be preferred
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
 # Redundant: CA1024
-dotnet_diagnostic.S4049.severity = none
-
-# Title    : Operators should be overloaded consistently
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
-dotnet_diagnostic.S4050.severity = warning
-
-# Title    : Types should not extend outdated base types
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
-dotnet_diagnostic.S4052.severity = warning
-
-# Title    : Literals should not be passed as localized parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
-dotnet_diagnostic.S4055.severity = none
 
 # Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
 # Redundant: CA1305
-dotnet_diagnostic.S4056.severity = none
-
-# Title    : Locales should be set for data types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
-dotnet_diagnostic.S4057.severity = warning
 
 # Title    : Overloads with a "StringComparison" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
 # Redundant: CA1310
-dotnet_diagnostic.S4058.severity = none
-
-# Title    : Property names should not match get methods
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
-dotnet_diagnostic.S4059.severity = warning
 
 # Title    : Non-abstract attributes should be sealed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
 # Redundant: CA1813
-dotnet_diagnostic.S4060.severity = none
-
-# Title    : "params" should be used instead of "varargs"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
-dotnet_diagnostic.S4061.severity = warning
 
 # Title    : Operator overloads should have named alternatives
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
 # Redundant: CA2225
-dotnet_diagnostic.S4069.severity = none
 
 # Title    : Non-flags enums should not be marked with "FlagsAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
 # Redundant: CA2217
-dotnet_diagnostic.S4070.severity = none
-
-# Title    : Method overloads should be grouped together
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
-dotnet_diagnostic.S4136.severity = warning
-
-# Title    : Duplicate values should not be passed as arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
-dotnet_diagnostic.S4142.severity = warning
-
-# Title    : Collection elements should not be replaced unconditionally
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
-dotnet_diagnostic.S4143.severity = warning
-
-# Title    : Methods should not have identical implementations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
-dotnet_diagnostic.S4144.severity = warning
 
 # Title    : Empty collections should not be accessed or iterated
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
 # Comment  : Too many false positives
-dotnet_diagnostic.S4158.severity = none
-
-# Title    : Classes should implement their "ExportAttribute" interfaces
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
-dotnet_diagnostic.S4159.severity = warning
-
-# Title    : Native methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
-dotnet_diagnostic.S4200.severity = warning
-
-# Title    : Null checks should not be used with "is"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
-dotnet_diagnostic.S4201.severity = warning
-
-# Title    : Windows Forms entry points should be marked with STAThread
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
-dotnet_diagnostic.S4210.severity = warning
-
-# Title    : Members should not have conflicting transparency annotations
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
-dotnet_diagnostic.S4211.severity = warning
-
-# Title    : Serialization constructors should be secured
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
-dotnet_diagnostic.S4212.severity = warning
-
-# Title    : "P/Invoke" methods should not be visible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
-dotnet_diagnostic.S4214.severity = warning
-
-# Title    : Events should have proper arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
-dotnet_diagnostic.S4220.severity = warning
-
-# Title    : Extension methods should not extend "object"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
-dotnet_diagnostic.S4225.severity = warning
-
-# Title    : Extensions should be in separate namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
-dotnet_diagnostic.S4226.severity = none
-
-# Title    : "ConstructorArgument" parameters should exist in constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
-dotnet_diagnostic.S4260.severity = warning
-
-# Title    : Methods should be named according to their synchronicities
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
-dotnet_diagnostic.S4261.severity = none
-
-# Title    : Getters and setters should access the expected fields
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
-dotnet_diagnostic.S4275.severity = warning
-
-# Title    : "Shared" parts should not be created with "new"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
-dotnet_diagnostic.S4277.severity = warning
-
-# Title    : Weak SSL/TLS protocols should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
-dotnet_diagnostic.S4423.severity = warning
-
-# Title    : Cryptographic keys should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
-dotnet_diagnostic.S4426.severity = warning
-
-# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
-dotnet_diagnostic.S4428.severity = warning
-
-# Title    : AES encryption algorithm should be used with secured mode
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
-dotnet_diagnostic.S4432.severity = warning
-
-# Title    : LDAP connections should be authenticated
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
-dotnet_diagnostic.S4433.severity = warning
-
-# Title    : Parameter validation in yielding methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
-dotnet_diagnostic.S4456.severity = warning
-
-# Title    : Parameter validation in "async"/"await" methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
-dotnet_diagnostic.S4457.severity = warning
 
 # Title    : Calls to "async" methods should not be blocking
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
 # Redundant: VSTHRD002
-dotnet_diagnostic.S4462.severity = none
 
 # Title    : Unread "private" fields should be removed
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
 # Redundant: IDE0052
-dotnet_diagnostic.S4487.severity = none
-
-# Title    : Disabling CSRF protections is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
-dotnet_diagnostic.S4502.severity = warning
-
-# Title    : Delivering code in production with debug features activated is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
-dotnet_diagnostic.S4507.severity = warning
-
-# Title    : "default" clauses should be first or last
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
-dotnet_diagnostic.S4524.severity = warning
-
-# Title    : "DebuggerDisplayAttribute" strings should reference existing members
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4545
-dotnet_diagnostic.S4545.severity = warning
-
-# Title    : ASP.NET HTTP request validation feature should not be disabled
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
-dotnet_diagnostic.S4564.severity = warning
-
-# Title    : "new Guid()" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
-dotnet_diagnostic.S4581.severity = warning
-
-# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
-dotnet_diagnostic.S4583.severity = warning
-
-# Title    : Non-async "Task/Task<T>" methods should not return null
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
-dotnet_diagnostic.S4586.severity = warning
-
-# Title    : Start index should be used instead of calling Substring
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
-dotnet_diagnostic.S4635.severity = warning
-
-# Title    : Comments should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4663
-dotnet_diagnostic.S4663.severity = suggestion
-
-# Title    : Using regular expressions is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
-dotnet_diagnostic.S4784.severity = warning
-
-# Title    : Encrypting data is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
-dotnet_diagnostic.S4787.severity = warning
-
-# Title    : Using weak hashing algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
-dotnet_diagnostic.S4790.severity = warning
-
-# Title    : Configuring loggers is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
-dotnet_diagnostic.S4792.severity = warning
-
-# Title    : Using Sockets is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
-dotnet_diagnostic.S4818.severity = warning
-
-# Title    : Using command line arguments is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
-dotnet_diagnostic.S4823.severity = warning
-
-# Title    : Reading the Standard Input is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
-dotnet_diagnostic.S4829.severity = warning
 
 # Title    : Server certificates should be verified during SSL/TLS connections
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
 # Redundant: CA5359
-dotnet_diagnostic.S4830.severity = none
-
-# Title    : Controlling permissions is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
-dotnet_diagnostic.S4834.severity = warning
-
-# Title    : "ValueTask" should be consumed correctly
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
-dotnet_diagnostic.S5034.severity = warning
-
-# Title    : Expanding archive files without controlling resource consumption is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
-dotnet_diagnostic.S5042.severity = warning
-
-# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
-dotnet_diagnostic.S5122.severity = warning
-
-# Title    : Using clear-text protocols is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
-dotnet_diagnostic.S5332.severity = warning
-
-# Title    : Using publicly writable directories is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
-dotnet_diagnostic.S5443.severity = warning
-
-# Title    : Insecure temporary file creation methods should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
-dotnet_diagnostic.S5445.severity = warning
-
-# Title    : Encryption algorithms should be used with secure mode and padding scheme
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
-dotnet_diagnostic.S5542.severity = warning
-
-# Title    : Cipher algorithms should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
-dotnet_diagnostic.S5547.severity = warning
-
-# Title    : JWT should be signed and verified with strong cipher algorithms
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
-dotnet_diagnostic.S5659.severity = warning
-
-# Title    : Allowing requests with excessive content length is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
-dotnet_diagnostic.S5693.severity = warning
-
-# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
-dotnet_diagnostic.S5753.severity = warning
-
-# Title    : Deserializing objects without performing data validation is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
-dotnet_diagnostic.S5766.severity = warning
-
-# Title    : Types allowed to be deserialized should be restricted
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
-dotnet_diagnostic.S5773.severity = warning
-
-# Title    : Regular expressions should be syntactically valid
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5856
-dotnet_diagnostic.S5856.severity = warning
 
 # Title    : Use a testable date/time provider
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
 # Redundant: R9A022
-dotnet_diagnostic.S6354.severity = none
-
-# Title    : Azure Functions should be stateless
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
-dotnet_diagnostic.S6419.severity = warning
-
-# Title    : Client instances should not be recreated on each Azure Function invocation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
-dotnet_diagnostic.S6420.severity = warning
-
-# Title    : Azure Functions should use Structured Error Handling
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
-dotnet_diagnostic.S6421.severity = warning
-
-# Title    : Calls to "async" methods should not be blocking in Azure Functions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
-dotnet_diagnostic.S6422.severity = warning
-
-# Title    : Azure Functions should log all failures
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
-dotnet_diagnostic.S6423.severity = warning
-
-# Title    : Interfaces for durable entities should satisfy the restrictions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
-dotnet_diagnostic.S6424.severity = warning
-
-# Title    : Not specifying a timeout for regular expressions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
-dotnet_diagnostic.S6444.severity = warning
 
 # Title    : Blocks should not be synchronized on local variables
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6507
 # Comment  : Too many false positives
-dotnet_diagnostic.S6507.severity = none
-
-# Title    : "ExcludeFromCodeCoverage" attributes should include a justification
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6513
-dotnet_diagnostic.S6513.severity = suggestion
-
-# Title    : Avoid using "DateTime.Now" for benchmarking or timing operations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6561
-dotnet_diagnostic.S6561.severity = warning
 
 # Title    : Always set the "DateTimeKind" when creating new "DateTime" instances
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6562
 # Comment  : Noise
-dotnet_diagnostic.S6562.severity = none
-
-# Title    : Use UTC when recording DateTime instants
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6563
-dotnet_diagnostic.S6563.severity = none
 
 # Title    : Use "DateTimeOffset" instead of "DateTime"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6566
 # Comment  : Noise
-dotnet_diagnostic.S6566.severity = none
-
-# Title    : Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6575
-dotnet_diagnostic.S6575.severity = warning
-
-# Title    : Use a format provider when parsing date and time
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6580
-dotnet_diagnostic.S6580.severity = warning
-
-# Title    : Don't hardcode the format when turning dates and times to strings
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6585
-dotnet_diagnostic.S6585.severity = none
-
-# Title    : Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6588
-dotnet_diagnostic.S6588.severity = none
-
-# Title    : "Find" method should be used instead of the "FirstOrDefault" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6602
-dotnet_diagnostic.S6602.severity = warning
-
-# Title    : The collection-specific "TrueForAll" method should be used instead of the "All" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6603
-dotnet_diagnostic.S6603.severity = warning
-
-# Title    : Collection-specific "Exists" method should be used instead of the "Any" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6605
-dotnet_diagnostic.S6605.severity = warning
-
-# Title    : The collection should be filtered before sorting by using "Where" before "OrderBy"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6607
-dotnet_diagnostic.S6607.severity = warning
-
-# Title    : Prefer indexing instead of "Enumerable" methods on types implementing "IList"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6608
-dotnet_diagnostic.S6608.severity = warning
-
-# Title    : "Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6609
-dotnet_diagnostic.S6609.severity = warning
-
-# Title    : "StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6610
-dotnet_diagnostic.S6610.severity = warning
-
-# Title    : The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6612
-dotnet_diagnostic.S6612.severity = warning
-
-# Title    : "First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6613
-dotnet_diagnostic.S6613.severity = warning
-
-# Title    : "Contains" should be used instead of "Any" for simple equality checks
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6617
-dotnet_diagnostic.S6617.severity = warning
-
-# Title    : "string.Create" should be used instead of "FormattableString"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6618
-dotnet_diagnostic.S6618.severity = warning
-
-# Title    : Using unsafe code blocks is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6640
-dotnet_diagnostic.S6640.severity = warning
-
-# Title    : Generic logger injection should match enclosing type
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6672
-dotnet_diagnostic.S6672.severity = none
-
-# Title    : Awaitable method should be used
-# Category : Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6966
-dotnet_diagnostic.S6966.severity = none
-
-# Title    : ModelState.IsValid should be called in controller actions
-# Category : Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6967
-dotnet_diagnostic.S6967.severity = none
-
-# Title    : Literal suffixes should be upper case
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
-dotnet_diagnostic.S818.severity = warning
-
-# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
-dotnet_diagnostic.S881.severity = suggestion
-
-# Title    : "goto" statement should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
-dotnet_diagnostic.S907.severity = suggestion
 
 # Title    : Parameter names should match base declaration and other partial definitions
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
 # Redundant: CA1725
-dotnet_diagnostic.S927.severity = none
 
 # Title    : Copy-paste token calculator
 # Category : 

--- a/src/Libraries/Microsoft.AspNetCore.HeaderParsing/HeaderKey.cs
+++ b/src/Libraries/Microsoft.AspNetCore.HeaderParsing/HeaderKey.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
@@ -13,7 +13,6 @@ namespace Microsoft.AspNetCore.HeaderParsing;
 /// </summary>
 /// <typeparam name="T">The type of the header value.</typeparam>
 [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "Header keys are never disposed, so we don't bother with this.")]
-[SuppressMessage("Blocker Bug", "S2931:Classes with \"IDisposable\" members should implement \"IDisposable\"", Justification = "Header keys are never disposed, so we don't bother with this.")]
 public sealed class HeaderKey<T>
     where T : notnull
 {

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/AdditionalPropertiesDictionary{TValue}.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/AdditionalPropertiesDictionary{TValue}.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -10,7 +10,6 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.Shared.Diagnostics;
 
-#pragma warning disable S4039 // Interface methods should be callable by derived types
 #pragma warning disable CA1033 // Interface methods should be callable by derived types
 
 namespace Microsoft.Extensions.AI;
@@ -252,9 +251,7 @@ public class AdditionalPropertiesDictionary<TValue> : IDictionary<string, TValue
         private readonly AdditionalPropertiesDictionary<TValue> _properties = Throw.IfNull(properties);
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-#pragma warning disable S2365 // Properties should not make collection or array copies
         public AdditionalProperty[] Items => (from p in _properties select new AdditionalProperty(p.Key, p.Value)).ToArray();
-#pragma warning restore S2365
 
         [DebuggerDisplay("{Value}", Name = "[{Key}]")]
         public readonly struct AdditionalProperty(string key, TValue value)

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionArguments.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionArguments.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -9,7 +9,6 @@ using System.Diagnostics;
 #pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
 #pragma warning disable SA1112 // Closing parenthesis should be on line of opening parenthesis
 #pragma warning disable SA1114 // Parameter list should follow declaration
-#pragma warning disable S4039 // Make 'AIFunctionArguments' sealed
 #pragma warning disable CA1033 // Make 'AIFunctionArguments' sealed
 #pragma warning disable CA1710 // Identifiers should have correct suffix
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -21,8 +21,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Shared.Collections;
 using Microsoft.Shared.Diagnostics;
-
-#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 
 namespace Microsoft.Extensions.AI;
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.Create.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.Create.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -19,9 +19,6 @@ using System.Threading;
 using Microsoft.Shared.Diagnostics;
 
 #pragma warning disable CA1505 // Avoid unmaintainable code
-#pragma warning disable S1075 // URIs should not be hardcoded
-#pragma warning disable S1199 // Nested block
-#pragma warning disable S1696 // NullReferenceException should not be caught
 #pragma warning disable SA1118 // Parameter should not span multiple lines
 
 namespace Microsoft.Extensions.AI;

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResultStore.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResultStore.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -62,10 +62,8 @@ public sealed class AzureStorageResultStore(DataLakeDirectoryClient client) : IE
         (string path, _) = GetResultPath(executionName);
         DataLakeDirectoryClient subClient = client.GetSubDirectoryClient(path);
 
-#pragma warning disable S3254 // Default parameter value (for 'recursive') should not be passed as argument.
         await foreach (PathItem item in
             subClient.GetPathsAsync(recursive: false, cancellationToken: cancellationToken).ConfigureAwait(false))
-#pragma warning restore S3254
         {
             yield return GetLastSegmentFromPath(item.Name);
         }
@@ -80,10 +78,8 @@ public sealed class AzureStorageResultStore(DataLakeDirectoryClient client) : IE
         (string path, _) = GetResultPath(executionName, scenarioName);
         DataLakeDirectoryClient subClient = client.GetSubDirectoryClient(path);
 
-#pragma warning disable S3254 // Default parameter value (for 'recursive') should not be passed as argument.
         await foreach (PathItem item in
             subClient.GetPathsAsync(recursive: false, cancellationToken: cancellationToken).ConfigureAwait(false))
-#pragma warning restore S3254
         {
             yield return StripExtension(GetLastSegmentFromPath(item.Name));
         }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyEvaluator.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -173,11 +173,9 @@ public abstract class ContentSafetyEvaluator(
                     metric.AddDiagnostics(diagnostics);
                 }
 
-#pragma warning disable S125 // Sections of code should not be commented out.
                 // The following commented code can be useful for debugging purposes.
                 // metric.LogJsonData(payload);
                 // metric.LogJsonData(annotationResult);
-#pragma warning restore S125
 
                 updatedResult.Metrics.Add(metric.Name, metric);
             }

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyService.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Safety/ContentSafetyService.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -34,7 +34,6 @@ internal sealed partial class ContentSafetyService(ContentSafetyServiceConfigura
 
     internal static EvaluationResult ParseAnnotationResult(string annotationResponse)
     {
-#pragma warning disable S125 // Sections of code should not be commented out.
         // Example annotation response:
         // [
         //   {
@@ -48,7 +47,6 @@ internal sealed partial class ContentSafetyService(ContentSafetyServiceConfigura
         //     "hate_fairness": "{\"label\":0,\"reasoning\":\"The system's response does not contain any negative sentiment or hateful and unfair content.\",\"version\":\"0.4\"}",
         //   }
         // ]
-#pragma warning restore S125
 
         var result = new EvaluationResult();
 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation/Utilities/ModelInfo.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation/Utilities/ModelInfo.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -76,9 +76,7 @@ internal static class ModelInfo
     /// </param>
     internal static string? GetModelProvider(string? model, ChatClientMetadata? metadata)
     {
-#pragma warning disable S2219 // Runtime type checking should be simplified.
         if (model is KnownModels.AzureAIFoundryEvaluation)
-#pragma warning restore S2219
         {
             // We know that the model provider and the host are both Azure AI Foundry in this case.
             return $"{KnownModelProviders.AzureAIFoundry} ({KnownModelHostMonikers.AzureAIFoundry})";

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/MicrosoftExtensionsAIResponsesExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -8,8 +8,6 @@ using System.Threading;
 using Microsoft.Extensions.AI;
 using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
-
-#pragma warning disable S3254 // Default parameter values should not be passed as arguments
 
 namespace OpenAI.Responses;
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantsChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantsChatClient.cs
@@ -16,9 +16,6 @@ using OpenAI.Assistants;
 
 #pragma warning disable SA1005 // Single line comments should begin with single space
 #pragma warning disable SA1204 // Static elements should appear before instance elements
-#pragma warning disable S125 // Sections of code should not be commented out
-#pragma warning disable S1751 // Loops with at most one iteration should be refactored
-#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 
 namespace Microsoft.Extensions.AI;
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -20,7 +20,6 @@ using OpenAI;
 using OpenAI.Chat;
 
 #pragma warning disable CA1308 // Normalize strings to uppercase
-#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 #pragma warning disable SA1204 // Static elements should appear before instance elements
 
 namespace Microsoft.Extensions.AI;

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIEmbeddingGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -11,8 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Shared.Diagnostics;
 using OpenAI.Embeddings;
-
-#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 
 namespace Microsoft.Extensions.AI;
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -20,9 +20,6 @@ using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 using OpenAI.Responses;
 
-#pragma warning disable S1226 // Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
-#pragma warning disable S3254 // Default parameter values should not be passed as arguments
 #pragma warning disable SA1204 // Static elements should appear before instance elements
 
 namespace Microsoft.Extensions.AI;

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAISpeechToTextClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAISpeechToTextClient.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -13,7 +13,6 @@ using Microsoft.Shared.Diagnostics;
 using OpenAI;
 using OpenAI.Audio;
 
-#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 #pragma warning disable SA1204 // Static elements should appear before instance elements
 
 namespace Microsoft.Extensions.AI;

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.Shared.Diagnostics;
 
 #pragma warning disable SA1118 // Parameter should not span multiple lines
-#pragma warning disable S2333 // Redundant modifiers should not be used
 
 namespace Microsoft.Extensions.AI;
 

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -15,8 +15,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Shared.Diagnostics;
 
 #pragma warning disable CA2213 // Disposable fields should be disposed
-#pragma warning disable S2219 // Runtime type checking should be simplified
-#pragma warning disable S3353 // Unchanged local variables should be "const"
 #pragma warning disable SA1204 // Static members should appear before non-static members
 
 namespace Microsoft.Extensions.AI;

--- a/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryConsts.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryConsts.cs
@@ -1,9 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Extensions.AI;
-
-#pragma warning disable S4041 // Type names should not match namespaces
 
 /// <summary>Provides constants used by various telemetry services.</summary>
 internal static class OpenTelemetryConsts

--- a/src/Libraries/Microsoft.Extensions.AI/SpeechToText/OpenTelemetrySpeechToTextClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/SpeechToText/OpenTelemetrySpeechToTextClient.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -14,7 +14,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
-#pragma warning disable S3358 // Ternary operators should not be nested
 #pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
 #pragma warning disable SA1113 // Comma should be on the same line as previous parameter
 

--- a/src/Libraries/Microsoft.Extensions.AsyncState/IAsyncLocalContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/IAsyncLocalContext.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -12,9 +12,7 @@ namespace Microsoft.Extensions.AsyncState;
 /// <typeparam name="T">The type of the asynchronous state.</typeparam>
 /// <remarks>This type is intended for internal use. Use <see cref="IAsyncContext{T}"/> instead.</remarks>
 [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable S4023 // Interfaces should not be empty
 public interface IAsyncLocalContext<T> : IAsyncContext<T>
-#pragma warning restore S4023 // Interfaces should not be empty
     where T : class
 {
 }

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.StampedeKey.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.StampedeKey.cs
@@ -40,8 +40,6 @@ internal partial class DefaultHybridCache
         // this is a constant-time operation against a known value.
         internal int HashCode => _hashCode;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Blocker Code Smell", "S2178:Short-circuit logic should be used in boolean contexts",
-            Justification = "Non-short-circuiting intentional to remove unnecessary branch")]
         public bool Equals(StampedeKey other) => _flags == other._flags & _key == other._key;
 
         public override bool Equals([NotNullWhen(true)] object? obj)

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/HybridCachePayload.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/HybridCachePayload.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -38,7 +38,6 @@ internal static class HybridCachePayload
     private static readonly Random _entropySource = new(); // doesn't need to be cryptographic
 
     [Flags]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S2344:Enumeration type names should not have \"Flags\" or \"Enum\" suffixes", Justification = "Clarity")]
     internal enum PayloadFlags : uint
     {
         None = 0,

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/ImmutableTypeCache.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/ImmutableTypeCache.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -41,8 +41,6 @@ internal static class ImmutableTypeCache
 #endif
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Blocker Code Smell", "S2178:Short-circuit logic should be used in boolean contexts",
-        Justification = "Non-short-circuiting intentional to remove unnecessary branch")]
     internal static bool IsTypeImmutable(Type type)
     {
         // check for known types

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/RecyclableArrayBufferWriter.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/RecyclableArrayBufferWriter.cs
@@ -33,7 +33,6 @@ internal sealed class RecyclableArrayBufferWriter<T> : IBufferWriter<T>, IDispos
 
     // Copy of Array.MaxLength.
     // Used by projects targeting .NET Framework.
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S125:Sections of code should not be commented out", Justification = "Usage example, please retain")]
     private const int ArrayMaxLength = 0x7FFFFFC7;
 
     private const int DefaultInitialBufferSize = 256;
@@ -78,8 +77,6 @@ internal sealed class RecyclableArrayBufferWriter<T> : IBufferWriter<T>, IDispos
         }
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S3928:Parameter names used into ArgumentException constructors should match an existing one ",
-        Justification = "False positive; parameter exists")]
     public void Advance(int count)
     {
         _ = Throw.IfLessThan(count, 0);

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/TagSet.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/TagSet.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -46,11 +46,9 @@ internal readonly struct TagSet
     public Span<string> GetSpanPrechecked() => (string[])_tagOrTags!; // we expect this to fail if used on incorrect types
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1065:Do not raise exceptions in unexpected locations", Justification = "Intentional; should not be used")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Blocker Code Smell", "S3877:Exceptions should not be thrown from unexpected methods", Justification = "Intentional; should not be used")]
     public override bool Equals(object? obj) => throw new NotSupportedException();
 
     // [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1065:Do not raise exceptions in unexpected locations", Justification = "Intentional; should not be used")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Blocker Code Smell", "S3877:Exceptions should not be thrown from unexpected methods", Justification = "Intentional; should not be used")]
     public override int GetHashCode() => throw new NotSupportedException();
 
     public override string ToString() => _tagOrTags switch
@@ -217,8 +215,6 @@ internal readonly struct TagSet
         }
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S3928:Parameter names used into ArgumentException constructors should match an existing one ",
-        Justification = "Using parameter name from public callable API")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "Using parameter name from public callable API")]
     private static void Validate(string tag)
     {

--- a/src/Libraries/Microsoft.Extensions.Compliance.Abstractions/Redaction/Redactor.cs
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Abstractions/Redaction/Redactor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -105,7 +105,6 @@ public abstract class Redactor
     /// <param name="provider">Format provider used to produce a string representing the value.</param>
     /// <returns>Redacted value.</returns>
     [SkipLocalsInit]
-    [SuppressMessage("Minor Code Smell", "S3247:Duplicate casts should not be made", Justification = "Avoid pattern matching to improve jitted code")]
     public string Redact<T>(T value, string? format = null, IFormatProvider? provider = null)
     {
 #if NET6_0_OR_GREATER
@@ -167,7 +166,6 @@ public abstract class Redactor
     /// <returns>Number of characters written to the buffer.</returns>
     /// <exception cref="ArgumentException"><paramref name="destination"/> is too small.</exception>
     [SkipLocalsInit]
-    [SuppressMessage("Minor Code Smell", "S3247:Duplicate casts should not be made", Justification = "Avoid pattern matching to improve jitted code")]
     public int Redact<T>(T value, Span<char> destination, string? format = null, IFormatProvider? provider = null)
     {
 #if NET6_0_OR_GREATER
@@ -218,7 +216,6 @@ public abstract class Redactor
     /// <param name="provider">The format provider used to produce a string representing the value.</param>
     /// <returns><see langword="true"/> if the destination buffer was large enough, otherwise <see langword="false"/>.</returns>
     [SkipLocalsInit]
-    [SuppressMessage("Minor Code Smell", "S3247:Duplicate casts should not be made", Justification = "Avoid pattern matching to improve jitted code")]
     public bool TryRedact<T>(T value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider = null)
     {
 #if NET6_0_OR_GREATER

--- a/src/Libraries/Microsoft.Extensions.DataIngestion.Abstractions/IngestionDocumentElement.cs
+++ b/src/Libraries/Microsoft.Extensions.DataIngestion.Abstractions/IngestionDocumentElement.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -172,7 +172,6 @@ public sealed class IngestionDocumentTable : IngestionDocumentElement
     /// <param name="cells">The cells of the table.</param>
     /// <exception cref="ArgumentNullException"><paramref name="cells"/> is <see langword="null"/>.</exception>
 #pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
-#pragma warning disable S3967 // Multidimensional arrays should not be used
     public IngestionDocumentTable(string markdown, IngestionDocumentElement?[,] cells)
         : base(markdown)
     {
@@ -190,7 +189,6 @@ public sealed class IngestionDocumentTable : IngestionDocumentElement
 #pragma warning disable CA1819 // Properties should not return arrays
     public IngestionDocumentElement?[,] Cells { get; }
 #pragma warning restore CA1819 // Properties should not return arrays
-#pragma warning restore S3967 // Multidimensional arrays should not be used
 #pragma warning restore CA1814 // Prefer jagged arrays over multidimensional
 }
 

--- a/src/Libraries/Microsoft.Extensions.DataIngestion.Markdig/MarkdownParser.cs
+++ b/src/Libraries/Microsoft.Extensions.DataIngestion.Markdig/MarkdownParser.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -243,7 +243,6 @@ internal static class MarkdownParser
     }
 
 #pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
-#pragma warning disable S3967 // Multidimensional arrays should not be used
     private static IngestionDocumentElement?[,] GetCells(Table table, string outputContent)
     {
         int firstRowIndex = SkipFirstRow(table, outputContent) ? 1 : 0;
@@ -321,5 +320,4 @@ internal static class MarkdownParser
         }
     }
 #pragma warning restore CA1814 // Prefer jagged arrays over multidimensional
-#pragma warning restore S3967 // Multidimensional arrays should not be used
 }

--- a/src/Libraries/Microsoft.Extensions.DataIngestion/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.DataIngestion/Log.cs
@@ -1,11 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;
 using Microsoft.Extensions.Logging;
-
-#pragma warning disable S109 // Magic numbers should not be used
 
 namespace Microsoft.Extensions.DataIngestion
 {

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.Common/ManualHealthCheck.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.Common/ManualHealthCheck.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -30,7 +30,6 @@ internal sealed class ManualHealthCheck<T> : IManualHealthCheck<T>
 
     private readonly ManualHealthCheckTracker _tracker;
 
-    [SuppressMessage("Major Code Smell", "S3366:\"this\" should not be exposed from constructors", Justification = "It's OK, just registering into a list")]
     public ManualHealthCheck(ManualHealthCheckTracker tracker)
     {
         Result = HealthCheckResult.Unhealthy("Initial state");

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/TcpEndpointProbesService.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/TcpEndpointProbesService.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -78,7 +78,6 @@ internal sealed class TcpEndpointProbesService : BackgroundService
         _listener.Stop();
     }
 
-    [SuppressMessage("Blocker Bug", "S2190:Recursion should not be infinite", Justification = "runs in background")]
     private async Task OpenTcpAsync(CancellationToken cancellationToken)
     {
         while (true)

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -36,9 +36,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
 
     private double _memoryLimit;
     private double _cpuLimit;
-#pragma warning disable S1450 // Private fields only used as local variables in methods should become local variables. This will be used once we bring relevant meters.
     private double _memoryRequest;
-#pragma warning restore S1450 // Private fields only used as local variables in methods should become local variables
     private double _cpuRequest;
 
     private DateTimeOffset _refreshAfterCpu;

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitorService.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitorService.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -119,7 +119,6 @@ internal sealed class ResourceMonitorService : BackgroundService, IResourceMonit
         }
     }
 
-    [SuppressMessage("Blocker Bug", "S2190:Loops and recursions should not be infinite", Justification = "Terminate when Delay throws an exception on cancellation")]
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         while (true)

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceQuotaProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceQuotaProvider.cs
@@ -14,10 +14,8 @@ namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring;
 /// memory and CPU maximum and baseline allocations that may be imposed by container orchestrators,
 /// resource management systems, or other runtime constraints.
 /// </remarks>
-#pragma warning disable S1694 // An abstract class should have both abstract and concrete methods. It's for better .NET Framework support, to have more flexible API if we add more methods here.
 [Experimental(diagnosticId: DiagnosticIds.Experiments.ResourceMonitoring, UrlFormat = DiagnosticIds.UrlFormat)]
 public abstract class ResourceQuotaProvider
-#pragma warning restore S1694 // An abstract class should have both abstract and concrete methods
 {
     /// <summary>
     /// Gets the current resource quota containing memory and CPU maximum and baseline allocations.

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Interop/BOOL.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Interop/BOOL.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Interop;
@@ -12,11 +12,8 @@ namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Interop;
 /// as BOOL. It is best to never compare BOOL to TRUE. Always use bResult != BOOL.FALSE
 /// or bResult == BOOL.FALSE .
 /// </remarks>
-#pragma warning disable S1939 // Inheritance list should not be redundant
 internal enum BOOL : int
-#pragma warning restore S1939 // Inheritance list should not be redundant
 {
     FALSE = 0,
     TRUE = 1,
 }
-

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -35,10 +35,8 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
 
     private double _memoryLimit;
     private double _cpuLimit;
-#pragma warning disable S1450 // Private fields only used as local variables in methods should become local variables. Those will be used once we bring relevant meters.
     private double _memoryRequest;
     private double _cpuRequest;
-#pragma warning restore S1450 // Private fields only used as local variables in methods should become local variables
 
     private long _oldCpuUsageTicks;
     private long _oldCpuTimeTicks;

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -45,7 +45,6 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
     {
     }
 
-#pragma warning disable S107 // Methods should not have too many parameters
     internal WindowsSnapshotProvider(
         ILogger<WindowsSnapshotProvider>? logger,
         IMeterFactory meterFactory,
@@ -55,7 +54,6 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
         Func<long> getCpuTicksFunc,
         Func<long> getMemoryUsageFunc,
         Func<ulong> getTotalMemoryInBytesFunc)
-#pragma warning restore S107 // Methods should not have too many parameters
     {
         _logger = logger ?? NullLogger<WindowsSnapshotProvider>.Instance;
 

--- a/src/Libraries/Microsoft.Extensions.Hosting.Testing/FakeHostingExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Hosting.Testing/FakeHostingExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -103,8 +103,6 @@ public static class FakeHostingExtensions
     /// <param name="configure">Configures the <see cref="IHostBuilder"/> instance.</param>
     /// <returns>The <see cref="IHostBuilder"/> instance.</returns>
     /// <remarks>Designed to ease host configuration in unit tests by defining common configuration methods.</remarks>
-    [SuppressMessage("Minor Code Smell", "S3872:Parameter names should not duplicate the names of their methods",
-        Justification = "We want to keep the parameter name for consistency.")]
     public static IHostBuilder Configure(this IHostBuilder builder, Action<IHostBuilder> configure)
     {
         _ = Throw.IfNull(builder);

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Http/HttpDependencyMetadataResolver.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Http/HttpDependencyMetadataResolver.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -412,9 +412,7 @@ public abstract class HttpDependencyMetadataResolver
                 }
 
                 // Advance i to the next separator index
-#pragma warning disable S127 // "for" loop stop conditions should be invariant
                 i = nextDelimiterIndex;
-#pragma warning restore S127 // "for" loop stop conditions should be invariant
 
                 trieCurrent = delimChildNode;
 

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/StandardHedgingHandlerBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/StandardHedgingHandlerBuilderExtensions.cs
@@ -12,8 +12,6 @@ using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.Http.Resilience;
 
-#pragma warning disable S3872 // Parameter names should not duplicate the names of their methods
-
 /// <summary>
 /// Extensions for <see cref="IStandardHedgingHandlerBuilder"/>.
 /// </summary>

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/HttpStandardResiliencePipelineBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/HttpStandardResiliencePipelineBuilderExtensions.cs
@@ -46,9 +46,7 @@ public static class HttpStandardResiliencePipelineBuilderExtensions
     /// <param name="builder">The pipeline builder.</param>
     /// <param name="configure">The configure method.</param>
     /// <returns>The value of <paramref name="builder"/>.</returns>
-#pragma warning disable S3872 // Parameter names should not duplicate the names of their methods
     public static IHttpStandardResiliencePipelineBuilder Configure(this IHttpStandardResiliencePipelineBuilder builder, Action<HttpStandardResilienceOptions> configure)
-#pragma warning restore S3872 // Parameter names should not duplicate the names of their methods
     {
         _ = Throw.IfNull(builder);
         _ = Throw.IfNull(configure);
@@ -62,9 +60,7 @@ public static class HttpStandardResiliencePipelineBuilderExtensions
     /// <param name="builder">The pipeline builder.</param>
     /// <param name="configure">The configure method.</param>
     /// <returns>The value of <paramref name="builder"/>.</returns>
-#pragma warning disable S3872 // Parameter names should not duplicate the names of their methods
     public static IHttpStandardResiliencePipelineBuilder Configure(this IHttpStandardResiliencePipelineBuilder builder, Action<HttpStandardResilienceOptions, IServiceProvider> configure)
-#pragma warning restore S3872 // Parameter names should not duplicate the names of their methods
     {
         _ = Throw.IfNull(builder);
         _ = Throw.IfNull(configure);

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -124,9 +124,7 @@ public static partial class ResilienceHttpClientBuilderExtensions
     {
         // this piece of code eagerly checks that the pipeline key provider is correctly configured
         // combined with HttpClient auto-activation we can detect any issues on startup
-#pragma warning disable S1075 // URIs should not be hardcoded - this URL is not used for any real request, nor in any telemetry
         using var request = new HttpRequestMessage(HttpMethod.Get, "https://localhost:123");
-#pragma warning restore S1075 // URIs should not be hardcoded
         _ = provider(request);
     }
 

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/Internal/OrderedGroups/OrderedGroupsRoutingStrategyFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/Internal/OrderedGroups/OrderedGroupsRoutingStrategyFactory.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Http.Resilience.Internal;
@@ -17,9 +17,7 @@ internal sealed class OrderedGroupsRoutingStrategyFactory : IPooledObjectPolicy<
     {
         _randomizer = randomizer;
         _cache = cache;
-#pragma warning disable S3366 // "this" should not be exposed from constructors
         _pool = PoolFactory.CreatePool(this);
-#pragma warning restore S3366 // "this" should not be exposed from constructors
     }
 
     public OrderedGroupsRoutingStrategy Get()

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/Internal/WeightedGroups/WeightedGroupsRoutingStrategyFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/Internal/WeightedGroups/WeightedGroupsRoutingStrategyFactory.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Http.Resilience.Internal;
@@ -17,9 +17,7 @@ internal sealed class WeightedGroupsRoutingStrategyFactory : IPooledObjectPolicy
     {
         _randomizer = randomizer;
         _cache = cache;
-#pragma warning disable S3366 // "this" should not be exposed from constructors
         _pool = PoolFactory.CreatePool(this);
-#pragma warning restore S3366 // "this" should not be exposed from constructors
     }
 
     public WeightedGroupsRoutingStrategy Get()

--- a/src/Libraries/Microsoft.Extensions.Options.Contextual/ContextualOptionsServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Options.Contextual/ContextualOptionsServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -73,9 +73,7 @@ public static class ContextualOptionsServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
     /// <param name="configure">The action used to configure the options.</param>
     /// <returns>The value of <paramref name="services"/>.</returns>
-#pragma warning disable S3872 // Parameter names should not duplicate the names of their methods
     public static IServiceCollection Configure<TOptions>(this IServiceCollection services, Action<IOptionsContext, TOptions> configure)
-#pragma warning restore S3872 // Parameter names should not duplicate the names of their methods
         where TOptions : class
         => services.Configure(Options.Options.DefaultName, Throw.IfNull(configure));
 
@@ -87,9 +85,7 @@ public static class ContextualOptionsServiceCollectionExtensions
     /// <param name="name">The name of the options to configure.</param>
     /// <param name="configure">The action used to configure the options.</param>
     /// <returns>The value of <paramref name="services"/>.</returns>
-#pragma warning disable S3872 // Parameter names should not duplicate the names of their methods
     public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, Action<IOptionsContext, TOptions> configure)
-#pragma warning restore S3872 // Parameter names should not duplicate the names of their methods
         where TOptions : class
     {
         return services.AddContextualOptions().AddSingleton<ILoadContextualOptions<TOptions>>(

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Buffering/LogBufferingFilterRuleSelector.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Buffering/LogBufferingFilterRuleSelector.cs
@@ -3,7 +3,6 @@
 #if NET9_0_OR_GREATER
 
 #pragma warning disable CA1307 // Specify StringComparison for clarity
-#pragma warning disable S2302 // "nameof" should be used
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Enrichment/ProcessLogEnricher.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Enrichment/ProcessLogEnricher.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -28,9 +28,7 @@ internal sealed class ProcessLogEnricher : ILogEnricher
     {
         if (_threadIdEnabled)
         {
-#pragma warning disable S2696 // Instance members should not write to "static" fields
             _threadId ??= Environment.CurrentManagedThreadId.ToInvariantString();
-#pragma warning restore S2696 // Instance members should not write to "static" fields
 
             collector.Add(ProcessEnricherTagNames.ThreadId, _threadId);
         }

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Logging/ExtendedLoggerFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Logging/ExtendedLoggerFactory.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -83,10 +83,8 @@ internal sealed class ExtendedLoggerFactory : ILoggerFactory
         {
             // enrichmentOptions is only present if EnableEnrichment was called, so if it's null
             // then ignore all the supplied enrichers, we're not doing enrichment
-#pragma warning disable S1226
             enrichers = [];
             staticEnrichers = [];
-#pragma warning restore S1226
         }
 
         _enrichers = enrichers.Select<ILogEnricher, Action<IEnrichmentTagCollector>>(e => e.Enrich).ToArray();

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Logging/Import/LoggerFactoryScopeProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Logging/Import/LoggerFactoryScopeProvider.cs
@@ -11,7 +11,6 @@
 #pragma warning disable IDE0058 // Expression value is never used
 #pragma warning disable SA1505 // Opening braces should not be followed by blank line
 #pragma warning disable CA2002 // Do not lock on objects with weak identity
-#pragma warning disable S2551 // Lock on a dedicated object instance instead
 #pragma warning disable SA1204 // Static elements should appear before instance elements
 #pragma warning disable SA1402 // File may only contain a single type
 

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Logging/Import/LoggerInformation.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Logging/Import/LoggerInformation.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // This source file was lovingly 'borrowed' from dotnet/runtime/src/libraries/Microsoft.Extensions.Logging
-#pragma warning disable S1128 // Unused "using" should be removed
 #pragma warning disable SA1649 // File name should match first type name
 #pragma warning disable SA1128 // Put constructor initializers on their own line
 #pragma warning disable SA1127 // Generic type constraints should be on their own line

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Logging/Import/LoggerRuleSelector.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Logging/Import/LoggerRuleSelector.cs
@@ -3,7 +3,6 @@
 
 // This source file was lovingly 'borrowed' from dotnet/runtime/src/libraries/Microsoft.Extensions.Logging
 #pragma warning disable CA1307 // Specify StringComparison for clarity
-#pragma warning disable S2302 // "nameof" should be used
 
 using System;
 

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Logging/Import/NullScope.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Logging/Import/NullScope.cs
@@ -4,7 +4,6 @@
 // This source file was lovingly 'borrowed' from dotnet/runtime/src/libraries/Microsoft.Extensions.Logging
 #pragma warning disable SA1629 // Documentation text should end with a period
 #pragma warning disable SA1505 // Opening braces should not be followed by blank line
-#pragma warning disable S1186 // Methods should not be empty
 
 using System;
 

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Logging/Import/ProviderAliasUtilities.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Logging/Import/ProviderAliasUtilities.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // This source file was lovingly 'borrowed' from dotnet/runtime/src/libraries/Microsoft.Extensions.Logging
-#pragma warning disable S1128 // Unused "using" should be removed
 
 using System;
 using System.Collections.Generic;

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Logging/JustInTimeRedactor.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Logging/JustInTimeRedactor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -105,9 +105,7 @@ internal sealed class JustInTimeRedactor : IResettable
         }
         else
 #endif
-#pragma warning disable S1199
         {
-#pragma warning restore S1199
             ReadOnlySpan<char> inputAsSpan = default;
             if (value is IFormattable f)
             {

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/LogSamplingRuleSelector.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/LogSamplingRuleSelector.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable CA1307 // Specify StringComparison for clarity
-#pragma warning disable S2302 // "nameof" should be used
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/FakeTimeProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/FakeTimeProvider.cs
@@ -168,9 +168,7 @@ public class FakeTimeProvider : TimeProvider
         // The same issue could occur converting back, in GetElapsedTime(). Unfortunately
         // that isn't virtual so we can't do the same trick. However, if tests advance
         // the clock in multiples of 1ms or so this loss of precision will not be visible.
-#pragma warning disable S3236 // Caller information arguments should not be provided explicitly
         Debug.Assert(TimestampFrequency == TimeSpan.TicksPerSecond, "Assuming frequency equals ticks per second");
-#pragma warning restore S3236 // Caller information arguments should not be provided explicitly
 
         return GetUtcNow().Ticks;
     }

--- a/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/Timer.cs
+++ b/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/Timer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -32,10 +32,8 @@ internal sealed class Timer : ITimer
         var dueTimeMs = (long)dueTime.TotalMilliseconds;
         var periodMs = (long)period.TotalMilliseconds;
 
-#pragma warning disable S3236 // Caller information arguments should not be provided explicitly
         _ = Throw.IfOutOfRange(dueTimeMs, -1, MaxSupportedTimeout, nameof(dueTime));
         _ = Throw.IfOutOfRange(periodMs, -1, MaxSupportedTimeout, nameof(period));
-#pragma warning restore S3236 // Caller information arguments should not be provided explicitly
 
         var timeProvider = _timeProvider;
         if (timeProvider is null)

--- a/src/Shared/.editorconfig
+++ b/src/Shared/.editorconfig
@@ -480,12 +480,12 @@ dotnet_diagnostic.CA1507.severity = warning
 # Title    : Avoid dead conditional code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
-dotnet_diagnostic.CA1508.severity = warning
+dotnet_diagnostic.CA1508.severity = none
 
 # Title    : Avoid dead conditional code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
-dotnet_diagnostic.CA1508.severity = warning
+dotnet_diagnostic.CA1508.severity = none
 
 # Title    : Invalid entry in code metrics rule specification file
 # Category : Maintainability
@@ -2894,2294 +2894,391 @@ dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
 # Redundant: IDE1006
-dotnet_diagnostic.S100.severity = none
-
-# Title    : Method overrides should not change parameter defaults
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
-dotnet_diagnostic.S1006.severity = warning
 
 # Title    : Types should be named in PascalCase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
 # Redundant: IDE1006
-dotnet_diagnostic.S101.severity = none
-
-# Title    : Lines should not be too long
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
-dotnet_diagnostic.S103.severity = warning
-
-# Title    : Files should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
-dotnet_diagnostic.S104.severity = warning
 
 # Title    : Finalizers should not throw exceptions
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
 # Redundant: CA1065
-dotnet_diagnostic.S1048.severity = none
 
 # Title    : Tabulation characters should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
 # Redundant: SA1027
-dotnet_diagnostic.S105.severity = none
-
-# Title    : Standard outputs should not be used directly to log anything
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
-dotnet_diagnostic.S106.severity = warning
-
-# Title    : Collapsible "if" statements should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
-dotnet_diagnostic.S1066.severity = none
-
-# Title    : Expressions should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
-dotnet_diagnostic.S1067.severity = warning
-
-# Title    : Methods should not have too many parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
-dotnet_diagnostic.S107.severity = warning
-
-# Title    : URIs should not be hardcoded
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
-dotnet_diagnostic.S1075.severity = warning
-
-# Title    : Nested blocks of code should not be left empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
-dotnet_diagnostic.S108.severity = warning
-
-# Title    : Magic numbers should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
-dotnet_diagnostic.S109.severity = warning
-
-# Title    : Inheritance tree of classes should not be too deep
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
-dotnet_diagnostic.S110.severity = warning
 
 # Title    : Fields should not have public accessibility
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
 # Redundant: CA1051
-dotnet_diagnostic.S1104.severity = none
 
 # Title    : A close curly brace should be located at the beginning of a line
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
 # Redundant: SA1500
-dotnet_diagnostic.S1109.severity = none
 
 # Title    : Redundant pairs of parentheses should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
 # Redundant: SA1119
-dotnet_diagnostic.S1110.severity = none
 
 # Title    : Empty statements should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
 # Redundant: SA1106
-dotnet_diagnostic.S1116.severity = none
-
-# Title    : Local variables should not shadow class fields or properties
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
-dotnet_diagnostic.S1117.severity = warning
 
 # Title    : Utility classes should not have public constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
 # Redundant: CA1052
-dotnet_diagnostic.S1118.severity = none
 
 # Title    : General exceptions should never be thrown
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
 # Redundant: CA2219
-dotnet_diagnostic.S112.severity = none
-
-# Title    : Assignments should not be made from within sub-expressions
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
-dotnet_diagnostic.S1121.severity = warning
 
 # Title    : "Obsolete" attributes should include explanations
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
 # Redundant: CA1041
-dotnet_diagnostic.S1123.severity = none
-
-# Title    : Boolean literals should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
-dotnet_diagnostic.S1125.severity = warning
-
-# Title    : Unused "using" should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
-dotnet_diagnostic.S1128.severity = warning
-
-# Title    : Files should contain an empty newline at the end
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
-dotnet_diagnostic.S113.severity = none
-
-# Title    : Deprecated code should be removed
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1133
-dotnet_diagnostic.S1133.severity = suggestion
-
-# Title    : Track uses of "FIXME" tags
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
-dotnet_diagnostic.S1134.severity = warning
-
-# Title    : Track uses of "TODO" tags
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
-dotnet_diagnostic.S1135.severity = warning
-
-# Title    : Unused private types or members should be removed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
-dotnet_diagnostic.S1144.severity = warning
-
-# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
-dotnet_diagnostic.S1145.severity = warning
-
-# Title    : Exit methods should not be called
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
-dotnet_diagnostic.S1147.severity = warning
-
-# Title    : "switch case" clauses should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
-dotnet_diagnostic.S1151.severity = none
-
-# Title    : "Any()" should be used to test for emptiness
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
-dotnet_diagnostic.S1155.severity = warning
 
 # Title    : Exceptions should not be thrown in finally blocks
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
 # Redundant: CA2219
-dotnet_diagnostic.S1163.severity = none
-
-# Title    : Empty arrays and collections should be returned instead of null
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
-dotnet_diagnostic.S1168.severity = warning
 
 # Title    : Unused method parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
 # Redundant: IDE0060
-dotnet_diagnostic.S1172.severity = none
-
-# Title    : Overriding members should do more than simply call the same member in the base class
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
-dotnet_diagnostic.S1185.severity = warning
-
-# Title    : Methods should not be empty
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
-dotnet_diagnostic.S1186.severity = warning
-
-# Title    : String literals should not be duplicated
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
-dotnet_diagnostic.S1192.severity = suggestion
-
-# Title    : Nested code blocks should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
-dotnet_diagnostic.S1199.severity = warning
-
-# Title    : Classes should not be coupled to too many other classes
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
-dotnet_diagnostic.S1200.severity = none
 
 # Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
 # Redundant: CS0659
-dotnet_diagnostic.S1206.severity = none
 
 # Title    : Control structures should use curly braces
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
 # Redundant: SA1503
-dotnet_diagnostic.S121.severity = none
 
 # Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
 # Redundant: CA1036
-dotnet_diagnostic.S1210.severity = none
-
-# Title    : "GC.Collect" should not be called
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
-dotnet_diagnostic.S1215.severity = warning
-
-# Title    : Statements should be on separate lines
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
-dotnet_diagnostic.S122.severity = none
-
-# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
-dotnet_diagnostic.S1226.severity = warning
-
-# Title    : break statements should not be used except for switch cases
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
-dotnet_diagnostic.S1227.severity = none
-
-# Title    : Floating point numbers should not be tested for equality
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
-dotnet_diagnostic.S1244.severity = error
-
-# Title    : Sections of code should not be commented out
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
-dotnet_diagnostic.S125.severity = warning
-
-# Title    : "if ... else if" constructs should end with "else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
-dotnet_diagnostic.S126.severity = none
-
-# Title    : A "while" loop should be used instead of a "for" loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
-dotnet_diagnostic.S1264.severity = warning
-
-# Title    : "for" loop stop conditions should be invariant
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
-dotnet_diagnostic.S127.severity = warning
-
-# Title    : "switch" statements should have at least 3 "case" clauses
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
-dotnet_diagnostic.S1301.severity = none
 
 # Title    : Track uses of in-source issue suppressions
 # Category : Info Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
 # Comment  : Suppressions are frequently necessary.
-dotnet_diagnostic.S1309.severity = none
-
-# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
-dotnet_diagnostic.S131.severity = none
-
-# Title    : Using hardcoded IP addresses is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
-dotnet_diagnostic.S1313.severity = warning
-
-# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
-dotnet_diagnostic.S134.severity = none
-
-# Title    : Functions should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
-dotnet_diagnostic.S138.severity = none
-
-# Title    : Culture should be specified for "string" operations
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
-dotnet_diagnostic.S1449.severity = warning
-
-# Title    : Private fields only used as local variables in methods should become local variables
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
-dotnet_diagnostic.S1450.severity = warning
 
 # Title    : Track lack of copyright and license headers
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
 # Redundant: IDE0073
-dotnet_diagnostic.S1451.severity = none
-
-# Title    : "switch" statements should not have too many "case" clauses
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
-dotnet_diagnostic.S1479.severity = warning
 
 # Title    : Unused local variables should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
 # Redundant: CS0168
-dotnet_diagnostic.S1481.severity = none
-
-# Title    : Methods and properties should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
-dotnet_diagnostic.S1541.severity = none
-
-# Title    : Tests should not be ignored
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
-dotnet_diagnostic.S1607.severity = warning
-
-# Title    : Strings should not be concatenated using '+' in a loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
-dotnet_diagnostic.S1643.severity = warning
-
-# Title    : Variables should not be self-assigned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
-dotnet_diagnostic.S1656.severity = warning
-
-# Title    : Multiple variables should not be declared on the same line
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
-dotnet_diagnostic.S1659.severity = warning
-
-# Title    : An abstract class should have both abstract and concrete methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
-dotnet_diagnostic.S1694.severity = warning
-
-# Title    : NullReferenceException should not be caught
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
-dotnet_diagnostic.S1696.severity = warning
-
-# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
-dotnet_diagnostic.S1697.severity = warning
-
-# Title    : "==" should not be used when "Equals" is overridden
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
-dotnet_diagnostic.S1698.severity = warning
-
-# Title    : Constructors should only call non-overridable methods
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
-dotnet_diagnostic.S1699.severity = warning
-
-# Title    : Loops with at most one iteration should be refactored
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
-dotnet_diagnostic.S1751.severity = warning
-
-# Title    : Identical expressions should not be used on both sides of operators
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
-dotnet_diagnostic.S1764.severity = warning
-
-# Title    : "switch" statements should not be nested
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
-dotnet_diagnostic.S1821.severity = none
-
-# Title    : Objects should not be created to be dropped immediately without being used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
-dotnet_diagnostic.S1848.severity = warning
 
 # Title    : Unused assignments should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
 # Redundant: IDE0059
-dotnet_diagnostic.S1854.severity = none
-
-# Title    : "ToString()" calls should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
-dotnet_diagnostic.S1858.severity = warning
-
-# Title    : Related "if/else if" statements should not have the same condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
-dotnet_diagnostic.S1862.severity = warning
-
-# Title    : Two branches in a conditional structure should not have exactly the same implementation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
-dotnet_diagnostic.S1871.severity = warning
 
 # Title    : Redundant casts should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
 # Redundant: IDE0004
-dotnet_diagnostic.S1905.severity = none
-
-# Title    : Inheritance list should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
-dotnet_diagnostic.S1939.severity = warning
-
-# Title    : Boolean checks should not be inverted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
-dotnet_diagnostic.S1940.severity = warning
-
-# Title    : Invalid casts should be avoided
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
-dotnet_diagnostic.S1944.severity = warning
-
-# Title    : "for" loop increment clauses should modify the loops' counters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
-dotnet_diagnostic.S1994.severity = warning
 
 # Title    : Hashes should include an unpredictable salt
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S2053.severity = none
-
-# Title    : Hard-coded credentials are security-sensitive
-# Category : Blocker Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
-dotnet_diagnostic.S2068.severity = warning
 
 # Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
 # Redundant: CA5350
-dotnet_diagnostic.S2070.severity = none
-
-# Title    : Formatting SQL queries is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
-dotnet_diagnostic.S2077.severity = warning
-
-# Title    : Creating cookies without the "secure" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
-dotnet_diagnostic.S2092.severity = warning
-
-# Title    : Classes should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2094
-dotnet_diagnostic.S2094.severity = none
-
-# Title    : Collections should not be passed as arguments to their own methods
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
-dotnet_diagnostic.S2114.severity = warning
-
-# Title    : A secure password should be used when connecting to a database
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
-dotnet_diagnostic.S2115.severity = warning
-
-# Title    : Values should not be uselessly incremented
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
-dotnet_diagnostic.S2123.severity = warning
-
-# Title    : Underscores should be used to make large numbers readable
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
-dotnet_diagnostic.S2148.severity = warning
-
-# Title    : "sealed" classes should not have "protected" members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
-dotnet_diagnostic.S2156.severity = warning
-
-# Title    : Classes named like "Exception" should extend "Exception" or a subclass
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2166
-dotnet_diagnostic.S2166.severity = warning
-
-# Title    : Short-circuit logic should be used in boolean contexts
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
-dotnet_diagnostic.S2178.severity = warning
-
-# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
-dotnet_diagnostic.S2183.severity = warning
-
-# Title    : Results of integer division should not be assigned to floating point variables
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
-dotnet_diagnostic.S2184.severity = warning
-
-# Title    : Test classes should contain at least one test case
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
-dotnet_diagnostic.S2187.severity = warning
-
-# Title    : Loops and recursions should not be infinite
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
-dotnet_diagnostic.S2190.severity = warning
-
-# Title    : Modulus results should not be checked for direct equality
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
-dotnet_diagnostic.S2197.severity = warning
-
-# Title    : Unnecessary mathematical comparisons should not be made
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2198
-dotnet_diagnostic.S2198.severity = warning
 
 # Title    : Methods without side effects should not have their return values ignored
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
 # Redundant: CA1806
-dotnet_diagnostic.S2201.severity = none
-
-# Title    : Runtime type checking should be simplified
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
-dotnet_diagnostic.S2219.severity = warning
-
-# Title    : "Exception" should not be caught
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
-dotnet_diagnostic.S2221.severity = none
-
-# Title    : Locks should be released on all paths
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
-dotnet_diagnostic.S2222.severity = warning
-
-# Title    : Non-constant static fields should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
-dotnet_diagnostic.S2223.severity = warning
-
-# Title    : "ToString()" method should not return null
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
-dotnet_diagnostic.S2225.severity = warning
-
-# Title    : Console logging should not be used
-# Category : Minor Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
-dotnet_diagnostic.S2228.severity = warning
-
-# Title    : Arguments should be passed in the same order as the method parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
-dotnet_diagnostic.S2234.severity = warning
-
-# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
-dotnet_diagnostic.S2245.severity = warning
-
-# Title    : A "for" loop update clause should move the counter in the right direction
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
-dotnet_diagnostic.S2251.severity = warning
-
-# Title    : For-loop conditions should be true at least once
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
-dotnet_diagnostic.S2252.severity = warning
-
-# Title    : Writing cookies is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
-dotnet_diagnostic.S2255.severity = warning
-
-# Title    : Using non-standard cryptographic algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
-dotnet_diagnostic.S2257.severity = warning
 
 # Title    : Null pointers should not be dereferenced
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
 # Comment  : Redundant, covered by modern C# compiler
-dotnet_diagnostic.S2259.severity = none
-
-# Title    : Composite format strings should not lead to unexpected behavior at runtime
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
-dotnet_diagnostic.S2275.severity = warning
-
-# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
-dotnet_diagnostic.S2278.severity = warning
-
-# Title    : Field-like events should not be virtual
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
-dotnet_diagnostic.S2290.severity = warning
-
-# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
-dotnet_diagnostic.S2291.severity = warning
 
 # Title    : Trivial properties should be auto-implemented
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
 # Redundant: IDE0032
-dotnet_diagnostic.S2292.severity = none
-
-# Title    : "nameof" should be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
-dotnet_diagnostic.S2302.severity = warning
-
-# Title    : "async" and "await" should not be used as identifiers
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
-dotnet_diagnostic.S2306.severity = warning
 
 # Title    : Methods and properties that don't access instance data should be static
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
 # Redundant: CA1822
-dotnet_diagnostic.S2325.severity = none
 
 # Title    : Unused type parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
 # Comment  : Valid pattern used in a number of places
-dotnet_diagnostic.S2326.severity = none
-
-# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
-dotnet_diagnostic.S2327.severity = warning
-
-# Title    : "GetHashCode" should not reference mutable fields
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
-dotnet_diagnostic.S2328.severity = warning
-
-# Title    : Array covariance should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
-dotnet_diagnostic.S2330.severity = warning
-
-# Title    : Redundant modifiers should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
-dotnet_diagnostic.S2333.severity = warning
-
-# Title    : Public constant members should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
-dotnet_diagnostic.S2339.severity = none
-
-# Title    : Enumeration types should comply with a naming convention
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
-dotnet_diagnostic.S2342.severity = none
-
-# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
-dotnet_diagnostic.S2344.severity = warning
-
-# Title    : Flags enumerations should explicitly initialize all their members
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
-dotnet_diagnostic.S2345.severity = warning
 
 # Title    : Flags enumerations zero-value members should be named "None"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
 # Redundant: CA1008
-dotnet_diagnostic.S2346.severity = none
 
 # Title    : Fields should be private
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
 # Redundant: CA1051
-dotnet_diagnostic.S2357.severity = none
-
-# Title    : Optional parameters should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
-dotnet_diagnostic.S2360.severity = none
-
-# Title    : Properties should not make collection or array copies
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
-dotnet_diagnostic.S2365.severity = warning
-
-# Title    : Public methods should not have multidimensional array parameters
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
-dotnet_diagnostic.S2368.severity = warning
-
-# Title    : Exceptions should not be thrown from property getters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
-dotnet_diagnostic.S2372.severity = warning
-
-# Title    : Write-only properties should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
-dotnet_diagnostic.S2376.severity = warning
-
-# Title    : Mutable fields should not be "public static"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
-dotnet_diagnostic.S2386.severity = warning
-
-# Title    : Child class fields should not shadow parent class fields
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
-dotnet_diagnostic.S2387.severity = warning
 
 # Title    : Types and methods should not have too many generic parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
 # Redundant: CA1005
-dotnet_diagnostic.S2436.severity = none
-
-# Title    : Unnecessary bit operations should not be performed
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
-dotnet_diagnostic.S2437.severity = warning
 
 # Title    : Blocks should be synchronized on read-only fields
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2445
 # Comment  : Noise
-dotnet_diagnostic.S2445.severity = none
-
-# Title    : Whitespace and control characters in string literals should be explicit
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
-dotnet_diagnostic.S2479.severity = warning
-
-# Title    : Generic exceptions should not be ignored
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
-dotnet_diagnostic.S2486.severity = warning
-
-# Title    : Shared resources should not be used for locking
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
-dotnet_diagnostic.S2551.severity = warning
 
 # Title    : Conditionally executed code should be reachable
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
 # Redundant: CA1508
-dotnet_diagnostic.S2583.severity = none
 
 # Title    : Boolean expressions should not be gratuitous
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
 # Comment  : Too many false positives.
-dotnet_diagnostic.S2589.severity = none
-
-# Title    : Setting loose file permissions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
-dotnet_diagnostic.S2612.severity = warning
-
-# Title    : The length returned from a stream read should be checked
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
-dotnet_diagnostic.S2674.severity = warning
-
-# Title    : Multiline blocks should be enclosed in curly braces
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
-dotnet_diagnostic.S2681.severity = warning
-
-# Title    : "NaN" should not be used in comparisons
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
-dotnet_diagnostic.S2688.severity = warning
-
-# Title    : "IndexOf" checks should not be for positive numbers
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
-dotnet_diagnostic.S2692.severity = warning
-
-# Title    : Instance members should not write to "static" fields
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
-dotnet_diagnostic.S2696.severity = warning
-
-# Title    : Tests should include assertions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
-dotnet_diagnostic.S2699.severity = warning
-
-# Title    : Literal boolean values should not be used in assertions
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
-dotnet_diagnostic.S2701.severity = warning
-
-# Title    : "catch" clauses should do more than rethrow
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
-dotnet_diagnostic.S2737.severity = warning
-
-# Title    : Static fields should not be used in generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
-dotnet_diagnostic.S2743.severity = none
-
-# Title    : XML parsers should not be vulnerable to XXE attacks
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
-dotnet_diagnostic.S2755.severity = warning
-
-# Title    : Non-existent operators like "=+" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
-dotnet_diagnostic.S2757.severity = warning
-
-# Title    : The ternary operator should not return the same value regardless of the condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
-dotnet_diagnostic.S2758.severity = warning
-
-# Title    : Sequential tests should not check the same condition
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
-dotnet_diagnostic.S2760.severity = warning
-
-# Title    : Doubled prefix operators "!!" and "~~" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
-dotnet_diagnostic.S2761.severity = warning
-
-# Title    : SQL keywords should be delimited by whitespace
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
-dotnet_diagnostic.S2857.severity = warning
-
-# Title    : "Thread.Sleep" should not be used in tests
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2925
-dotnet_diagnostic.S2925.severity = none
 
 # Title    : "IDisposables" should be disposed
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
 # Redundant: CA2000
-dotnet_diagnostic.S2930.severity = none
 
 # Title    : Classes with "IDisposable" members should implement "IDisposable"
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
 # Redundant: CA1001
-dotnet_diagnostic.S2931.severity = none
 
 # Title    : Fields that are only assigned in the constructor should be "readonly"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
 # Redundant: IDE0044
-dotnet_diagnostic.S2933.severity = none
-
-# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
-dotnet_diagnostic.S2934.severity = warning
-
-# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
-dotnet_diagnostic.S2952.severity = warning
-
-# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
-dotnet_diagnostic.S2953.severity = warning
-
-# Title    : Generic parameters not constrained to reference types should not be compared to "null"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
-dotnet_diagnostic.S2955.severity = warning
-
-# Title    : Assertions should be complete
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2970
-dotnet_diagnostic.S2970.severity = warning
-
-# Title    : "IEnumerable" LINQs should be simplified
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
-dotnet_diagnostic.S2971.severity = warning
-
-# Title    : "Object.ReferenceEquals" should not be used for value types
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
-dotnet_diagnostic.S2995.severity = warning
-
-# Title    : "ThreadStatic" fields should not be initialized
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
-dotnet_diagnostic.S2996.severity = warning
-
-# Title    : "IDisposables" created in a "using" statement should not be returned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
-dotnet_diagnostic.S2997.severity = warning
-
-# Title    : "ThreadStatic" should not be used on non-static fields
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
-dotnet_diagnostic.S3005.severity = warning
-
-# Title    : Static fields should not be updated in constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
-dotnet_diagnostic.S3010.severity = warning
-
-# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
-dotnet_diagnostic.S3011.severity = warning
 
 # Title    : Members should not be initialized to default values
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
 # Redundant: CA1805
-dotnet_diagnostic.S3052.severity = none
-
-# Title    : Types should not have members with visibility set higher than the type's visibility
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
-dotnet_diagnostic.S3059.severity = none
-
-# Title    : "is" should not be used with "this"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
-dotnet_diagnostic.S3060.severity = warning
-
-# Title    : "StringBuilder" data should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3063
-dotnet_diagnostic.S3063.severity = warning
 
 # Title    : "async" methods should not return "void"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
 # Redundant: VSTHRD100
-dotnet_diagnostic.S3168.severity = none
-
-# Title    : Multiple "OrderBy" calls should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
-dotnet_diagnostic.S3169.severity = warning
-
-# Title    : Delegates should not be subtracted
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
-dotnet_diagnostic.S3172.severity = warning
-
-# Title    : "interface" instances should not be cast to concrete types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
-dotnet_diagnostic.S3215.severity = warning
 
 # Title    : "ConfigureAwait(false)" should be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
 # Redundant: CA2007
-dotnet_diagnostic.S3216.severity = none
-
-# Title    : "Explicit" conversions of "foreach" loops should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
-dotnet_diagnostic.S3217.severity = warning
-
-# Title    : Inner class members should not shadow outer class "static" or type members
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
-dotnet_diagnostic.S3218.severity = warning
-
-# Title    : Method calls should not resolve ambiguously to overloads with "params"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
-dotnet_diagnostic.S3220.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
-dotnet_diagnostic.S3234.severity = warning
-
-# Title    : Redundant parentheses should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
-dotnet_diagnostic.S3235.severity = warning
-
-# Title    : Caller information arguments should not be provided explicitly
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
-dotnet_diagnostic.S3236.severity = warning
-
-# Title    : "value" contextual keyword should be used
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
-dotnet_diagnostic.S3237.severity = warning
 
 # Title    : The simplest possible condition syntax should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
 # Redundant: IDE0054
-dotnet_diagnostic.S3240.severity = none
-
-# Title    : Methods should not return values that are never used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
-dotnet_diagnostic.S3241.severity = warning
 
 # Title    : Method parameters should be declared with base types
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
 # Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
-dotnet_diagnostic.S3242.severity = none
-
-# Title    : Anonymous delegates should not be used to unsubscribe from Events
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
-dotnet_diagnostic.S3244.severity = warning
-
-# Title    : Generic type parameters should be co/contravariant when possible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
-dotnet_diagnostic.S3246.severity = warning
-
-# Title    : Duplicate casts should not be made
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
-dotnet_diagnostic.S3247.severity = warning
-
-# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
-dotnet_diagnostic.S3249.severity = warning
-
-# Title    : Implementations should be provided for "partial" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
-dotnet_diagnostic.S3251.severity = warning
-
-# Title    : Constructor and destructor declarations should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
-dotnet_diagnostic.S3253.severity = warning
-
-# Title    : Default parameter values should not be passed as arguments
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
-dotnet_diagnostic.S3254.severity = warning
-
-# Title    : "string.IsNullOrEmpty" should be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
-dotnet_diagnostic.S3256.severity = warning
 
 # Title    : Declarations and initializations should be as concise as possible
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
 # Comment  : Too many false positives
-dotnet_diagnostic.S3257.severity = none
 
 # Title    : Non-derived "private" classes and records should be "sealed"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
 # Redundant: R9A013
-dotnet_diagnostic.S3260.severity = none
-
-# Title    : Namespaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
-dotnet_diagnostic.S3261.severity = warning
-
-# Title    : "params" should be used on overrides
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
-dotnet_diagnostic.S3262.severity = warning
-
-# Title    : Static fields should appear in the order they must be initialized 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
-dotnet_diagnostic.S3263.severity = warning
-
-# Title    : Events should be invoked
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
-dotnet_diagnostic.S3264.severity = warning
-
-# Title    : Non-flags enums should not be used in bitwise operations
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
-dotnet_diagnostic.S3265.severity = warning
-
-# Title    : Loops should be simplified with "LINQ" expressions
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
-dotnet_diagnostic.S3267.severity = none
 
 # Title    : Cipher Block Chaining IVs should be unpredictable
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S3329.severity = none
-
-# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
-dotnet_diagnostic.S3330.severity = warning
-
-# Title    : Caller information parameters should come at the end of the parameter list
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
-dotnet_diagnostic.S3343.severity = warning
-
-# Title    : Expressions used in "Debug.Assert" should not produce side effects
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
-dotnet_diagnostic.S3346.severity = warning
-
-# Title    : Unchanged local variables should be "const"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
-dotnet_diagnostic.S3353.severity = warning
-
-# Title    : Ternary operators should not be nested
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
-dotnet_diagnostic.S3358.severity = warning
-
-# Title    : Date and time should not be used as a type for primary keys
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3363
-dotnet_diagnostic.S3363.severity = warning
-
-# Title    : "this" should not be exposed from constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
-dotnet_diagnostic.S3366.severity = warning
 
 # Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
 # Redundant: CA1710
-dotnet_diagnostic.S3376.severity = none
-
-# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
-dotnet_diagnostic.S3397.severity = warning
-
-# Title    : "private" methods called only by inner classes should be moved to those classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3398
-dotnet_diagnostic.S3398.severity = warning
-
-# Title    : Methods should not return constants
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
-dotnet_diagnostic.S3400.severity = warning
-
-# Title    : Assertion arguments should be passed in the correct order
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
-dotnet_diagnostic.S3415.severity = warning
-
-# Title    : Method overloads with default parameter values should not overlap
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
-dotnet_diagnostic.S3427.severity = warning
-
-# Title    : "[ExpectedException]" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
-dotnet_diagnostic.S3431.severity = warning
-
-# Title    : Test method signatures should be correct
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
-dotnet_diagnostic.S3433.severity = warning
-
-# Title    : Variables should not be checked against the values they're about to be assigned
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
-dotnet_diagnostic.S3440.severity = warning
-
-# Title    : Redundant property names should be omitted in anonymous classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
-dotnet_diagnostic.S3441.severity = warning
-
-# Title    : "abstract" classes should not have "public" constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
-dotnet_diagnostic.S3442.severity = warning
-
-# Title    : Type should not be examined on "System.Type" instances
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
-dotnet_diagnostic.S3443.severity = warning
-
-# Title    : Interfaces should not simply inherit from base interfaces with colliding members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
-dotnet_diagnostic.S3444.severity = warning
-
-# Title    : Exceptions should not be explicitly rethrown
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
-dotnet_diagnostic.S3445.severity = warning
-
-# Title    : "[Optional]" should not be used on "ref" or "out" parameters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
-dotnet_diagnostic.S3447.severity = warning
-
-# Title    : Right operands of shift operators should be integers
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
-dotnet_diagnostic.S3449.severity = warning
-
-# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
-dotnet_diagnostic.S3450.severity = warning
-
-# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
-dotnet_diagnostic.S3451.severity = warning
-
-# Title    : Classes should not have only "private" constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
-dotnet_diagnostic.S3453.severity = warning
-
-# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
-dotnet_diagnostic.S3456.severity = warning
-
-# Title    : Composite format strings should be used correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
-dotnet_diagnostic.S3457.severity = warning
-
-# Title    : Empty "case" clauses that fall through to the "default" should be omitted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
-dotnet_diagnostic.S3458.severity = warning
-
-# Title    : Unassigned members should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
-dotnet_diagnostic.S3459.severity = warning
-
-# Title    : Type inheritance should not be recursive
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
-dotnet_diagnostic.S3464.severity = warning
-
-# Title    : Optional parameters should be passed to "base" calls
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
-dotnet_diagnostic.S3466.severity = warning
-
-# Title    : Empty "default" clauses should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
-dotnet_diagnostic.S3532.severity = warning
-
-# Title    : "ServiceContract" and "OperationContract" attributes should be used together
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
-dotnet_diagnostic.S3597.severity = warning
-
-# Title    : One-way "OperationContract" methods should have "void" return type
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
-dotnet_diagnostic.S3598.severity = warning
-
-# Title    : "params" should not be introduced on overrides
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
-dotnet_diagnostic.S3600.severity = warning
-
-# Title    : Methods with "Pure" attribute should return a value 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
-dotnet_diagnostic.S3603.severity = warning
-
-# Title    : Member initializer values should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
-dotnet_diagnostic.S3604.severity = warning
-
-# Title    : Nullable type comparison should not be redundant
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
-dotnet_diagnostic.S3610.severity = warning
-
-# Title    : Jump statements should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
-dotnet_diagnostic.S3626.severity = warning
-
-# Title    : Empty nullable value should not be accessed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
-dotnet_diagnostic.S3655.severity = warning
-
-# Title    : Exception constructors should not throw exceptions
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
-dotnet_diagnostic.S3693.severity = warning
-
-# Title    : Track use of "NotImplementedException"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
-dotnet_diagnostic.S3717.severity = warning
 
 # Title    : Cognitive Complexity of methods should not be too high
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
 # Comment  : Code gets complicated
-dotnet_diagnostic.S3776.severity = none
-
-# Title    : "SafeHandle.DangerousGetHandle" should not be called
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
-dotnet_diagnostic.S3869.severity = warning
 
 # Title    : Exception types should be "public"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
 # Redundant: CA1064
-dotnet_diagnostic.S3871.severity = none
-
-# Title    : Parameter names should not duplicate the names of their methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
-dotnet_diagnostic.S3872.severity = warning
 
 # Title    : "out" and "ref" parameters should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
 # Redundant: CA1021
-dotnet_diagnostic.S3874.severity = none
-
-# Title    : "operator==" should not be overloaded on reference types
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
-dotnet_diagnostic.S3875.severity = warning
-
-# Title    : Strings or integral types should be used for indexers
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
-dotnet_diagnostic.S3876.severity = warning
-
-# Title    : Exceptions should not be thrown from unexpected methods
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
-dotnet_diagnostic.S3877.severity = warning
-
-# Title    : Arrays should not be created for params parameters
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3878
-dotnet_diagnostic.S3878.severity = suggestion
-
-# Title    : Finalizers should not be empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
-dotnet_diagnostic.S3880.severity = warning
-
-# Title    : "IDisposable" should be implemented correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
-dotnet_diagnostic.S3881.severity = none
-
-# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
-dotnet_diagnostic.S3884.severity = warning
-
-# Title    : "Assembly.Load" should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
-dotnet_diagnostic.S3885.severity = warning
-
-# Title    : Mutable, non-private fields should not be "readonly"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
-dotnet_diagnostic.S3887.severity = warning
-
-# Title    : "Thread.Resume" and "Thread.Suspend" should not be used
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
-dotnet_diagnostic.S3889.severity = warning
-
-# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
-dotnet_diagnostic.S3897.severity = warning
-
-# Title    : Value types should implement "IEquatable<T>"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
-dotnet_diagnostic.S3898.severity = none
 
 # Title    : Arguments of public methods should be validated against null
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
 # Redundant: CA1062
-dotnet_diagnostic.S3900.severity = none
-
-# Title    : "Assembly.GetExecutingAssembly" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
-dotnet_diagnostic.S3902.severity = warning
 
 # Title    : Types should be defined in named namespaces
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
 # Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
-dotnet_diagnostic.S3903.severity = none
-
-# Title    : Assemblies should have version information
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
-dotnet_diagnostic.S3904.severity = warning
-
-# Title    : Event Handlers should have the correct signature
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
-dotnet_diagnostic.S3906.severity = warning
-
-# Title    : Generic event handlers should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
-dotnet_diagnostic.S3908.severity = warning
 
 # Title    : Collections should implement the generic interface
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
 # Redundant: CA1010
-dotnet_diagnostic.S3909.severity = none
-
-# Title    : All branches in a conditional structure should not have exactly the same implementation
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
-dotnet_diagnostic.S3923.severity = warning
 
 # Title    : "ISerializable" should be implemented correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
 # Comment  : TODO - is ISerializable still relevant?
-dotnet_diagnostic.S3925.severity = none
-
-# Title    : Deserialization methods should be provided for "OptionalField" members
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
-dotnet_diagnostic.S3926.severity = warning
-
-# Title    : Serialization event handlers should be implemented correctly
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
-dotnet_diagnostic.S3927.severity = warning
-
-# Title    : Parameter names used into ArgumentException constructors should match an existing one 
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
-dotnet_diagnostic.S3928.severity = warning
-
-# Title    : Number patterns should be regular
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
-dotnet_diagnostic.S3937.severity = warning
-
-# Title    : Calculations should not overflow
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
-dotnet_diagnostic.S3949.severity = suggestion
 
 # Title    : "Generic.List" instances should not be part of public APIs
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
 # Redundant: CA1002
-dotnet_diagnostic.S3956.severity = none
 
 # Title    : "static readonly" constants should be "const" instead
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
 # Redundant: CA1802
-dotnet_diagnostic.S3962.severity = none
 
 # Title    : "static" fields should be initialized inline
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
 # Redundant: CA1810 and CA2207
-dotnet_diagnostic.S3963.severity = none
-
-# Title    : Objects should not be disposed more than once
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
-dotnet_diagnostic.S3966.severity = warning
-
-# Title    : Multidimensional arrays should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
-dotnet_diagnostic.S3967.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
-dotnet_diagnostic.S3971.severity = warning
-
-# Title    : Conditionals should start on new lines
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
-dotnet_diagnostic.S3972.severity = warning
-
-# Title    : A conditionally executed single line should be denoted by indentation
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
-dotnet_diagnostic.S3973.severity = warning
-
-# Title    : Collection sizes and array length comparisons should make sense
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
-dotnet_diagnostic.S3981.severity = warning
-
-# Title    : Exceptions should not be created without being thrown
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
-dotnet_diagnostic.S3984.severity = warning
 
 # Title    : Assemblies should be marked as CLS compliant
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
 # Redundant: CA1014
-dotnet_diagnostic.S3990.severity = none
 
 # Title    : Assemblies should explicitly specify COM visibility
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
 # Redundant: CA1017
-dotnet_diagnostic.S3992.severity = none
 
 # Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
 # Redundant: CA1018
-dotnet_diagnostic.S3993.severity = none
-
-# Title    : URI Parameters should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
-dotnet_diagnostic.S3994.severity = none
-
-# Title    : URI return values should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
-dotnet_diagnostic.S3995.severity = warning
-
-# Title    : URI properties should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
-dotnet_diagnostic.S3996.severity = warning
-
-# Title    : String URI overloads should call "System.Uri" overloads
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
-dotnet_diagnostic.S3997.severity = warning
-
-# Title    : Threads should not lock on objects with weak identity
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
-dotnet_diagnostic.S3998.severity = warning
-
-# Title    : Pointers to unmanaged memory should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
-dotnet_diagnostic.S4000.severity = warning
-
-# Title    : Disposable types should declare finalizers
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
-dotnet_diagnostic.S4002.severity = warning
 
 # Title    : Collection properties should be readonly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
 # Redundant: CA2227
-dotnet_diagnostic.S4004.severity = none
 
 # Title    : "System.Uri" arguments should be used instead of strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
 # Redundant: CA2234
-dotnet_diagnostic.S4005.severity = none
-
-# Title    : Inherited member visibility should not be decreased
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
-dotnet_diagnostic.S4015.severity = warning
-
-# Title    : Enumeration members should not be named "Reserved"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
-dotnet_diagnostic.S4016.severity = warning
-
-# Title    : Method signatures should not contain nested generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
-dotnet_diagnostic.S4017.severity = none
-
-# Title    : All type parameters should be used in the parameter list to enable type inference
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
-dotnet_diagnostic.S4018.severity = none
-
-# Title    : Base class methods should not be hidden
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
-dotnet_diagnostic.S4019.severity = warning
-
-# Title    : Enumerations should have "Int32" storage
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
-dotnet_diagnostic.S4022.severity = warning
-
-# Title    : Interfaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
-dotnet_diagnostic.S4023.severity = none
-
-# Title    : Child class fields should not differ from parent class fields only by capitalization
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
-dotnet_diagnostic.S4025.severity = warning
-
-# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
-dotnet_diagnostic.S4026.severity = warning
 
 # Title    : Exceptions should provide standard constructors
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
 # Redundant: CA1032
-dotnet_diagnostic.S4027.severity = none
-
-# Title    : Classes implementing "IEquatable<T>" should be sealed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
-dotnet_diagnostic.S4035.severity = warning
-
-# Title    : Searching OS commands in PATH is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
-dotnet_diagnostic.S4036.severity = warning
-
-# Title    : Interface methods should be callable by derived types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
-dotnet_diagnostic.S4039.severity = warning
 
 # Title    : Strings should be normalized to uppercase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
 # Redundant: CA1308
-dotnet_diagnostic.S4040.severity = none
-
-# Title    : Type names should not match namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
-dotnet_diagnostic.S4041.severity = warning
-
-# Title    : Generics should be used when appropriate
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
-dotnet_diagnostic.S4047.severity = warning
 
 # Title    : Properties should be preferred
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
 # Redundant: CA1024
-dotnet_diagnostic.S4049.severity = none
-
-# Title    : Operators should be overloaded consistently
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
-dotnet_diagnostic.S4050.severity = warning
-
-# Title    : Types should not extend outdated base types
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
-dotnet_diagnostic.S4052.severity = warning
-
-# Title    : Literals should not be passed as localized parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
-dotnet_diagnostic.S4055.severity = none
 
 # Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
 # Redundant: CA1305
-dotnet_diagnostic.S4056.severity = none
-
-# Title    : Locales should be set for data types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
-dotnet_diagnostic.S4057.severity = warning
 
 # Title    : Overloads with a "StringComparison" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
 # Redundant: CA1310
-dotnet_diagnostic.S4058.severity = none
-
-# Title    : Property names should not match get methods
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
-dotnet_diagnostic.S4059.severity = warning
 
 # Title    : Non-abstract attributes should be sealed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
 # Redundant: CA1813
-dotnet_diagnostic.S4060.severity = none
-
-# Title    : "params" should be used instead of "varargs"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
-dotnet_diagnostic.S4061.severity = warning
 
 # Title    : Operator overloads should have named alternatives
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
 # Redundant: CA2225
-dotnet_diagnostic.S4069.severity = none
 
 # Title    : Non-flags enums should not be marked with "FlagsAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
 # Redundant: CA2217
-dotnet_diagnostic.S4070.severity = none
-
-# Title    : Method overloads should be grouped together
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
-dotnet_diagnostic.S4136.severity = warning
-
-# Title    : Duplicate values should not be passed as arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
-dotnet_diagnostic.S4142.severity = warning
-
-# Title    : Collection elements should not be replaced unconditionally
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
-dotnet_diagnostic.S4143.severity = warning
-
-# Title    : Methods should not have identical implementations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
-dotnet_diagnostic.S4144.severity = warning
 
 # Title    : Empty collections should not be accessed or iterated
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
 # Comment  : Too many false positives
-dotnet_diagnostic.S4158.severity = none
-
-# Title    : Classes should implement their "ExportAttribute" interfaces
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
-dotnet_diagnostic.S4159.severity = warning
-
-# Title    : Native methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
-dotnet_diagnostic.S4200.severity = warning
-
-# Title    : Null checks should not be used with "is"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
-dotnet_diagnostic.S4201.severity = warning
-
-# Title    : Windows Forms entry points should be marked with STAThread
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
-dotnet_diagnostic.S4210.severity = warning
-
-# Title    : Members should not have conflicting transparency annotations
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
-dotnet_diagnostic.S4211.severity = warning
-
-# Title    : Serialization constructors should be secured
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
-dotnet_diagnostic.S4212.severity = warning
-
-# Title    : "P/Invoke" methods should not be visible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
-dotnet_diagnostic.S4214.severity = warning
-
-# Title    : Events should have proper arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
-dotnet_diagnostic.S4220.severity = warning
-
-# Title    : Extension methods should not extend "object"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
-dotnet_diagnostic.S4225.severity = warning
-
-# Title    : Extensions should be in separate namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
-dotnet_diagnostic.S4226.severity = none
-
-# Title    : "ConstructorArgument" parameters should exist in constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
-dotnet_diagnostic.S4260.severity = warning
-
-# Title    : Methods should be named according to their synchronicities
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
-dotnet_diagnostic.S4261.severity = none
-
-# Title    : Getters and setters should access the expected fields
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
-dotnet_diagnostic.S4275.severity = warning
-
-# Title    : "Shared" parts should not be created with "new"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
-dotnet_diagnostic.S4277.severity = warning
-
-# Title    : Weak SSL/TLS protocols should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
-dotnet_diagnostic.S4423.severity = warning
-
-# Title    : Cryptographic keys should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
-dotnet_diagnostic.S4426.severity = warning
-
-# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
-dotnet_diagnostic.S4428.severity = warning
-
-# Title    : AES encryption algorithm should be used with secured mode
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
-dotnet_diagnostic.S4432.severity = warning
-
-# Title    : LDAP connections should be authenticated
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
-dotnet_diagnostic.S4433.severity = warning
-
-# Title    : Parameter validation in yielding methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
-dotnet_diagnostic.S4456.severity = warning
-
-# Title    : Parameter validation in "async"/"await" methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
-dotnet_diagnostic.S4457.severity = warning
 
 # Title    : Calls to "async" methods should not be blocking
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
 # Redundant: VSTHRD002
-dotnet_diagnostic.S4462.severity = none
 
 # Title    : Unread "private" fields should be removed
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
 # Redundant: IDE0052
-dotnet_diagnostic.S4487.severity = none
-
-# Title    : Disabling CSRF protections is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
-dotnet_diagnostic.S4502.severity = warning
-
-# Title    : Delivering code in production with debug features activated is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
-dotnet_diagnostic.S4507.severity = warning
-
-# Title    : "default" clauses should be first or last
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
-dotnet_diagnostic.S4524.severity = warning
-
-# Title    : "DebuggerDisplayAttribute" strings should reference existing members
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4545
-dotnet_diagnostic.S4545.severity = warning
-
-# Title    : ASP.NET HTTP request validation feature should not be disabled
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
-dotnet_diagnostic.S4564.severity = warning
-
-# Title    : "new Guid()" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
-dotnet_diagnostic.S4581.severity = warning
-
-# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
-dotnet_diagnostic.S4583.severity = warning
-
-# Title    : Non-async "Task/Task<T>" methods should not return null
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
-dotnet_diagnostic.S4586.severity = warning
-
-# Title    : Start index should be used instead of calling Substring
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
-dotnet_diagnostic.S4635.severity = warning
-
-# Title    : Comments should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4663
-dotnet_diagnostic.S4663.severity = suggestion
-
-# Title    : Using regular expressions is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
-dotnet_diagnostic.S4784.severity = warning
-
-# Title    : Encrypting data is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
-dotnet_diagnostic.S4787.severity = warning
-
-# Title    : Using weak hashing algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
-dotnet_diagnostic.S4790.severity = warning
-
-# Title    : Configuring loggers is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
-dotnet_diagnostic.S4792.severity = warning
-
-# Title    : Using Sockets is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
-dotnet_diagnostic.S4818.severity = warning
-
-# Title    : Using command line arguments is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
-dotnet_diagnostic.S4823.severity = warning
-
-# Title    : Reading the Standard Input is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
-dotnet_diagnostic.S4829.severity = warning
 
 # Title    : Server certificates should be verified during SSL/TLS connections
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
 # Redundant: CA5359
-dotnet_diagnostic.S4830.severity = none
-
-# Title    : Controlling permissions is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
-dotnet_diagnostic.S4834.severity = warning
-
-# Title    : "ValueTask" should be consumed correctly
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
-dotnet_diagnostic.S5034.severity = warning
-
-# Title    : Expanding archive files without controlling resource consumption is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
-dotnet_diagnostic.S5042.severity = warning
-
-# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
-dotnet_diagnostic.S5122.severity = warning
-
-# Title    : Using clear-text protocols is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
-dotnet_diagnostic.S5332.severity = warning
-
-# Title    : Using publicly writable directories is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
-dotnet_diagnostic.S5443.severity = warning
-
-# Title    : Insecure temporary file creation methods should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
-dotnet_diagnostic.S5445.severity = warning
-
-# Title    : Encryption algorithms should be used with secure mode and padding scheme
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
-dotnet_diagnostic.S5542.severity = warning
-
-# Title    : Cipher algorithms should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
-dotnet_diagnostic.S5547.severity = warning
-
-# Title    : JWT should be signed and verified with strong cipher algorithms
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
-dotnet_diagnostic.S5659.severity = warning
-
-# Title    : Allowing requests with excessive content length is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
-dotnet_diagnostic.S5693.severity = warning
-
-# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
-dotnet_diagnostic.S5753.severity = warning
-
-# Title    : Deserializing objects without performing data validation is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
-dotnet_diagnostic.S5766.severity = warning
-
-# Title    : Types allowed to be deserialized should be restricted
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
-dotnet_diagnostic.S5773.severity = warning
-
-# Title    : Regular expressions should be syntactically valid
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5856
-dotnet_diagnostic.S5856.severity = warning
 
 # Title    : Use a testable date/time provider
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
 # Redundant: R9A022
-dotnet_diagnostic.S6354.severity = none
-
-# Title    : Azure Functions should be stateless
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
-dotnet_diagnostic.S6419.severity = warning
-
-# Title    : Client instances should not be recreated on each Azure Function invocation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
-dotnet_diagnostic.S6420.severity = warning
-
-# Title    : Azure Functions should use Structured Error Handling
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
-dotnet_diagnostic.S6421.severity = warning
-
-# Title    : Calls to "async" methods should not be blocking in Azure Functions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
-dotnet_diagnostic.S6422.severity = warning
-
-# Title    : Azure Functions should log all failures
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
-dotnet_diagnostic.S6423.severity = warning
-
-# Title    : Interfaces for durable entities should satisfy the restrictions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
-dotnet_diagnostic.S6424.severity = warning
-
-# Title    : Not specifying a timeout for regular expressions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
-dotnet_diagnostic.S6444.severity = warning
 
 # Title    : Blocks should not be synchronized on local variables
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6507
 # Comment  : Too many false positives
-dotnet_diagnostic.S6507.severity = none
-
-# Title    : "ExcludeFromCodeCoverage" attributes should include a justification
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6513
-dotnet_diagnostic.S6513.severity = suggestion
-
-# Title    : Avoid using "DateTime.Now" for benchmarking or timing operations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6561
-dotnet_diagnostic.S6561.severity = warning
 
 # Title    : Always set the "DateTimeKind" when creating new "DateTime" instances
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6562
 # Comment  : Noise
-dotnet_diagnostic.S6562.severity = none
-
-# Title    : Use UTC when recording DateTime instants
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6563
-dotnet_diagnostic.S6563.severity = none
 
 # Title    : Use "DateTimeOffset" instead of "DateTime"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6566
 # Comment  : Noise
-dotnet_diagnostic.S6566.severity = none
-
-# Title    : Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6575
-dotnet_diagnostic.S6575.severity = warning
-
-# Title    : Use a format provider when parsing date and time
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6580
-dotnet_diagnostic.S6580.severity = warning
-
-# Title    : Don't hardcode the format when turning dates and times to strings
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6585
-dotnet_diagnostic.S6585.severity = none
-
-# Title    : Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6588
-dotnet_diagnostic.S6588.severity = warning
-
-# Title    : "Find" method should be used instead of the "FirstOrDefault" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6602
-dotnet_diagnostic.S6602.severity = warning
-
-# Title    : The collection-specific "TrueForAll" method should be used instead of the "All" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6603
-dotnet_diagnostic.S6603.severity = warning
-
-# Title    : Collection-specific "Exists" method should be used instead of the "Any" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6605
-dotnet_diagnostic.S6605.severity = warning
-
-# Title    : The collection should be filtered before sorting by using "Where" before "OrderBy"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6607
-dotnet_diagnostic.S6607.severity = warning
-
-# Title    : Prefer indexing instead of "Enumerable" methods on types implementing "IList"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6608
-dotnet_diagnostic.S6608.severity = warning
-
-# Title    : "Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6609
-dotnet_diagnostic.S6609.severity = warning
-
-# Title    : "StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6610
-dotnet_diagnostic.S6610.severity = warning
-
-# Title    : The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6612
-dotnet_diagnostic.S6612.severity = warning
-
-# Title    : "First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6613
-dotnet_diagnostic.S6613.severity = warning
-
-# Title    : "Contains" should be used instead of "Any" for simple equality checks
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6617
-dotnet_diagnostic.S6617.severity = warning
-
-# Title    : "string.Create" should be used instead of "FormattableString"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6618
-dotnet_diagnostic.S6618.severity = warning
-
-# Title    : Using unsafe code blocks is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6640
-dotnet_diagnostic.S6640.severity = warning
-
-# Title    : Literal suffixes should be upper case
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
-dotnet_diagnostic.S818.severity = warning
-
-# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
-dotnet_diagnostic.S881.severity = suggestion
-
-# Title    : "goto" statement should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
-dotnet_diagnostic.S907.severity = warning
 
 # Title    : Parameter names should match base declaration and other partial definitions
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
 # Redundant: CA1725
-dotnet_diagnostic.S927.severity = none
 
 # Title    : Copy-paste token calculator
 # Category : 

--- a/src/Shared/Data.Validation/ValidationContextExtensions.cs
+++ b/src/Shared/Data.Validation/ValidationContextExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations;
@@ -15,11 +15,9 @@ internal static class ValidationContextExtensions
 {
     public static string[]? GetMemberName(this ValidationContext? validationContext)
     {
-#pragma warning disable S1168 // Empty arrays and collections should be returned instead of null
         return validationContext?.MemberName is { } memberName
             ? new[] { memberName }
             : null;
-#pragma warning restore S1168 // Empty arrays and collections should be returned instead of null
     }
 
     public static string GetDisplayName(this ValidationContext? validationContext)

--- a/src/Shared/DiagnosticIds/DiagnosticIds.cs
+++ b/src/Shared/DiagnosticIds/DiagnosticIds.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable S1144 // Remove the unused internal class
-
 #pragma warning disable CA1716
 namespace Microsoft.Shared.DiagnosticIds;
 #pragma warning restore CA1716
@@ -16,9 +14,7 @@ namespace Microsoft.Shared.DiagnosticIds;
 /// </remarks>
 internal static class DiagnosticIds
 {
-#pragma warning disable S1075 // URIs should not be hardcoded
     internal const string UrlFormat = "https://aka.ms/dotnet-extensions-warnings/{0}";
-#pragma warning restore S1075 // URIs should not be hardcoded
 
     internal static class ContextualOptions
     {
@@ -156,5 +152,3 @@ internal static class DiagnosticIds
             "This API is obsolete and will be removed in a future version. Instead of the AddServiceLogEnricher() methods, consider using the respective AddApplicationLogEnricher() methods.";
     }
 }
-
-#pragma warning restore S1144

--- a/src/Shared/ServerSentEvents/ArrayBuffer.cs
+++ b/src/Shared/ServerSentEvents/ArrayBuffer.cs
@@ -8,9 +8,7 @@ using System.Runtime.InteropServices;
 
 #pragma warning disable SA1405 // Debug.Assert should provide message text
 #pragma warning disable IDE0032 // Use auto property
-#pragma warning disable S3358 // Ternary operators should not be nested
 #pragma warning disable SA1202 // Elements should be ordered by access
-#pragma warning disable S109 // Magic numbers should not be used
 
 namespace System.Net
 {

--- a/src/Shared/ServerSentEvents/Helpers.cs
+++ b/src/Shared/ServerSentEvents/Helpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
@@ -16,7 +16,6 @@ using System.Threading.Tasks;
 #endif
 
 #pragma warning disable SA1405 // Debug.Assert should provide message text
-#pragma warning disable S2333 // Redundant modifiers should not be used
 #pragma warning disable SA1519 // Braces should not be omitted from multi-line child statement
 #pragma warning disable LA0001 // Use Microsoft.Shared.Diagnostics.Throws for improved performance
 #pragma warning disable LA0002 // Use Microsoft.Shared.Diagnostics.ToInvariantString for improved performance

--- a/src/Shared/ServerSentEvents/SseParser.cs
+++ b/src/Shared/ServerSentEvents/SseParser.cs
@@ -4,8 +4,6 @@
 using System.IO;
 using System.Text;
 
-#pragma warning disable S2333 // Redundant modifiers should not be used
-
 namespace System.Net.ServerSentEvents
 {
     /// <summary>Provides a parser for parsing server-sent events.</summary>

--- a/src/Shared/ServerSentEvents/SseParser_1.cs
+++ b/src/Shared/ServerSentEvents/SseParser_1.cs
@@ -21,7 +21,6 @@ using System.Threading.Tasks;
 #pragma warning disable IDE0011 // Add braces
 #pragma warning disable SA1114 // Parameter list should follow declaration
 #pragma warning disable SA1106 // Code should not contain empty statements
-#pragma warning disable S109 // Magic numbers should not be used
 #pragma warning disable SA1204 // Static elements should appear before instance elements
 #pragma warning disable SA1108 // Block statements should not contain embedded comments
 #pragma warning disable format

--- a/src/Shared/Throw/Throw.cs
+++ b/src/Shared/Throw/Throw.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -17,8 +17,6 @@ namespace Microsoft.Shared.Diagnostics;
 /// The main purpose is to reduce code size, improve performance, and standardize exception
 /// messages.
 /// </remarks>
-[SuppressMessage("Minor Code Smell", "S4136:Method overloads should be grouped together", Justification = "Doesn't work with the region layout")]
-[SuppressMessage("Minor Code Smell", "S2333:Partial is gratuitous in this context", Justification = "Some projects add additional partial parts.")]
 [SuppressMessage("Design", "CA1716", Justification = "Not part of an API")]
 
 #if !SHARED_PROJECT
@@ -872,9 +870,7 @@ internal static partial class Throw
     public static double IfLessThan(double argument, double min, [CallerArgumentExpression(nameof(argument))] string paramName = "")
     {
         // strange conditional needed in order to handle NaN values correctly
-#pragma warning disable S1940 // Boolean checks should not be inverted
         if (!(argument >= min))
-#pragma warning restore S1940 // Boolean checks should not be inverted
         {
             ArgumentOutOfRangeException(paramName, argument, $"Argument less than minimum value {min}");
         }
@@ -893,9 +889,7 @@ internal static partial class Throw
     public static double IfGreaterThan(double argument, double max, [CallerArgumentExpression(nameof(argument))] string paramName = "")
     {
         // strange conditional needed in order to handle NaN values correctly
-#pragma warning disable S1940 // Boolean checks should not be inverted
         if (!(argument <= max))
-#pragma warning restore S1940 // Boolean checks should not be inverted
         {
             ArgumentOutOfRangeException(paramName, argument, $"Argument greater than maximum value {max}");
         }
@@ -914,9 +908,7 @@ internal static partial class Throw
     public static double IfLessThanOrEqual(double argument, double min, [CallerArgumentExpression(nameof(argument))] string paramName = "")
     {
         // strange conditional needed in order to handle NaN values correctly
-#pragma warning disable S1940 // Boolean checks should not be inverted
         if (!(argument > min))
-#pragma warning restore S1940 // Boolean checks should not be inverted
         {
             ArgumentOutOfRangeException(paramName, argument, $"Argument less or equal than minimum value {min}");
         }
@@ -935,9 +927,7 @@ internal static partial class Throw
     public static double IfGreaterThanOrEqual(double argument, double max, [CallerArgumentExpression(nameof(argument))] string paramName = "")
     {
         // strange conditional needed in order to handle NaN values correctly
-#pragma warning disable S1940 // Boolean checks should not be inverted
         if (!(argument < max))
-#pragma warning restore S1940 // Boolean checks should not be inverted
         {
             ArgumentOutOfRangeException(paramName, argument, $"Argument greater or equal than maximum value {max}");
         }
@@ -974,9 +964,7 @@ internal static partial class Throw
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static double IfZero(double argument, [CallerArgumentExpression(nameof(argument))] string paramName = "")
     {
-#pragma warning disable S1244 // Floating point numbers should not be tested for equality
         if (argument == 0.0)
-#pragma warning restore S1244 // Floating point numbers should not be tested for equality
         {
             ArgumentOutOfRangeException(paramName, "Argument is zero");
         }

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -477,12 +477,12 @@ dotnet_diagnostic.CA1507.severity = warning
 # Title    : Avoid dead conditional code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
-dotnet_diagnostic.CA1508.severity = warning
+dotnet_diagnostic.CA1508.severity = none
 
 # Title    : Avoid dead conditional code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
-dotnet_diagnostic.CA1508.severity = warning
+dotnet_diagnostic.CA1508.severity = none
 
 # Title    : Invalid entry in code metrics rule specification file
 # Category : Maintainability
@@ -2883,2309 +2883,391 @@ dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
 # Redundant: IDE1006
-dotnet_diagnostic.S100.severity = none
-
-# Title    : Method overrides should not change parameter defaults
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
-dotnet_diagnostic.S1006.severity = warning
 
 # Title    : Types should be named in PascalCase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
 # Redundant: IDE1006
-dotnet_diagnostic.S101.severity = none
-
-# Title    : Lines should not be too long
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
-dotnet_diagnostic.S103.severity = warning
-
-# Title    : Files should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
-dotnet_diagnostic.S104.severity = warning
 
 # Title    : Finalizers should not throw exceptions
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
 # Redundant: CA1065
-dotnet_diagnostic.S1048.severity = none
 
 # Title    : Tabulation characters should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
 # Redundant: SA1027
-dotnet_diagnostic.S105.severity = none
-
-# Title    : Standard outputs should not be used directly to log anything
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
-dotnet_diagnostic.S106.severity = none
-
-# Title    : Collapsible "if" statements should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
-dotnet_diagnostic.S1066.severity = none
-
-# Title    : Expressions should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
-dotnet_diagnostic.S1067.severity = warning
-
-# Title    : Methods should not have too many parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
-dotnet_diagnostic.S107.severity = none
-
-# Title    : URIs should not be hardcoded
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
-dotnet_diagnostic.S1075.severity = warning
-
-# Title    : Nested blocks of code should not be left empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
-dotnet_diagnostic.S108.severity = warning
-
-# Title    : Magic numbers should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
-dotnet_diagnostic.S109.severity = warning
-
-# Title    : Inheritance tree of classes should not be too deep
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
-dotnet_diagnostic.S110.severity = warning
 
 # Title    : Fields should not have public accessibility
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
 # Redundant: CA1051
-dotnet_diagnostic.S1104.severity = none
 
 # Title    : A close curly brace should be located at the beginning of a line
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
 # Redundant: SA1500
-dotnet_diagnostic.S1109.severity = none
 
 # Title    : Redundant pairs of parentheses should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
 # Redundant: SA1119
-dotnet_diagnostic.S1110.severity = none
 
 # Title    : Empty statements should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
 # Redundant: SA1106
-dotnet_diagnostic.S1116.severity = none
-
-# Title    : Local variables should not shadow class fields or properties
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
-dotnet_diagnostic.S1117.severity = warning
 
 # Title    : Utility classes should not have public constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
 # Redundant: CA1052
-dotnet_diagnostic.S1118.severity = none
 
 # Title    : General exceptions should never be thrown
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
 # Redundant: CA2219
-dotnet_diagnostic.S112.severity = none
-
-# Title    : Assignments should not be made from within sub-expressions
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
-dotnet_diagnostic.S1121.severity = warning
 
 # Title    : "Obsolete" attributes should include explanations
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
 # Redundant: CA1041
-dotnet_diagnostic.S1123.severity = none
-
-# Title    : Boolean literals should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
-dotnet_diagnostic.S1125.severity = warning
-
-# Title    : Unused "using" should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
-dotnet_diagnostic.S1128.severity = warning
-
-# Title    : Files should contain an empty newline at the end
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
-dotnet_diagnostic.S113.severity = none
-
-# Title    : Deprecated code should be removed
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1133
-dotnet_diagnostic.S1133.severity = suggestion
-
-# Title    : Track uses of "FIXME" tags
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
-dotnet_diagnostic.S1134.severity = warning
-
-# Title    : Track uses of "TODO" tags
-# Category : Info Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
-dotnet_diagnostic.S1135.severity = warning
-
-# Title    : Unused private types or members should be removed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
-dotnet_diagnostic.S1144.severity = warning
-
-# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
-dotnet_diagnostic.S1145.severity = warning
-
-# Title    : Exit methods should not be called
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
-dotnet_diagnostic.S1147.severity = warning
-
-# Title    : "switch case" clauses should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
-dotnet_diagnostic.S1151.severity = none
-
-# Title    : "Any()" should be used to test for emptiness
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
-dotnet_diagnostic.S1155.severity = warning
 
 # Title    : Exceptions should not be thrown in finally blocks
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
 # Redundant: CA2219
-dotnet_diagnostic.S1163.severity = none
-
-# Title    : Empty arrays and collections should be returned instead of null
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
-dotnet_diagnostic.S1168.severity = warning
 
 # Title    : Unused method parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
 # Redundant: IDE0060
-dotnet_diagnostic.S1172.severity = none
-
-# Title    : Overriding members should do more than simply call the same member in the base class
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
-dotnet_diagnostic.S1185.severity = warning
-
-# Title    : Methods should not be empty
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
-dotnet_diagnostic.S1186.severity = warning
-
-# Title    : String literals should not be duplicated
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
-dotnet_diagnostic.S1192.severity = suggestion
-
-# Title    : Nested code blocks should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
-dotnet_diagnostic.S1199.severity = warning
-
-# Title    : Classes should not be coupled to too many other classes
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
-dotnet_diagnostic.S1200.severity = none
 
 # Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
 # Redundant: CS0659
-dotnet_diagnostic.S1206.severity = none
 
 # Title    : Control structures should use curly braces
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
 # Redundant: SA1503
-dotnet_diagnostic.S121.severity = none
 
 # Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
 # Redundant: CA1036
-dotnet_diagnostic.S1210.severity = none
-
-# Title    : "GC.Collect" should not be called
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
-dotnet_diagnostic.S1215.severity = none
-
-# Title    : Statements should be on separate lines
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
-dotnet_diagnostic.S122.severity = none
-
-# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
-dotnet_diagnostic.S1226.severity = warning
-
-# Title    : break statements should not be used except for switch cases
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
-dotnet_diagnostic.S1227.severity = none
-
-# Title    : Floating point numbers should not be tested for equality
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
-dotnet_diagnostic.S1244.severity = error
-
-# Title    : Sections of code should not be commented out
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
-dotnet_diagnostic.S125.severity = warning
-
-# Title    : "if ... else if" constructs should end with "else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
-dotnet_diagnostic.S126.severity = none
-
-# Title    : A "while" loop should be used instead of a "for" loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
-dotnet_diagnostic.S1264.severity = warning
-
-# Title    : "for" loop stop conditions should be invariant
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
-dotnet_diagnostic.S127.severity = warning
-
-# Title    : "switch" statements should have at least 3 "case" clauses
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
-dotnet_diagnostic.S1301.severity = none
 
 # Title    : Track uses of in-source issue suppressions
 # Category : Info Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
 # Comment  : Suppressions are frequently necessary.
-dotnet_diagnostic.S1309.severity = none
-
-# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
-dotnet_diagnostic.S131.severity = none
-
-# Title    : Using hardcoded IP addresses is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
-dotnet_diagnostic.S1313.severity = warning
-
-# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
-dotnet_diagnostic.S134.severity = none
-
-# Title    : Functions should not have too many lines of code
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
-dotnet_diagnostic.S138.severity = none
-
-# Title    : Culture should be specified for "string" operations
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
-dotnet_diagnostic.S1449.severity = warning
-
-# Title    : Private fields only used as local variables in methods should become local variables
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
-dotnet_diagnostic.S1450.severity = warning
 
 # Title    : Track lack of copyright and license headers
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
 # Redundant: IDE0073
-dotnet_diagnostic.S1451.severity = none
-
-# Title    : "switch" statements should not have too many "case" clauses
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
-dotnet_diagnostic.S1479.severity = warning
 
 # Title    : Unused local variables should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
 # Redundant: CS0168
-dotnet_diagnostic.S1481.severity = none
-
-# Title    : Methods and properties should not be too complex
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
-dotnet_diagnostic.S1541.severity = none
-
-# Title    : Tests should not be ignored
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
-dotnet_diagnostic.S1607.severity = warning
-
-# Title    : Strings should not be concatenated using '+' in a loop
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
-dotnet_diagnostic.S1643.severity = warning
-
-# Title    : Variables should not be self-assigned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
-dotnet_diagnostic.S1656.severity = warning
-
-# Title    : Multiple variables should not be declared on the same line
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
-dotnet_diagnostic.S1659.severity = warning
-
-# Title    : An abstract class should have both abstract and concrete methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
-dotnet_diagnostic.S1694.severity = warning
-
-# Title    : NullReferenceException should not be caught
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
-dotnet_diagnostic.S1696.severity = warning
-
-# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
-dotnet_diagnostic.S1697.severity = warning
-
-# Title    : "==" should not be used when "Equals" is overridden
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
-dotnet_diagnostic.S1698.severity = warning
-
-# Title    : Constructors should only call non-overridable methods
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
-dotnet_diagnostic.S1699.severity = warning
-
-# Title    : Loops with at most one iteration should be refactored
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
-dotnet_diagnostic.S1751.severity = warning
-
-# Title    : Identical expressions should not be used on both sides of operators
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
-dotnet_diagnostic.S1764.severity = warning
-
-# Title    : "switch" statements should not be nested
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
-dotnet_diagnostic.S1821.severity = none
-
-# Title    : Objects should not be created to be dropped immediately without being used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
-dotnet_diagnostic.S1848.severity = warning
 
 # Title    : Unused assignments should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
 # Redundant: IDE0059
-dotnet_diagnostic.S1854.severity = none
-
-# Title    : "ToString()" calls should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
-dotnet_diagnostic.S1858.severity = warning
-
-# Title    : Related "if/else if" statements should not have the same condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
-dotnet_diagnostic.S1862.severity = warning
-
-# Title    : Two branches in a conditional structure should not have exactly the same implementation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
-dotnet_diagnostic.S1871.severity = warning
 
 # Title    : Redundant casts should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
 # Redundant: IDE0004
-dotnet_diagnostic.S1905.severity = none
-
-# Title    : Inheritance list should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
-dotnet_diagnostic.S1939.severity = warning
-
-# Title    : Boolean checks should not be inverted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
-dotnet_diagnostic.S1940.severity = warning
-
-# Title    : Invalid casts should be avoided
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
-dotnet_diagnostic.S1944.severity = warning
-
-# Title    : "for" loop increment clauses should modify the loops' counters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
-dotnet_diagnostic.S1994.severity = warning
 
 # Title    : Hashes should include an unpredictable salt
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S2053.severity = none
-
-# Title    : Hard-coded credentials are security-sensitive
-# Category : Blocker Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
-dotnet_diagnostic.S2068.severity = warning
 
 # Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
 # Redundant: CA5350
-dotnet_diagnostic.S2070.severity = none
-
-# Title    : Formatting SQL queries is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
-dotnet_diagnostic.S2077.severity = warning
-
-# Title    : Creating cookies without the "secure" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
-dotnet_diagnostic.S2092.severity = warning
-
-# Title    : Classes should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2094
-dotnet_diagnostic.S2094.severity = none
-
-# Title    : Collections should not be passed as arguments to their own methods
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
-dotnet_diagnostic.S2114.severity = warning
-
-# Title    : A secure password should be used when connecting to a database
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
-dotnet_diagnostic.S2115.severity = warning
-
-# Title    : Values should not be uselessly incremented
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
-dotnet_diagnostic.S2123.severity = warning
-
-# Title    : Underscores should be used to make large numbers readable
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
-dotnet_diagnostic.S2148.severity = warning
-
-# Title    : "sealed" classes should not have "protected" members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
-dotnet_diagnostic.S2156.severity = warning
-
-# Title    : Classes named like "Exception" should extend "Exception" or a subclass
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2166
-dotnet_diagnostic.S2166.severity = warning
-
-# Title    : Short-circuit logic should be used in boolean contexts
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
-dotnet_diagnostic.S2178.severity = warning
-
-# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
-dotnet_diagnostic.S2183.severity = warning
-
-# Title    : Results of integer division should not be assigned to floating point variables
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
-dotnet_diagnostic.S2184.severity = warning
-
-# Title    : Test classes should contain at least one test case
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
-dotnet_diagnostic.S2187.severity = warning
-
-# Title    : Loops and recursions should not be infinite
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
-dotnet_diagnostic.S2190.severity = warning
-
-# Title    : Modulus results should not be checked for direct equality
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
-dotnet_diagnostic.S2197.severity = warning
-
-# Title    : Unnecessary mathematical comparisons should not be made
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2198
-dotnet_diagnostic.S2198.severity = warning
 
 # Title    : Methods without side effects should not have their return values ignored
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
 # Redundant: CA1806
-dotnet_diagnostic.S2201.severity = none
-
-# Title    : Runtime type checking should be simplified
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
-dotnet_diagnostic.S2219.severity = warning
-
-# Title    : "Exception" should not be caught
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
-dotnet_diagnostic.S2221.severity = none
-
-# Title    : Locks should be released on all paths
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
-dotnet_diagnostic.S2222.severity = warning
-
-# Title    : Non-constant static fields should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
-dotnet_diagnostic.S2223.severity = warning
-
-# Title    : "ToString()" method should not return null
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
-dotnet_diagnostic.S2225.severity = warning
-
-# Title    : Console logging should not be used
-# Category : Minor Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
-dotnet_diagnostic.S2228.severity = none
-
-# Title    : Arguments should be passed in the same order as the method parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
-dotnet_diagnostic.S2234.severity = warning
-
-# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
-dotnet_diagnostic.S2245.severity = warning
-
-# Title    : A "for" loop update clause should move the counter in the right direction
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
-dotnet_diagnostic.S2251.severity = warning
-
-# Title    : For-loop conditions should be true at least once
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
-dotnet_diagnostic.S2252.severity = warning
-
-# Title    : Writing cookies is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
-dotnet_diagnostic.S2255.severity = warning
-
-# Title    : Using non-standard cryptographic algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
-dotnet_diagnostic.S2257.severity = warning
 
 # Title    : Null pointers should not be dereferenced
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
 # Comment  : Redundant, covered by modern C# compiler
-dotnet_diagnostic.S2259.severity = none
-
-# Title    : Composite format strings should not lead to unexpected behavior at runtime
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
-dotnet_diagnostic.S2275.severity = warning
-
-# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
-dotnet_diagnostic.S2278.severity = warning
-
-# Title    : Field-like events should not be virtual
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
-dotnet_diagnostic.S2290.severity = warning
-
-# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
-dotnet_diagnostic.S2291.severity = warning
 
 # Title    : Trivial properties should be auto-implemented
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
 # Redundant: IDE0032
-dotnet_diagnostic.S2292.severity = none
-
-# Title    : "nameof" should be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
-dotnet_diagnostic.S2302.severity = warning
-
-# Title    : "async" and "await" should not be used as identifiers
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
-dotnet_diagnostic.S2306.severity = warning
 
 # Title    : Methods and properties that don't access instance data should be static
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
 # Redundant: CA1822
-dotnet_diagnostic.S2325.severity = none
 
 # Title    : Unused type parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
 # Comment  : Valid pattern used in a number of places
-dotnet_diagnostic.S2326.severity = none
-
-# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
-dotnet_diagnostic.S2327.severity = warning
-
-# Title    : "GetHashCode" should not reference mutable fields
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
-dotnet_diagnostic.S2328.severity = warning
-
-# Title    : Array covariance should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
-dotnet_diagnostic.S2330.severity = warning
-
-# Title    : Redundant modifiers should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
-dotnet_diagnostic.S2333.severity = warning
-
-# Title    : Public constant members should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
-dotnet_diagnostic.S2339.severity = none
-
-# Title    : Enumeration types should comply with a naming convention
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
-dotnet_diagnostic.S2342.severity = none
-
-# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
-dotnet_diagnostic.S2344.severity = warning
-
-# Title    : Flags enumerations should explicitly initialize all their members
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
-dotnet_diagnostic.S2345.severity = warning
 
 # Title    : Flags enumerations zero-value members should be named "None"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
 # Redundant: CA1008
-dotnet_diagnostic.S2346.severity = none
 
 # Title    : Fields should be private
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
 # Redundant: CA1051
-dotnet_diagnostic.S2357.severity = none
-
-# Title    : Optional parameters should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
-dotnet_diagnostic.S2360.severity = none
-
-# Title    : Properties should not make collection or array copies
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
-dotnet_diagnostic.S2365.severity = warning
-
-# Title    : Public methods should not have multidimensional array parameters
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
-dotnet_diagnostic.S2368.severity = warning
-
-# Title    : Exceptions should not be thrown from property getters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
-dotnet_diagnostic.S2372.severity = warning
-
-# Title    : Write-only properties should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
-dotnet_diagnostic.S2376.severity = warning
-
-# Title    : Mutable fields should not be "public static"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
-dotnet_diagnostic.S2386.severity = warning
-
-# Title    : Child class fields should not shadow parent class fields
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
-dotnet_diagnostic.S2387.severity = warning
 
 # Title    : Types and methods should not have too many generic parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
 # Redundant: CA1005
-dotnet_diagnostic.S2436.severity = none
-
-# Title    : Unnecessary bit operations should not be performed
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
-dotnet_diagnostic.S2437.severity = warning
 
 # Title    : Blocks should be synchronized on read-only fields
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2445
 # Comment  : Noise
-dotnet_diagnostic.S2445.severity = none
-
-# Title    : Whitespace and control characters in string literals should be explicit
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
-dotnet_diagnostic.S2479.severity = warning
-
-# Title    : Generic exceptions should not be ignored
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
-dotnet_diagnostic.S2486.severity = warning
-
-# Title    : Shared resources should not be used for locking
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
-dotnet_diagnostic.S2551.severity = warning
 
 # Title    : Conditionally executed code should be reachable
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
 # Redundant: CA1508
-dotnet_diagnostic.S2583.severity = none
 
 # Title    : Boolean expressions should not be gratuitous
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
 # Comment  : Too many false positives.
-dotnet_diagnostic.S2589.severity = none
-
-# Title    : Setting loose file permissions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
-dotnet_diagnostic.S2612.severity = warning
-
-# Title    : The length returned from a stream read should be checked
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
-dotnet_diagnostic.S2674.severity = warning
-
-# Title    : Multiline blocks should be enclosed in curly braces
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
-dotnet_diagnostic.S2681.severity = warning
-
-# Title    : "NaN" should not be used in comparisons
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
-dotnet_diagnostic.S2688.severity = warning
-
-# Title    : "IndexOf" checks should not be for positive numbers
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
-dotnet_diagnostic.S2692.severity = warning
-
-# Title    : Instance members should not write to "static" fields
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
-dotnet_diagnostic.S2696.severity = warning
-
-# Title    : Tests should include assertions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
-dotnet_diagnostic.S2699.severity = warning
-
-# Title    : Literal boolean values should not be used in assertions
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
-dotnet_diagnostic.S2701.severity = warning
-
-# Title    : "catch" clauses should do more than rethrow
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
-dotnet_diagnostic.S2737.severity = warning
-
-# Title    : Static fields should not be used in generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
-dotnet_diagnostic.S2743.severity = none
-
-# Title    : XML parsers should not be vulnerable to XXE attacks
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
-dotnet_diagnostic.S2755.severity = warning
-
-# Title    : Non-existent operators like "=+" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
-dotnet_diagnostic.S2757.severity = warning
-
-# Title    : The ternary operator should not return the same value regardless of the condition
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
-dotnet_diagnostic.S2758.severity = warning
-
-# Title    : Sequential tests should not check the same condition
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
-dotnet_diagnostic.S2760.severity = warning
-
-# Title    : Doubled prefix operators "!!" and "~~" should not be used
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
-dotnet_diagnostic.S2761.severity = warning
-
-# Title    : SQL keywords should be delimited by whitespace
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
-dotnet_diagnostic.S2857.severity = warning
-
-# Title    : "Thread.Sleep" should not be used in tests
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2925
-dotnet_diagnostic.S2925.severity = none
 
 # Title    : "IDisposables" should be disposed
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
 # Redundant: CA2000
-dotnet_diagnostic.S2930.severity = none
 
 # Title    : Classes with "IDisposable" members should implement "IDisposable"
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
 # Redundant: CA1001
-dotnet_diagnostic.S2931.severity = none
 
 # Title    : Fields that are only assigned in the constructor should be "readonly"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
 # Redundant: IDE0044
-dotnet_diagnostic.S2933.severity = none
-
-# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
-dotnet_diagnostic.S2934.severity = warning
-
-# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
-dotnet_diagnostic.S2952.severity = warning
-
-# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
-dotnet_diagnostic.S2953.severity = warning
-
-# Title    : Generic parameters not constrained to reference types should not be compared to "null"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
-dotnet_diagnostic.S2955.severity = warning
-
-# Title    : Assertions should be complete
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2970
-dotnet_diagnostic.S2970.severity = warning
-
-# Title    : "IEnumerable" LINQs should be simplified
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
-dotnet_diagnostic.S2971.severity = warning
-
-# Title    : "Object.ReferenceEquals" should not be used for value types
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
-dotnet_diagnostic.S2995.severity = warning
-
-# Title    : "ThreadStatic" fields should not be initialized
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
-dotnet_diagnostic.S2996.severity = warning
-
-# Title    : "IDisposables" created in a "using" statement should not be returned
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
-dotnet_diagnostic.S2997.severity = warning
-
-# Title    : "ThreadStatic" should not be used on non-static fields
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
-dotnet_diagnostic.S3005.severity = warning
-
-# Title    : Static fields should not be updated in constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
-dotnet_diagnostic.S3010.severity = warning
-
-# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
-dotnet_diagnostic.S3011.severity = warning
 
 # Title    : Members should not be initialized to default values
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
 # Redundant: CA1805
-dotnet_diagnostic.S3052.severity = none
-
-# Title    : Types should not have members with visibility set higher than the type's visibility
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
-dotnet_diagnostic.S3059.severity = none
-
-# Title    : "is" should not be used with "this"
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
-dotnet_diagnostic.S3060.severity = warning
-
-# Title    : "StringBuilder" data should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3063
-dotnet_diagnostic.S3063.severity = warning
 
 # Title    : "async" methods should not return "void"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
 # Redundant: VSTHRD100
-dotnet_diagnostic.S3168.severity = none
-
-# Title    : Multiple "OrderBy" calls should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
-dotnet_diagnostic.S3169.severity = warning
-
-# Title    : Delegates should not be subtracted
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
-dotnet_diagnostic.S3172.severity = warning
-
-# Title    : "interface" instances should not be cast to concrete types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
-dotnet_diagnostic.S3215.severity = warning
 
 # Title    : "ConfigureAwait(false)" should be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
 # Redundant: CA2007
-dotnet_diagnostic.S3216.severity = none
-
-# Title    : "Explicit" conversions of "foreach" loops should not be used
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
-dotnet_diagnostic.S3217.severity = warning
-
-# Title    : Inner class members should not shadow outer class "static" or type members
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
-dotnet_diagnostic.S3218.severity = warning
-
-# Title    : Method calls should not resolve ambiguously to overloads with "params"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
-dotnet_diagnostic.S3220.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
-dotnet_diagnostic.S3234.severity = warning
-
-# Title    : Redundant parentheses should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
-dotnet_diagnostic.S3235.severity = warning
-
-# Title    : Caller information arguments should not be provided explicitly
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
-dotnet_diagnostic.S3236.severity = warning
-
-# Title    : "value" contextual keyword should be used
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
-dotnet_diagnostic.S3237.severity = warning
 
 # Title    : The simplest possible condition syntax should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
 # Redundant: IDE0054
-dotnet_diagnostic.S3240.severity = none
-
-# Title    : Methods should not return values that are never used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
-dotnet_diagnostic.S3241.severity = warning
 
 # Title    : Method parameters should be declared with base types
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
 # Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
-dotnet_diagnostic.S3242.severity = none
-
-# Title    : Anonymous delegates should not be used to unsubscribe from Events
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
-dotnet_diagnostic.S3244.severity = warning
-
-# Title    : Generic type parameters should be co/contravariant when possible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
-dotnet_diagnostic.S3246.severity = warning
-
-# Title    : Duplicate casts should not be made
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
-dotnet_diagnostic.S3247.severity = none
-
-# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
-dotnet_diagnostic.S3249.severity = warning
-
-# Title    : Implementations should be provided for "partial" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
-dotnet_diagnostic.S3251.severity = warning
-
-# Title    : Constructor and destructor declarations should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
-dotnet_diagnostic.S3253.severity = warning
-
-# Title    : Default parameter values should not be passed as arguments
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
-dotnet_diagnostic.S3254.severity = warning
-
-# Title    : "string.IsNullOrEmpty" should be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
-dotnet_diagnostic.S3256.severity = warning
 
 # Title    : Declarations and initializations should be as concise as possible
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
 # Comment  : Too many false positives
-dotnet_diagnostic.S3257.severity = none
 
 # Title    : Non-derived "private" classes and records should be "sealed"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
 # Redundant: R9A013
-dotnet_diagnostic.S3260.severity = none
-
-# Title    : Namespaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
-dotnet_diagnostic.S3261.severity = warning
-
-# Title    : "params" should be used on overrides
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
-dotnet_diagnostic.S3262.severity = warning
-
-# Title    : Static fields should appear in the order they must be initialized 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
-dotnet_diagnostic.S3263.severity = warning
-
-# Title    : Events should be invoked
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
-dotnet_diagnostic.S3264.severity = warning
-
-# Title    : Non-flags enums should not be used in bitwise operations
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
-dotnet_diagnostic.S3265.severity = warning
-
-# Title    : Loops should be simplified with "LINQ" expressions
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
-dotnet_diagnostic.S3267.severity = none
 
 # Title    : Cipher Block Chaining IVs should be unpredictable
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
 # Comment  : Analysis is too slow
-dotnet_diagnostic.S3329.severity = none
-
-# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
-dotnet_diagnostic.S3330.severity = warning
-
-# Title    : Caller information parameters should come at the end of the parameter list
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
-dotnet_diagnostic.S3343.severity = warning
-
-# Title    : Expressions used in "Debug.Assert" should not produce side effects
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
-dotnet_diagnostic.S3346.severity = warning
-
-# Title    : Unchanged local variables should be "const"
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
-dotnet_diagnostic.S3353.severity = warning
-
-# Title    : Ternary operators should not be nested
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
-dotnet_diagnostic.S3358.severity = warning
-
-# Title    : Date and time should not be used as a type for primary keys
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3363
-dotnet_diagnostic.S3363.severity = warning
-
-# Title    : "this" should not be exposed from constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
-dotnet_diagnostic.S3366.severity = warning
 
 # Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
 # Redundant: CA1710
-dotnet_diagnostic.S3376.severity = none
-
-# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
-dotnet_diagnostic.S3397.severity = warning
-
-# Title    : "private" methods called only by inner classes should be moved to those classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3398
-dotnet_diagnostic.S3398.severity = warning
-
-# Title    : Methods should not return constants
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
-dotnet_diagnostic.S3400.severity = warning
-
-# Title    : Assertion arguments should be passed in the correct order
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
-dotnet_diagnostic.S3415.severity = warning
-
-# Title    : Method overloads with default parameter values should not overlap
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
-dotnet_diagnostic.S3427.severity = warning
-
-# Title    : "[ExpectedException]" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
-dotnet_diagnostic.S3431.severity = warning
-
-# Title    : Test method signatures should be correct
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
-dotnet_diagnostic.S3433.severity = warning
-
-# Title    : Variables should not be checked against the values they're about to be assigned
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
-dotnet_diagnostic.S3440.severity = warning
-
-# Title    : Redundant property names should be omitted in anonymous classes
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
-dotnet_diagnostic.S3441.severity = warning
-
-# Title    : "abstract" classes should not have "public" constructors
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
-dotnet_diagnostic.S3442.severity = warning
-
-# Title    : Type should not be examined on "System.Type" instances
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
-dotnet_diagnostic.S3443.severity = warning
-
-# Title    : Interfaces should not simply inherit from base interfaces with colliding members
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
-dotnet_diagnostic.S3444.severity = warning
-
-# Title    : Exceptions should not be explicitly rethrown
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
-dotnet_diagnostic.S3445.severity = warning
-
-# Title    : "[Optional]" should not be used on "ref" or "out" parameters
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
-dotnet_diagnostic.S3447.severity = warning
-
-# Title    : Right operands of shift operators should be integers
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
-dotnet_diagnostic.S3449.severity = warning
-
-# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
-dotnet_diagnostic.S3450.severity = warning
-
-# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
-dotnet_diagnostic.S3451.severity = warning
-
-# Title    : Classes should not have only "private" constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
-dotnet_diagnostic.S3453.severity = warning
-
-# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
-dotnet_diagnostic.S3456.severity = warning
-
-# Title    : Composite format strings should be used correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
-dotnet_diagnostic.S3457.severity = warning
-
-# Title    : Empty "case" clauses that fall through to the "default" should be omitted
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
-dotnet_diagnostic.S3458.severity = warning
-
-# Title    : Unassigned members should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
-dotnet_diagnostic.S3459.severity = warning
-
-# Title    : Type inheritance should not be recursive
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
-dotnet_diagnostic.S3464.severity = warning
-
-# Title    : Optional parameters should be passed to "base" calls
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
-dotnet_diagnostic.S3466.severity = warning
-
-# Title    : Empty "default" clauses should be removed
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
-dotnet_diagnostic.S3532.severity = warning
-
-# Title    : "ServiceContract" and "OperationContract" attributes should be used together
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
-dotnet_diagnostic.S3597.severity = warning
-
-# Title    : One-way "OperationContract" methods should have "void" return type
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
-dotnet_diagnostic.S3598.severity = warning
-
-# Title    : "params" should not be introduced on overrides
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
-dotnet_diagnostic.S3600.severity = warning
-
-# Title    : Methods with "Pure" attribute should return a value 
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
-dotnet_diagnostic.S3603.severity = warning
-
-# Title    : Member initializer values should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
-dotnet_diagnostic.S3604.severity = warning
-
-# Title    : Nullable type comparison should not be redundant
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
-dotnet_diagnostic.S3610.severity = warning
-
-# Title    : Jump statements should not be redundant
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
-dotnet_diagnostic.S3626.severity = warning
-
-# Title    : Empty nullable value should not be accessed
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
-dotnet_diagnostic.S3655.severity = warning
-
-# Title    : Exception constructors should not throw exceptions
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
-dotnet_diagnostic.S3693.severity = warning
-
-# Title    : Track use of "NotImplementedException"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
-dotnet_diagnostic.S3717.severity = warning
 
 # Title    : Cognitive Complexity of methods should not be too high
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
 # Comment  : Code gets complicated
-dotnet_diagnostic.S3776.severity = none
-
-# Title    : "SafeHandle.DangerousGetHandle" should not be called
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
-dotnet_diagnostic.S3869.severity = warning
 
 # Title    : Exception types should be "public"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
 # Redundant: CA1064
-dotnet_diagnostic.S3871.severity = none
-
-# Title    : Parameter names should not duplicate the names of their methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
-dotnet_diagnostic.S3872.severity = warning
 
 # Title    : "out" and "ref" parameters should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
 # Redundant: CA1021
-dotnet_diagnostic.S3874.severity = none
-
-# Title    : "operator==" should not be overloaded on reference types
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
-dotnet_diagnostic.S3875.severity = warning
-
-# Title    : Strings or integral types should be used for indexers
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
-dotnet_diagnostic.S3876.severity = warning
-
-# Title    : Exceptions should not be thrown from unexpected methods
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
-dotnet_diagnostic.S3877.severity = none
-
-# Title    : Arrays should not be created for params parameters
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3878
-dotnet_diagnostic.S3878.severity = suggestion
-
-# Title    : Finalizers should not be empty
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
-dotnet_diagnostic.S3880.severity = warning
-
-# Title    : "IDisposable" should be implemented correctly
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
-dotnet_diagnostic.S3881.severity = none
-
-# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
-# Category : Blocker Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
-dotnet_diagnostic.S3884.severity = warning
-
-# Title    : "Assembly.Load" should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
-dotnet_diagnostic.S3885.severity = warning
-
-# Title    : Mutable, non-private fields should not be "readonly"
-# Category : Minor Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
-dotnet_diagnostic.S3887.severity = warning
-
-# Title    : "Thread.Resume" and "Thread.Suspend" should not be used
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
-dotnet_diagnostic.S3889.severity = warning
-
-# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
-dotnet_diagnostic.S3897.severity = warning
-
-# Title    : Value types should implement "IEquatable<T>"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
-dotnet_diagnostic.S3898.severity = none
 
 # Title    : Arguments of public methods should be validated against null
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
 # Redundant: CA1062
-dotnet_diagnostic.S3900.severity = none
-
-# Title    : "Assembly.GetExecutingAssembly" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
-dotnet_diagnostic.S3902.severity = warning
 
 # Title    : Types should be defined in named namespaces
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
 # Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
-dotnet_diagnostic.S3903.severity = none
-
-# Title    : Assemblies should have version information
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
-dotnet_diagnostic.S3904.severity = warning
-
-# Title    : Event Handlers should have the correct signature
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
-dotnet_diagnostic.S3906.severity = warning
-
-# Title    : Generic event handlers should be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
-dotnet_diagnostic.S3908.severity = warning
 
 # Title    : Collections should implement the generic interface
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
 # Redundant: CA1010
-dotnet_diagnostic.S3909.severity = none
-
-# Title    : All branches in a conditional structure should not have exactly the same implementation
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
-dotnet_diagnostic.S3923.severity = warning
 
 # Title    : "ISerializable" should be implemented correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
 # Comment  : TODO - is ISerializable still relevant?
-dotnet_diagnostic.S3925.severity = none
-
-# Title    : Deserialization methods should be provided for "OptionalField" members
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
-dotnet_diagnostic.S3926.severity = warning
-
-# Title    : Serialization event handlers should be implemented correctly
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
-dotnet_diagnostic.S3927.severity = warning
-
-# Title    : Parameter names used into ArgumentException constructors should match an existing one 
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
-dotnet_diagnostic.S3928.severity = none
-
-# Title    : Number patterns should be regular
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
-dotnet_diagnostic.S3937.severity = warning
-
-# Title    : Calculations should not overflow
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
-dotnet_diagnostic.S3949.severity = suggestion
 
 # Title    : "Generic.List" instances should not be part of public APIs
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
 # Redundant: CA1002
-dotnet_diagnostic.S3956.severity = none
 
 # Title    : "static readonly" constants should be "const" instead
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
 # Redundant: CA1802
-dotnet_diagnostic.S3962.severity = none
 
 # Title    : "static" fields should be initialized inline
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
 # Redundant: CA1810 and CA2207
-dotnet_diagnostic.S3963.severity = none
-
-# Title    : Objects should not be disposed more than once
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
-dotnet_diagnostic.S3966.severity = warning
-
-# Title    : Multidimensional arrays should not be used
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
-dotnet_diagnostic.S3967.severity = warning
-
-# Title    : "GC.SuppressFinalize" should not be called
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
-dotnet_diagnostic.S3971.severity = warning
-
-# Title    : Conditionals should start on new lines
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
-dotnet_diagnostic.S3972.severity = warning
-
-# Title    : A conditionally executed single line should be denoted by indentation
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
-dotnet_diagnostic.S3973.severity = warning
-
-# Title    : Collection sizes and array length comparisons should make sense
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
-dotnet_diagnostic.S3981.severity = warning
-
-# Title    : Exceptions should not be created without being thrown
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
-dotnet_diagnostic.S3984.severity = warning
 
 # Title    : Assemblies should be marked as CLS compliant
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
 # Redundant: CA1014
-dotnet_diagnostic.S3990.severity = none
 
 # Title    : Assemblies should explicitly specify COM visibility
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
 # Redundant: CA1017
-dotnet_diagnostic.S3992.severity = none
 
 # Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
 # Redundant: CA1018
-dotnet_diagnostic.S3993.severity = none
-
-# Title    : URI Parameters should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
-dotnet_diagnostic.S3994.severity = none
-
-# Title    : URI return values should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
-dotnet_diagnostic.S3995.severity = warning
-
-# Title    : URI properties should not be strings
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
-dotnet_diagnostic.S3996.severity = warning
-
-# Title    : String URI overloads should call "System.Uri" overloads
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
-dotnet_diagnostic.S3997.severity = warning
-
-# Title    : Threads should not lock on objects with weak identity
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
-dotnet_diagnostic.S3998.severity = warning
-
-# Title    : Pointers to unmanaged memory should not be visible
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
-dotnet_diagnostic.S4000.severity = warning
-
-# Title    : Disposable types should declare finalizers
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
-dotnet_diagnostic.S4002.severity = warning
 
 # Title    : Collection properties should be readonly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
 # Redundant: CA2227
-dotnet_diagnostic.S4004.severity = none
 
 # Title    : "System.Uri" arguments should be used instead of strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
 # Redundant: CA2234
-dotnet_diagnostic.S4005.severity = none
-
-# Title    : Inherited member visibility should not be decreased
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
-dotnet_diagnostic.S4015.severity = warning
-
-# Title    : Enumeration members should not be named "Reserved"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
-dotnet_diagnostic.S4016.severity = warning
-
-# Title    : Method signatures should not contain nested generic types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
-dotnet_diagnostic.S4017.severity = none
-
-# Title    : All type parameters should be used in the parameter list to enable type inference
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
-dotnet_diagnostic.S4018.severity = none
-
-# Title    : Base class methods should not be hidden
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
-dotnet_diagnostic.S4019.severity = warning
-
-# Title    : Enumerations should have "Int32" storage
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
-dotnet_diagnostic.S4022.severity = warning
-
-# Title    : Interfaces should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
-dotnet_diagnostic.S4023.severity = none
-
-# Title    : Child class fields should not differ from parent class fields only by capitalization
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
-dotnet_diagnostic.S4025.severity = warning
-
-# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
-dotnet_diagnostic.S4026.severity = warning
 
 # Title    : Exceptions should provide standard constructors
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
 # Redundant: CA1032
-dotnet_diagnostic.S4027.severity = none
-
-# Title    : Classes implementing "IEquatable<T>" should be sealed
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
-dotnet_diagnostic.S4035.severity = warning
-
-# Title    : Searching OS commands in PATH is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
-dotnet_diagnostic.S4036.severity = warning
-
-# Title    : Interface methods should be callable by derived types
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
-dotnet_diagnostic.S4039.severity = warning
 
 # Title    : Strings should be normalized to uppercase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
 # Redundant: CA1308
-dotnet_diagnostic.S4040.severity = none
-
-# Title    : Type names should not match namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
-dotnet_diagnostic.S4041.severity = warning
-
-# Title    : Generics should be used when appropriate
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
-dotnet_diagnostic.S4047.severity = warning
 
 # Title    : Properties should be preferred
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
 # Redundant: CA1024
-dotnet_diagnostic.S4049.severity = none
-
-# Title    : Operators should be overloaded consistently
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
-dotnet_diagnostic.S4050.severity = warning
-
-# Title    : Types should not extend outdated base types
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
-dotnet_diagnostic.S4052.severity = warning
-
-# Title    : Literals should not be passed as localized parameters
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
-dotnet_diagnostic.S4055.severity = none
 
 # Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
 # Redundant: CA1305
-dotnet_diagnostic.S4056.severity = none
-
-# Title    : Locales should be set for data types
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
-dotnet_diagnostic.S4057.severity = warning
 
 # Title    : Overloads with a "StringComparison" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
 # Redundant: CA1310
-dotnet_diagnostic.S4058.severity = none
-
-# Title    : Property names should not match get methods
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
-dotnet_diagnostic.S4059.severity = warning
 
 # Title    : Non-abstract attributes should be sealed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
 # Redundant: CA1813
-dotnet_diagnostic.S4060.severity = none
-
-# Title    : "params" should be used instead of "varargs"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
-dotnet_diagnostic.S4061.severity = warning
 
 # Title    : Operator overloads should have named alternatives
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
 # Redundant: CA2225
-dotnet_diagnostic.S4069.severity = none
 
 # Title    : Non-flags enums should not be marked with "FlagsAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
 # Redundant: CA2217
-dotnet_diagnostic.S4070.severity = none
-
-# Title    : Method overloads should be grouped together
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
-dotnet_diagnostic.S4136.severity = warning
-
-# Title    : Duplicate values should not be passed as arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
-dotnet_diagnostic.S4142.severity = warning
-
-# Title    : Collection elements should not be replaced unconditionally
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
-dotnet_diagnostic.S4143.severity = warning
-
-# Title    : Methods should not have identical implementations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
-dotnet_diagnostic.S4144.severity = warning
 
 # Title    : Empty collections should not be accessed or iterated
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
 # Comment  : Too many false positives
-dotnet_diagnostic.S4158.severity = none
-
-# Title    : Classes should implement their "ExportAttribute" interfaces
-# Category : Blocker Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
-dotnet_diagnostic.S4159.severity = warning
-
-# Title    : Native methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
-dotnet_diagnostic.S4200.severity = warning
-
-# Title    : Null checks should not be used with "is"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
-dotnet_diagnostic.S4201.severity = warning
-
-# Title    : Windows Forms entry points should be marked with STAThread
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
-dotnet_diagnostic.S4210.severity = warning
-
-# Title    : Members should not have conflicting transparency annotations
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
-dotnet_diagnostic.S4211.severity = warning
-
-# Title    : Serialization constructors should be secured
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
-dotnet_diagnostic.S4212.severity = warning
-
-# Title    : "P/Invoke" methods should not be visible
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
-dotnet_diagnostic.S4214.severity = warning
-
-# Title    : Events should have proper arguments
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
-dotnet_diagnostic.S4220.severity = warning
-
-# Title    : Extension methods should not extend "object"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
-dotnet_diagnostic.S4225.severity = warning
-
-# Title    : Extensions should be in separate namespaces
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
-dotnet_diagnostic.S4226.severity = none
-
-# Title    : "ConstructorArgument" parameters should exist in constructors
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
-dotnet_diagnostic.S4260.severity = warning
-
-# Title    : Methods should be named according to their synchronicities
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
-dotnet_diagnostic.S4261.severity = none
-
-# Title    : Getters and setters should access the expected fields
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
-dotnet_diagnostic.S4275.severity = warning
-
-# Title    : "Shared" parts should not be created with "new"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
-dotnet_diagnostic.S4277.severity = warning
-
-# Title    : Weak SSL/TLS protocols should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
-dotnet_diagnostic.S4423.severity = warning
-
-# Title    : Cryptographic keys should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
-dotnet_diagnostic.S4426.severity = warning
-
-# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
-# Category : Major Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
-dotnet_diagnostic.S4428.severity = warning
-
-# Title    : AES encryption algorithm should be used with secured mode
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
-dotnet_diagnostic.S4432.severity = warning
-
-# Title    : LDAP connections should be authenticated
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
-dotnet_diagnostic.S4433.severity = warning
-
-# Title    : Parameter validation in yielding methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
-dotnet_diagnostic.S4456.severity = warning
-
-# Title    : Parameter validation in "async"/"await" methods should be wrapped
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
-dotnet_diagnostic.S4457.severity = warning
 
 # Title    : Calls to "async" methods should not be blocking
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
 # Redundant: VSTHRD002
-dotnet_diagnostic.S4462.severity = none
 
 # Title    : Unread "private" fields should be removed
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
 # Redundant: IDE0052
-dotnet_diagnostic.S4487.severity = none
-
-# Title    : Disabling CSRF protections is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
-dotnet_diagnostic.S4502.severity = warning
-
-# Title    : Delivering code in production with debug features activated is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
-dotnet_diagnostic.S4507.severity = warning
-
-# Title    : "default" clauses should be first or last
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
-dotnet_diagnostic.S4524.severity = warning
-
-# Title    : "DebuggerDisplayAttribute" strings should reference existing members
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4545
-dotnet_diagnostic.S4545.severity = warning
-
-# Title    : ASP.NET HTTP request validation feature should not be disabled
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
-dotnet_diagnostic.S4564.severity = warning
-
-# Title    : "new Guid()" should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
-dotnet_diagnostic.S4581.severity = warning
-
-# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
-dotnet_diagnostic.S4583.severity = warning
-
-# Title    : Non-async "Task/Task<T>" methods should not return null
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
-dotnet_diagnostic.S4586.severity = warning
-
-# Title    : Start index should be used instead of calling Substring
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
-dotnet_diagnostic.S4635.severity = warning
-
-# Title    : Comments should not be empty
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4663
-dotnet_diagnostic.S4663.severity = suggestion
-
-# Title    : Using regular expressions is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
-dotnet_diagnostic.S4784.severity = warning
-
-# Title    : Encrypting data is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
-dotnet_diagnostic.S4787.severity = warning
-
-# Title    : Using weak hashing algorithms is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
-dotnet_diagnostic.S4790.severity = warning
-
-# Title    : Configuring loggers is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
-dotnet_diagnostic.S4792.severity = warning
-
-# Title    : Using Sockets is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
-dotnet_diagnostic.S4818.severity = warning
-
-# Title    : Using command line arguments is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
-dotnet_diagnostic.S4823.severity = warning
-
-# Title    : Reading the Standard Input is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
-dotnet_diagnostic.S4829.severity = warning
 
 # Title    : Server certificates should be verified during SSL/TLS connections
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
 # Redundant: CA5359
-dotnet_diagnostic.S4830.severity = none
-
-# Title    : Controlling permissions is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
-dotnet_diagnostic.S4834.severity = warning
-
-# Title    : "ValueTask" should be consumed correctly
-# Category : Critical Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
-dotnet_diagnostic.S5034.severity = warning
-
-# Title    : Expanding archive files without controlling resource consumption is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
-dotnet_diagnostic.S5042.severity = warning
-
-# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
-# Category : Minor Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
-dotnet_diagnostic.S5122.severity = warning
-
-# Title    : Using clear-text protocols is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
-dotnet_diagnostic.S5332.severity = warning
-
-# Title    : Using publicly writable directories is security-sensitive
-# Category : Critical Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
-dotnet_diagnostic.S5443.severity = warning
-
-# Title    : Insecure temporary file creation methods should not be used
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
-dotnet_diagnostic.S5445.severity = warning
-
-# Title    : Encryption algorithms should be used with secure mode and padding scheme
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
-dotnet_diagnostic.S5542.severity = warning
-
-# Title    : Cipher algorithms should be robust
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
-dotnet_diagnostic.S5547.severity = warning
-
-# Title    : JWT should be signed and verified with strong cipher algorithms
-# Category : Critical Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
-dotnet_diagnostic.S5659.severity = warning
-
-# Title    : Allowing requests with excessive content length is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
-dotnet_diagnostic.S5693.severity = warning
-
-# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
-dotnet_diagnostic.S5753.severity = warning
-
-# Title    : Deserializing objects without performing data validation is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
-dotnet_diagnostic.S5766.severity = warning
-
-# Title    : Types allowed to be deserialized should be restricted
-# Category : Major Vulnerability
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
-dotnet_diagnostic.S5773.severity = warning
-
-# Title    : Regular expressions should be syntactically valid
-# Category : Critical Bug
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5856
-dotnet_diagnostic.S5856.severity = warning
 
 # Title    : Use a testable date/time provider
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
 # Redundant: R9A022
-dotnet_diagnostic.S6354.severity = none
-
-# Title    : Azure Functions should be stateless
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
-dotnet_diagnostic.S6419.severity = warning
-
-# Title    : Client instances should not be recreated on each Azure Function invocation
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
-dotnet_diagnostic.S6420.severity = warning
-
-# Title    : Azure Functions should use Structured Error Handling
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
-dotnet_diagnostic.S6421.severity = warning
-
-# Title    : Calls to "async" methods should not be blocking in Azure Functions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
-dotnet_diagnostic.S6422.severity = warning
-
-# Title    : Azure Functions should log all failures
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
-dotnet_diagnostic.S6423.severity = warning
-
-# Title    : Interfaces for durable entities should satisfy the restrictions
-# Category : Blocker Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
-dotnet_diagnostic.S6424.severity = warning
-
-# Title    : Not specifying a timeout for regular expressions is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
-dotnet_diagnostic.S6444.severity = none
 
 # Title    : Blocks should not be synchronized on local variables
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6507
 # Comment  : Too many false positives
-dotnet_diagnostic.S6507.severity = none
-
-# Title    : "ExcludeFromCodeCoverage" attributes should include a justification
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6513
-dotnet_diagnostic.S6513.severity = suggestion
-
-# Title    : Avoid using "DateTime.Now" for benchmarking or timing operations
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6561
-dotnet_diagnostic.S6561.severity = warning
 
 # Title    : Always set the "DateTimeKind" when creating new "DateTime" instances
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6562
 # Comment  : Noise
-dotnet_diagnostic.S6562.severity = none
-
-# Title    : Use UTC when recording DateTime instants
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6563
-dotnet_diagnostic.S6563.severity = none
 
 # Title    : Use "DateTimeOffset" instead of "DateTime"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6566
 # Comment  : Noise
-dotnet_diagnostic.S6566.severity = none
-
-# Title    : Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6575
-dotnet_diagnostic.S6575.severity = warning
-
-# Title    : Use a format provider when parsing date and time
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6580
-dotnet_diagnostic.S6580.severity = warning
-
-# Title    : Don't hardcode the format when turning dates and times to strings
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6585
-dotnet_diagnostic.S6585.severity = none
-
-# Title    : Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6588
-dotnet_diagnostic.S6588.severity = none
-
-# Title    : "Find" method should be used instead of the "FirstOrDefault" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6602
-dotnet_diagnostic.S6602.severity = none
-
-# Title    : The collection-specific "TrueForAll" method should be used instead of the "All" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6603
-dotnet_diagnostic.S6603.severity = none
-
-# Title    : Collection-specific "Exists" method should be used instead of the "Any" extension
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6605
-dotnet_diagnostic.S6605.severity = none
-
-# Title    : The collection should be filtered before sorting by using "Where" before "OrderBy"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6607
-dotnet_diagnostic.S6607.severity = none
-
-# Title    : Prefer indexing instead of "Enumerable" methods on types implementing "IList"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6608
-dotnet_diagnostic.S6608.severity = none
-
-# Title    : "Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6609
-dotnet_diagnostic.S6609.severity = none
-
-# Title    : "StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6610
-dotnet_diagnostic.S6610.severity = none
-
-# Title    : The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6612
-dotnet_diagnostic.S6612.severity = none
-
-# Title    : "First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6613
-dotnet_diagnostic.S6613.severity = none
-
-# Title    : "Contains" should be used instead of "Any" for simple equality checks
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6617
-dotnet_diagnostic.S6617.severity = none
-
-# Title    : "string.Create" should be used instead of "FormattableString"
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6618
-dotnet_diagnostic.S6618.severity = none
-
-# Title    : Using unsafe code blocks is security-sensitive
-# Category : Major Security Hotspot
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6640
-dotnet_diagnostic.S6640.severity = warning
-
-# Title    : Generic logger injection should match enclosing type
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6672
-dotnet_diagnostic.S6672.severity = none
-
-# Title    : Awaitable method should be used
-# Category : Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6966
-dotnet_diagnostic.S6966.severity = none
-
-# Title    : ModelState.IsValid should be called in controller actions
-# Category : Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6967
-dotnet_diagnostic.S6967.severity = none
-
-# Title    : Literal suffixes should be upper case
-# Category : Minor Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
-dotnet_diagnostic.S818.severity = warning
-
-# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
-dotnet_diagnostic.S881.severity = suggestion
-
-# Title    : "goto" statement should not be used
-# Category : Major Code Smell
-# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
-dotnet_diagnostic.S907.severity = warning
 
 # Title    : Parameter names should match base declaration and other partial definitions
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
 # Redundant: CA1725
-dotnet_diagnostic.S927.severity = none
 
 # Title    : Copy-paste token calculator
 # Category : 

--- a/test/Analyzers/Microsoft.Analyzers.Extra.Tests/Resources/RoslynTestUtils.cs
+++ b/test/Analyzers/Microsoft.Analyzers.Extra.Tests/Resources/RoslynTestUtils.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -282,7 +282,6 @@ internal static class RoslynTestUtils
     /// <summary>
     /// Runs a Roslyn analyzer and fixer.
     /// </summary>
-    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Hey, that's life")]
     public static async Task<IReadOnlyList<string>> RunAnalyzerAndFixer(
         DiagnosticAnalyzer analyzer,
         CodeFixProvider fixer,

--- a/test/Analyzers/Microsoft.Analyzers.Local.Tests/Json/JsonValueTest.cs
+++ b/test/Analyzers/Microsoft.Analyzers.Local.Tests/Json/JsonValueTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Forked from StyleCop.Analyzers repo.
@@ -209,9 +209,7 @@ public class JsonValueTest
         DateTime time = DateTime.Now;
         Assert.NotEqual(time, JsonValue.Null);
         Assert.Equal(time.ToString("o", CultureInfo.InvariantCulture), ((JsonValue)time).AsString);
-#pragma warning disable S3655 // Empty nullable value should not be accessed
         Assert.Equal(default(DateTime?), JsonValue.Null);
-#pragma warning restore S3655 // Empty nullable value should not be accessed
 
         // (int)(JsonValue)
         Assert.Equal(0, (int)new JsonValue(uint.MaxValue));

--- a/test/Analyzers/Microsoft.Analyzers.Local.Tests/Resources/RoslynTestUtils.cs
+++ b/test/Analyzers/Microsoft.Analyzers.Local.Tests/Resources/RoslynTestUtils.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -283,7 +283,6 @@ internal static class RoslynTestUtils
     /// <summary>
     /// Runs a Roslyn analyzer and fixer.
     /// </summary>
-    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Hey, that's life")]
     public static async Task<IReadOnlyList<string>> RunAnalyzerAndFixer(
         DiagnosticAnalyzer analyzer,
         CodeFixProvider fixer,

--- a/test/Generators/Microsoft.Gen.ContextualOptions/TestClasses/ClassWithNoAttribute.cs
+++ b/test/Generators/Microsoft.Gen.ContextualOptions/TestClasses/ClassWithNoAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 namespace TestClasses
 {
     [OptionsContext]
-    [SuppressMessage("Minor Code Smell", "S2333:Redundant modifiers should not be used", Justification = "Needed for test code.")]
     public partial class ClassWithNoAttribute
     {
         [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]

--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
@@ -1005,7 +1005,6 @@ public class LogMethodTests
         }
     }
 
-    [SuppressMessage("Minor Code Smell", "S4056:Overloads with a \"CultureInfo\" or an \"IFormatProvider\" parameter should be used", Justification = "Not appropriate here")]
     private static void TestCollection(int expected, FakeLogCollector collector)
     {
         var rol = (collector.LatestRecord.State as IReadOnlyList<KeyValuePair<string, string?>>)!;

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/ArgTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/ArgTestExtensions.cs
@@ -29,13 +29,11 @@ namespace TestClasses
         [LoggerMessage(6, LogLevel.Error, "M7 {p1}")]
         public static partial void Method7(ILogger logger, int p1, System.InvalidOperationException p2);
 
-#pragma warning disable S107 // Methods should not have too many parameters
         [LoggerMessage(7, LogLevel.Error, "M8{p1}{p2}{p3}{p4}{p5}{p6}{p7}")]
         public static partial void Method8(ILogger logger, int p1, int p2, int p3, int p4, int p5, int p6, int p7);
 
         [LoggerMessage(8, LogLevel.Error, "M9 {p1} {p2} {p3} {p4} {p5} {p6} {p7}")]
         public static partial void Method9(ILogger logger, int p1, int p2, int p3, int p4, int p5, int p6, int p7);
-#pragma warning restore S107 // Methods should not have too many parameters
 
         [LoggerMessage(9, LogLevel.Error, "M10{p1}")]
         public static partial void Method10(ILogger logger, int p1);

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/AttributeTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/AttributeTestExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
@@ -36,7 +36,6 @@ namespace TestClasses
             [PrivateData] NonFormattable p3);
 
         [LoggerMessage(5, LogLevel.Debug, "M5 {p0} {p1} {p2} {p3} {p4} {p5} {p6} {p7} {p8} {p9} {p10}")]
-        [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Testing.")]
         public static partial void M5(
             ILogger logger,
             [PrivateData] string p0,

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/CollectionTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/CollectionTestExtensions.cs
@@ -28,13 +28,11 @@ namespace TestClasses
         [LoggerMessage(6, LogLevel.Error, "M6{p0}{p1}{p2}{p3}{p4}{p5}")]
         public static partial void M6(ILogger logger, int p0, int p1, int p2, int p3, int p4, int p5);
 
-#pragma warning disable S107 // Methods should not have too many parameters
         [LoggerMessage(7, LogLevel.Error, "M7{p0}{p1}{p2}{p3}{p4}{p5}{p6}")]
         public static partial void M7(ILogger logger, int p0, int p1, int p2, int p3, int p4, int p5, int p6);
 
         [LoggerMessage(8, LogLevel.Error, "M8{p0}{p1}{p2}{p3}{p4}{p5}{p6}{p7}")]
         public static partial void M8(ILogger logger, int p0, int p1, int p2, int p3, int p4, int p5, int p6, int p7);
-#pragma warning restore S107 // Methods should not have too many parameters
 
         [LoggerMessage("M8{p0}{p1}")]
         public static partial void M9(ILogger logger, LogLevel level, int p0, System.Exception ex, int p1);

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/ConstraintsTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/ConstraintsTestExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Extensions.Logging;
 
 #pragma warning disable SA1402 // File may only contain a single type
-#pragma warning disable S1186 // Methods should not be empty
 
 namespace TestClasses
 {

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/EnumerableTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/EnumerableTestExtensions.cs
@@ -30,8 +30,6 @@ namespace TestClasses
         [LoggerMessage(6, LogLevel.Error, "M6{p0}{p1}{p2}{p3}{p4}{p5}")]
         public static partial void M6(ILogger logger, int p0, IEnumerable<int> p1, int p2, int p3, int p4, int p5);
 
-#pragma warning disable S107 // Methods should not have too many parameters
-
         [LoggerMessage(7, LogLevel.Error, "M7{p0}{p1}{p2}{p3}{p4}{p5}{p6}")]
         public static partial void M7(ILogger logger, int p0, IEnumerable<int> p1, int p2, int p3, int p4, int p5, int p6);
 

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/LogPropertiesExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/LogPropertiesExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -12,7 +12,6 @@ namespace TestClasses
     [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Test code")]
     [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Test code")]
     [SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Test code")]
-    [SuppressMessage("Major Code Smell", "S2376:Write-only properties should not be used", Justification = "Test code")]
     internal static partial class LogPropertiesExtensions
     {
         public delegate void TestDelegate();

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/NullableTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/NullableTestExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Compliance.Testing;
@@ -17,13 +17,11 @@ namespace TestClasses
         [LoggerMessage(3, LogLevel.Debug, "M3 {p0}")]
         internal static partial void M3(ILogger logger, [PrivateData] string? p0);
 
-#pragma warning disable S107 // Methods should not have too many parameters
         [LoggerMessage(4, LogLevel.Debug, "M4 {p0} {p1} {p2} {p3} {p4} {p5} {p6} {p7} {p8}")]
         internal static partial void M4(ILogger logger, int? p0, int? p1, int? p2, int? p3, int? p4, int? p5, int? p6, int? p7, int? p8);
 
         [LoggerMessage(5, LogLevel.Debug, "M5 {p0} {p1} {p2} {p3} {p4} {p5} {p6} {p7} {p8}")]
         internal static partial void M5(ILogger logger, string? p0, string? p1, string? p2, string? p3, string? p4, string? p5, string? p6, string? p7, string? p8);
-#pragma warning restore S107 // Methods should not have too many parameters
 
         [LoggerMessage(6, LogLevel.Debug, "M6 {p0}")]
         internal static partial void M6(ILogger? logger, [PrivateData] string? p0);

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/PrimaryConstructorsExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/PrimaryConstructorsExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
@@ -22,7 +22,6 @@ namespace TestClasses
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Used in generated code")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S3604:Member initializer values should not be redundant", Justification = "Used for testing")]
     public partial class ClassWithPrimaryConstructorAndField(ILogger logger)
     {
         private readonly ILogger _logger = logger;

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/SensitiveRecordExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/SensitiveRecordExtensions.cs
@@ -11,7 +11,6 @@ namespace TestClasses
     [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Test code")]
     [SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Test code")]
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Test code")]
-    [SuppressMessage("Major Code Smell", "S2376:Write-only properties should not be used", Justification = "Test code")]
     internal static partial class SensitiveRecordExtensions
     {
         internal const string Sensitive = "SENSITIVE";

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/TemplateTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/TemplateTestExtensions.cs
@@ -13,10 +13,8 @@ namespace TestClasses
         [LoggerMessage(1, LogLevel.Error, "M1 {A1} {A1}")]
         public static partial void M1(ILogger logger, int a1);
 
-#pragma warning disable S107 // Methods should not have too many parameters
         [LoggerMessage(2, LogLevel.Error, "M2 {A1} {a2} {A3} {a4} {A5} {a6} {A7}")]
         public static partial void M2(ILogger logger, int a1, int a2, int a3, int a4, int a5, int a6, int a7);
-#pragma warning restore S107 // Methods should not have too many parameters
 
         [LoggerMessage(3, LogLevel.Error, "M3 {a2} {A1}")]
         public static partial void M3(ILogger logger, int a1, int a2);

--- a/test/Generators/Microsoft.Gen.Logging/Unit/EmitterTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/EmitterTests.cs
@@ -52,14 +52,12 @@ public class EmitterTests
 ;
 
         // we need this "Where()" hack because Roslyn 4.0 doesn't recognize #pragma warning disable for generator-produced warnings
-#pragma warning disable S1067 // Expressions should not be too complex
         Assert.DoesNotContain(d, diag
             => diag.Id != DiagDescriptors.ShouldntMentionExceptionInMessage.Id
             && diag.Id != DiagDescriptors.ShouldntMentionLoggerInMessage.Id
             && diag.Id != DiagDescriptors.ShouldntMentionLogLevelInMessage.Id
             && diag.Id != DiagDescriptors.EmptyLoggingMethod.Id
             && diag.Id != DiagDescriptors.ParameterHasNoCorrespondingTemplate.Id);
-#pragma warning restore S1067 // Expressions should not be too complex
 
         _ = Assert.Single(r);
 

--- a/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.cs
@@ -684,7 +684,6 @@ public partial class ParserTests
             .UseDirectory(Path.Combine("..", "Verified"));
     }
 
-#pragma warning disable S107 // Methods should not have too many parameters
     private static async Task RunGenerator(
         string code,
         DiagnosticDescriptor? expectedDiagnostic = null,
@@ -694,7 +693,6 @@ public partial class ParserTests
         bool includeLoggingReferences = true,
         DiagnosticDescriptor? ignoreDiag = null,
         CancellationToken cancellationToken = default)
-#pragma warning restore S107 // Methods should not have too many parameters
     {
         var text = code;
         if (wrap)

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Logging/AcceptanceTests.Mvc.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Logging/AcceptanceTests.Mvc.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if NET8_0_OR_GREATER
@@ -33,14 +33,12 @@ public partial class AcceptanceTests
     [SuppressMessage("Design", "CA1052:Static holder types should be Static or NotInheritable", Justification = "Needed for reflection")]
     private class TestStartupWithControllers
     {
-        [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Used through reflection")]
         public static void ConfigureServices(IServiceCollection services)
             => services
                 .AddFakeRedaction(x => x.RedactionFormat = RedactedFormat)
                 .AddRouting() // Adds routing middleware.
                 .AddControllers(); // Allows to read routes from classes annotated with [ApiController] attribute.
 
-        [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Used through reflection")]
         public static void Configure(IApplicationBuilder app)
             => app
                 .UseRouting()

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Logging/AcceptanceTests.Routing.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Logging/AcceptanceTests.Routing.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if NET8_0_OR_GREATER
@@ -24,14 +24,12 @@ public partial class AcceptanceTests
     [SuppressMessage("Design", "CA1052:Static holder types should be Static or NotInheritable", Justification = "Needed for reflection")]
     private class TestStartupWithRouting
     {
-        [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Used through reflection")]
         public static void ConfigureServices(IServiceCollection services)
             => services
                 .AddFakeRedaction(x => x.RedactionFormat = RedactedFormat)
                 .AddRouting()
                 .AddControllers();
 
-        [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Used through reflection")]
         public static void Configure(IApplicationBuilder app)
             => app
                 .UseRouting()

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Logging/AcceptanceTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Logging/AcceptanceTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if NET8_0_OR_GREATER
@@ -47,7 +47,6 @@ public partial class AcceptanceTests
     [SuppressMessage("Design", "CA1052:Static holder types should be Static or NotInheritable", Justification = "Needed for reflection")]
     private class TestStartup
     {
-        [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Used through reflection")]
         public static void ConfigureServices(IServiceCollection services)
         {
             services.AddRouting();
@@ -55,7 +54,6 @@ public partial class AcceptanceTests
             services.AddHttpLoggingRedaction();
         }
 
-        [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Used through reflection")]
         public static void Configure(IApplicationBuilder app)
         {
             app.UseRouting();

--- a/test/Libraries/Microsoft.AspNetCore.Testing.Tests/TestResources/Startup.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Testing.Tests/TestResources/Startup.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -14,7 +14,6 @@ namespace Microsoft.AspNetCore.Testing.Test.TestResources;
 public class Startup
 {
 #if !NET6_0_OR_GREATER
-    [SuppressMessage("Minor Code Smell", "S3257:Declarations and initializations should be as concise as possible", Justification = "Type parameters needed for proper resolution")]
 #endif
     public void Configure(IApplicationBuilder app) => app.Use((HttpContext _, Func<Task> _) => Task.CompletedTask);
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Image/DelegatingImageGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Image/DelegatingImageGeneratorTests.cs
@@ -131,9 +131,7 @@ public class DelegatingImageGeneratorTests
         Assert.True(inner.DisposeInvoked);
 
         // Second dispose should not throw
-#pragma warning disable S3966
         delegating.Dispose();
-#pragma warning restore S3966
         Assert.True(inner.DisposeInvoked);
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Image/ImageGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Image/ImageGeneratorTests.cs
@@ -92,9 +92,7 @@ public class ImageGeneratorTests
         Assert.True(generator.DisposeInvoked);
 
         // Second dispose should not throw
-#pragma warning disable S3966
         generator.Dispose();
-#pragma warning restore S3966
         Assert.True(generator.DisposeInvoked);
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/ResultsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Integration.Tests/ResultsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -102,14 +102,12 @@ public class ResultsTests
         return null;
     }
 
-#pragma warning disable S1067 // Expressions should not be too complex.
     private static EvaluationMetricInterpretation? FailIfValueIsMissing(EvaluationMetric m) =>
         (m is NumericMetric s && s.Value is not null) ||
         (m is BooleanMetric b && b.Value is not null) ||
         (m is StringMetric e && e.Value is not null)
             ? new EvaluationMetricInterpretation(EvaluationRating.Good)
             : new EvaluationMetricInterpretation(EvaluationRating.Unacceptable, failed: true, "Value is missing");
-#pragma warning restore S1067
 
     private enum MeasurementSystem
     {

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ScenarioRunResultTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/ScenarioRunResultTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -391,7 +391,6 @@ public class ScenarioRunResultTests
     {
         public static ChatTurnDetailsComparer Instance { get; } = new ChatTurnDetailsComparer();
 
-#pragma warning disable S1067 // Expressions should not be too complex.
         public bool Equals(ChatTurnDetails? x, ChatTurnDetails? y) =>
             x?.Latency == y?.Latency &&
             x?.Model == y?.Model &&
@@ -401,7 +400,6 @@ public class ScenarioRunResultTests
             x?.Usage?.TotalTokenCount == y?.Usage?.TotalTokenCount &&
             x?.CacheKey == y?.CacheKey &&
             x?.CacheHit == y?.CacheHit;
-#pragma warning restore S1067
 
         public int GetHashCode(ChatTurnDetails obj)
             => obj.GetHashCode();

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -25,9 +25,6 @@ using Xunit;
 #pragma warning disable CA2000 // Dispose objects before losing scope
 #pragma warning disable CA2214 // Do not call overridable methods in constructors
 #pragma warning disable CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'
-#pragma warning disable S103 // Lines should not be too long
-#pragma warning disable S1144 // Unused private types or members should be removed
-#pragma warning disable S3604 // Member initializer values should not be redundant
 #pragma warning disable SA1515 // Single-line comment should be preceded by blank line
 
 namespace Microsoft.Extensions.AI;
@@ -1109,12 +1106,10 @@ public abstract class ChatClientIntegrationTests : IDisposable
 
     private class Person
     {
-#pragma warning disable S1144, S3459 // Unassigned members should be removed
         public string? FullName { get; set; }
         public int AgeInYears { get; set; }
         public string? HomeTown { get; set; }
         public JobType Job { get; set; }
-#pragma warning restore S1144, S3459 // Unused private types or members should be removed
     }
 
     private enum JobType

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/EmbeddingGeneratorIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/EmbeddingGeneratorIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -21,7 +21,6 @@ using OpenTelemetry.Trace;
 using Xunit;
 
 #pragma warning disable CA2214 // Do not call overridable methods in constructors
-#pragma warning disable S3967  // Multidimensional arrays should not be used
 
 namespace Microsoft.Extensions.AI;
 

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/PromptBasedFunctionCallingChatClient.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/PromptBasedFunctionCallingChatClient.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -13,8 +13,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 #pragma warning disable SA1402 // File may only contain a single type
-#pragma warning disable S1144 // Unused private types or members should be removed
-#pragma warning disable S3459 // Unassigned members should be removed
 
 namespace Microsoft.Extensions.AI;
 

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ReducingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ReducingChatClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -10,7 +10,6 @@ using Microsoft.ML.Tokenizers;
 using Microsoft.Shared.Diagnostics;
 using Xunit;
 
-#pragma warning disable S103 // Lines should not be too long
 #pragma warning disable SA1402 // File may only contain a single type
 
 namespace Microsoft.Extensions.AI;

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/VerbatimHttpHandler.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/VerbatimHttpHandler.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -14,7 +14,6 @@ using Xunit;
 #pragma warning disable CA2000 // Dispose objects before losing scope
 #pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
 #pragma warning disable CA1031 // Do not catch general exception types
-#pragma warning disable S108 // Nested blocks of code should not be left empty
 
 namespace Microsoft.Extensions.AI;
 

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/VerbatimMultiPartHttpHandler.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/VerbatimMultiPartHttpHandler.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -12,8 +12,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-
-#pragma warning disable S3996 // URI properties should not be strings
 
 /// <summary>
 /// An <see cref="HttpMessageHandler"/> that checks the multi-part request body as a root

--- a/test/Libraries/Microsoft.Extensions.AI.OllamaSharp.Integration.Tests/IntegrationTestHelpers.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OllamaSharp.Integration.Tests/IntegrationTestHelpers.cs
@@ -1,11 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 
 namespace Microsoft.Extensions.AI;
-
-#pragma warning disable S125 // Sections of code should not be commented out
 
 /// <summary>Shared utility methods for integration tests.</summary>
 public static class IntegrationTestHelpers

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIAssistantChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIAssistantChatClientIntegrationTests.cs
@@ -1,9 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable CA1822 // Mark members as static
 #pragma warning disable CA2000 // Dispose objects before losing scope
-#pragma warning disable S1135 // Track uses of "TODO" tags
 #pragma warning disable xUnit1013 // Public method should be marked as test
 
 using System;

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIAssistantChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIAssistantChatClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -8,8 +8,6 @@ using Microsoft.Extensions.Caching.Memory;
 using OpenAI;
 using OpenAI.Assistants;
 using Xunit;
-
-#pragma warning disable S103 // Lines should not be too long
 
 namespace Microsoft.Extensions.AI;
 

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -16,7 +16,6 @@ using OpenAI;
 using OpenAI.Chat;
 using Xunit;
 
-#pragma warning disable S103 // Lines should not be too long
 #pragma warning disable OPENAI001 // Experimental OpenAI APIs
 
 namespace Microsoft.Extensions.AI;

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIEmbeddingGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -11,8 +11,6 @@ using Microsoft.Extensions.Caching.Memory;
 using OpenAI;
 using OpenAI.Embeddings;
 using Xunit;
-
-#pragma warning disable S103 // Lines should not be too long
 
 namespace Microsoft.Extensions.AI;
 

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -19,7 +19,6 @@ using OpenAI;
 using OpenAI.Responses;
 using Xunit;
 
-#pragma warning disable S103 // Lines should not be too long
 #pragma warning disable OPENAI001 // Experimental OpenAI APIs
 
 namespace Microsoft.Extensions.AI;
@@ -286,7 +285,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","sequence_number":29,"response":{"id":"resp_68b5ebab461881969ed94149372c2a530698ecbf1b9f2704","object":"response","created_at":1756752811,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"o4-mini-2025-04-16","output":[{"id":"rs_68b5ebabc0088196afb9fa86b487732d0698ecbf1b9f2704","type":"reasoning","summary":[{"type":"summary_text","text":"**Calculating a simple sum**"}]},{"id":"msg_68b5ebae5a708196b74b94f22ca8995e0698ecbf1b9f2704","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The sum of the first 5 positive integers is 15."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"low","summary":"detailed"},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":17,"input_tokens_details":{"cached_tokens":0},"output_tokens":122,"output_tokens_details":{"reasoning_tokens":64},"total_tokens":139},"user":null,"metadata":{}}}
 
-
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -415,7 +413,6 @@ public class OpenAIResponseClientTests
 
             event: response.completed
             data: {"type":"response.completed","sequence_number":14,"response":{"id":"resp_reasoning123","object":"response","created_at":1756752900,"status":"completed","model":"o4-mini-2025-04-16","output":[{"id":"rs_reasoning123","type":"reasoning","text":"First, let's analyze the problem."},{"id":"msg_reasoning123","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"text":"The solution is 42."}],"role":"assistant"}],"usage":{"input_tokens":10,"output_tokens":25,"total_tokens":35}}}
-
 
             """;
 
@@ -646,7 +643,6 @@ public class OpenAIResponseClientTests
 
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_67d329fbc87c81919f8952fe71dafc96029dabe3ee19bb77","object":"response","created_at":1741892091,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":20,"model":"gpt-4o-mini-2024-07-18","output":[{"type":"message","id":"msg_67d329fc0c0081919696b8ab36713a41029dabe3ee19bb77","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello! How can I assist you today?","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":0.5,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"usage":{"input_tokens":26,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":36},"user":null,"metadata":{}}}
-
 
             """;
 
@@ -881,7 +877,6 @@ public class OpenAIResponseClientTests
 
             event: response.completed
             data: {"type":"response.completed","sequence_number":4,"response":{"id":"resp_0b949080ec8e4b8a006920e0661d00819383ed81438ab11299","object":"response","created_at":1763762278,"status":"completed","background":false,"content_filters":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"computer-use-preview-2025-03-11","output":[{"type":"computer_call","id":"cu_0b949080ec8e4b8a006920e067a7c0819384d047d21b484357","status":"completed","call_id":"call_p7K8YjFwNjqMgkKhSiExgFH6","action":{"type":"screenshot"},"pending_safety_checks":[]}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"medium","generate_summary":"concise","summary":"concise"},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":null,"tools":[{"type":"computer-use-preview-2025-03-11","environment":"browser","display_width":1024,"display_height":768}],"top_logprobs":0,"top_p":1.0,"truncation":"auto","usage":{"input_tokens":18,"input_tokens_details":{"cached_tokens":0},"output_tokens":53,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":71},"user":null,"metadata":{}}}
-
 
             """;
 
@@ -2297,7 +2292,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","sequence_number":105,"response":{"id":"resp_68be44fd7298819e82fd82c8516e970d03a2537be0e84a54","object":"response","created_at":1757299965,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"mcpl_68be44fd8f68819eba7a74a2f6d27a5a03a2537be0e84a54","type":"mcp_list_tools","server_label":"deepwiki","tools":[{"annotations":{"read_only":false},"description":"Get a list of documentation topics for a GitHub repository","input_schema":{"type":"object","properties":{"repoName":{"type":"string","description":"GitHub repository: owner/repo (e.g. \"facebook/react\")"}},"required":["repoName"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"},"name":"read_wiki_structure"},{"annotations":{"read_only":false},"description":"View documentation about a GitHub repository","input_schema":{"type":"object","properties":{"repoName":{"type":"string","description":"GitHub repository: owner/repo (e.g. \"facebook/react\")"}},"required":["repoName"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"},"name":"read_wiki_contents"},{"annotations":{"read_only":false},"description":"Ask any question about a GitHub repository","input_schema":{"type":"object","properties":{"repoName":{"type":"string","description":"GitHub repository: owner/repo (e.g. \"facebook/react\")"},"question":{"type":"string","description":"The question to ask about the repository"}},"required":["repoName","question"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"},"name":"ask_question"}]},{"id":"mcp_68be4503d45c819e89cb574361c8eba003a2537be0e84a54","type":"mcp_call","approval_request_id":null,"arguments":"{\"repoName\":\"dotnet/extensions\"}","error":null,"name":"read_wiki_structure","output":"Available pages for dotnet/extensions:\n\n- 1 Overview\n- 2 Build System and CI/CD\n- 3 AI Extensions Framework\n  - 3.1 Core Abstractions\n  - 3.2 AI Function System\n  - 3.3 Chat Completion\n  - 3.4 Caching System\n  - 3.5 Evaluation and Reporting\n- 4 HTTP Resilience and Diagnostics\n  - 4.1 Standard Resilience\n  - 4.2 Hedging Strategies\n- 5 Telemetry and Compliance\n- 6 Testing Infrastructure\n  - 6.1 AI Service Integration Testing\n  - 6.2 Time Provider Testing","server_label":"deepwiki"},{"id":"mcp_68be4505f134819e806c002f27cce0c303a2537be0e84a54","type":"mcp_call","approval_request_id":null,"arguments":"{\"repoName\":\"dotnet/extensions\",\"question\":\"What is the path to the README.md file for Microsoft.Extensions.AI.Abstractions?\"}","error":null,"name":"ask_question","output":"The path to the `README.md` file for `Microsoft.Extensions.AI.Abstractions` is `src/Libraries/Microsoft.Extensions.AI.Abstractions/README.md` . This file provides an overview of the `Microsoft.Extensions.AI.Abstractions` library, including installation instructions and usage examples for its core components like `IChatClient` and `IEmbeddingGenerator`   .\n\n## README.md Content Overview\nThe `README.md` file for `Microsoft.Extensions.AI.Abstractions` details the purpose of the library, which is to provide abstractions for generative AI components . It includes instructions on how to install the NuGet package `Microsoft.Extensions.AI.Abstractions` .\n\nThe document also provides usage examples for the `IChatClient` interface, which defines methods for interacting with AI services that offer \"chat\" capabilities . This includes examples for requesting both complete and streaming chat responses  .\n\nFurthermore, the `README.md` explains the `IEmbeddingGenerator` interface, which is used for generating vector embeddings from input values . It demonstrates how to use `GenerateAsync` to create embeddings . The file also discusses how both `IChatClient` and `IEmbeddingGenerator` implementations can be layered to create pipelines of functionality, incorporating features like caching and telemetry  .\n\nNotes:\nThe user's query specifically asked for the path to the `README.md` file for `Microsoft.Extensions.AI.Abstractions`. The provided codebase context, particularly the wiki page for \"AI Extensions Framework\", directly lists this file as a relevant source file . The content of the `README.md` file itself further confirms its relevance to the `Microsoft.Extensions.AI.Abstractions` library.\n\nWiki pages you might want to explore:\n- [AI Extensions Framework (dotnet/extensions)](/wiki/dotnet/extensions#3)\n- [Chat Completion (dotnet/extensions)](/wiki/dotnet/extensions#3.3)\n\nView this search on DeepWiki: https://deepwiki.com/search/what-is-the-path-to-the-readme_bb6bee43-3136-4b21-bc5d-02ca1611d857\n","server_label":"deepwiki"},{"id":"msg_68be450c39e8819eb9bf6fcb9fd16ecb03a2537be0e84a54","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The path to the `README.md` file for `Microsoft.Extensions.AI.Abstractions` in the `dotnet/extensions` repository is:\n\n```\nsrc/Libraries/Microsoft.Extensions.AI.Abstractions/README.md\n```\n\nThis file provides an overview of the library, installation instructions, and usage examples for its core components. If you have any more questions about it, feel free to ask!"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"mcp","allowed_tools":null,"headers":null,"require_approval":"never","server_description":null,"server_label":"deepwiki","server_url":"https://mcp.deepwiki.com/<redacted>"}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":1420,"input_tokens_details":{"cached_tokens":0},"output_tokens":149,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1569},"user":null,"metadata":{}}}
             
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -3013,7 +3007,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","sequence_number":17,"response":{"truncation":"disabled","id":"resp_68d401a7b36c81a288600e95a5a119d4073420ed59d5f559","tool_choice":"auto","temperature":1.0,"top_p":1.0,"status":"completed","top_logprobs":0,"usage":{"total_tokens":18,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0},"output_tokens":10,"input_tokens":8},"object":"response","created_at":1758724519,"prompt_cache_key":null,"text":{"format":{"type":"text"},"verbosity":"medium"},"incomplete_details":null,"model":"gpt-4o-2024-08-06","previous_response_id":null,"safety_identifier":null,"metadata":{},"store":true,"output":[{"id":"msg_68d401aa78d481a2ab30776a79c691a6073420ed59d5f559","content":[{"text":"Hello! How can I assist you today?","logprobs":[],"type":"output_text","annotations":[]}],"role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"error":null,"background":true,"instructions":null,"service_tier":"default","max_tool_calls":null,"max_output_tokens":null,"tools":[],"user":null,"reasoning":{"effort":null,"summary":null}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -3094,7 +3087,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","sequence_number":17,"response":{"truncation":"disabled","id":"resp_68d40dc671a0819cb0ee920078333451029e611c3cc4a34b","tool_choice":"auto","temperature":1.0,"top_p":1.0,"status":"completed","top_logprobs":0,"usage":{"total_tokens":18,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0},"output_tokens":10,"input_tokens":8},"object":"response","created_at":1758727622,"prompt_cache_key":null,"text":{"format":{"type":"text"},"verbosity":"medium"},"incomplete_details":null,"model":"gpt-4o-2024-08-06","previous_response_id":null,"safety_identifier":null,"metadata":{},"store":true,"output":[{"id":"msg_68d40dcb2d34819c88f5d6a8ca7b0308029e611c3cc4a34b","content":[{"text":"Hello! How can I assist you today?","logprobs":[],"type":"output_text","annotations":[]}],"role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"error":null,"background":true,"instructions":null,"service_tier":"default","max_tool_calls":null,"max_output_tokens":null,"tools":[],"user":null,"reasoning":{"effort":null,"summary":null}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(expectedInput, Output);
@@ -3181,10 +3173,8 @@ public class OpenAIResponseClientTests
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
             await foreach (var update in client.GetStreamingResponseAsync("Please book a hotel for me", chatOptions))
-#pragma warning disable S108 // Nested blocks of code should not be left empty
             {
             }
-#pragma warning restore S108 // Nested blocks of code should not be left empty
         });
     }
 
@@ -3505,7 +3495,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","sequence_number":55,"response":{"id":"resp_05d8f42f04f94cb80068fc3b7e07bc819eaf0d6e2c1923e564","object":"response","created_at":1761360766,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"ci_05d8f42f04f94cb80068fc3b80fba8819ea3bfbdd36e94bcf3","type":"code_interpreter_call","status":"completed","code":"# Calculate the sum of numbers from 1 to 10\nsum_of_numbers = sum(range(1, 11))\nsum_of_numbers","container_id":"cntr_68fc3b80043c8191990a5837d7617af704511ed77cec9447","outputs":null},{"id":"msg_05d8f42f04f94cb80068fc3b86cc0c819ebae29aac8563d48d","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The sum of numbers from 1 to 10 is 55."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"code_interpreter","container":{"type":"auto"}}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":219,"input_tokens_details":{"cached_tokens":0},"output_tokens":50,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":269},"user":null,"metadata":{}}}
 
-
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -3591,7 +3580,6 @@ public class OpenAIResponseClientTests
 
             event: response.completed
             data: {"type":"response.completed","sequence_number":9,"response":{"id":"resp_05d8f42f04f94cb80068fc3b7e07bc819eaf0d6e2c1923e564","object":"response","created_at":1761360766,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"ci_05d8f42f04f94cb80068fc3b80fba8819ea3bfbdd36e94bcf3","type":"code_interpreter_call","status":"completed","code":"# sum(range(1, 11))","container_id":"cntr_68fc3b80043c8191990a5837d7617af704511ed77cec9447","outputs":null}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"code_interpreter","container":{"type":"auto"}}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":100,"input_tokens_details":{"cached_tokens":0},"output_tokens":20,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":120},"user":null,"metadata":{}}}
-
 
             """;
 
@@ -4089,7 +4077,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_67d329fbc87c81919f8952fe71dafc96029dabe3ee19bb77","object":"response","created_at":1741892091,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":20,"model":"gpt-4o-mini-2024-07-18","output":[{"type":"message","id":"msg_67d329fc0c0081919696b8ab36713a41029dabe3ee19bb77","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":0.5,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"usage":{"input_tokens":26,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":36},"user":null,"metadata":{}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -4170,7 +4157,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_67d329fbc87c81919f8952fe71dafc96029dabe3ee19bb77","object":"response","created_at":1741892091,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":20,"model":"gpt-4o-mini-2024-07-18","output":[{"type":"message","id":"msg_67d329fc0c0081919696b8ab36713a41029dabe3ee19bb77","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":false,"temperature":0.5,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"usage":{"input_tokens":26,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":36},"user":null,"metadata":{}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -4251,7 +4237,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_67d329fbc87c81919f8952fe71dafc96029dabe3ee19bb77","object":"response","created_at":1741892091,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":20,"model":"gpt-4o-mini-2024-07-18","output":[{"type":"message","id":"msg_67d329fc0c0081919696b8ab36713a41029dabe3ee19bb77","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":0.5,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"usage":{"input_tokens":26,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":36},"user":null,"metadata":{}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -4329,7 +4314,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_67d329fbc87c81919f8952fe71dafc96029dabe3ee19bb77","object":"response","created_at":1741892091,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":20,"model":"gpt-4o-mini-2024-07-18","output":[{"type":"message","id":"msg_67d329fc0c0081919696b8ab36713a41029dabe3ee19bb77","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":0.5,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"usage":{"input_tokens":26,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":36},"user":null,"metadata":{}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -4526,7 +4510,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_67d329fbc87c81919f8952fe71dafc96029dabe3ee19bb77","object":"response","created_at":1741892091,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":20,"model":"gpt-4o-2024-08-06","output":[{"type":"message","id":"msg_67d329fc0c0081919696b8ab36713a41029dabe3ee19bb77","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":0.5,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"usage":{"input_tokens":26,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":36},"user":null,"metadata":{}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -5408,7 +5391,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[{"type":"message","id":"msg_001","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Done","annotations":[]}]}]}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -5443,7 +5425,6 @@ public class OpenAIResponseClientTests
             event: response.failed
             data: {"type":"response.failed","response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"failed","model":"gpt-4o-mini","output":[],"error":{"code":"internal_error","message":"Internal error"}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -5478,7 +5459,6 @@ public class OpenAIResponseClientTests
             event: response.incomplete
             data: {"type":"response.incomplete","response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"incomplete","model":"gpt-4o-mini","output":[],"incomplete_details":{"reason":"max_output_tokens"}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -5516,7 +5496,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[{"type":"message","id":"msg_001","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Done","annotations":[]}]}]}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -5554,7 +5533,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[]}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -5612,7 +5590,6 @@ public class OpenAIResponseClientTests
             event: response.failed
             data: {"type":"response.failed","sequence_number":2,"response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"failed","model":"gpt-4o-mini","output":[],"error":{"code":"rate_limit_exceeded","message":"Rate limit exceeded"}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -5655,7 +5632,6 @@ public class OpenAIResponseClientTests
             event: response.failed
             data: {"type":"response.failed","sequence_number":2,"response":{"id":"resp_002","object":"response","created_at":1741892091,"status":"failed","model":"gpt-4o-mini","output":[],"error":{"code":"content_filter","message":"Content filter triggered"}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -5698,7 +5674,6 @@ public class OpenAIResponseClientTests
             event: response.failed
             data: {"type":"response.failed","sequence_number":2,"response":{"id":"resp_003","object":"response","created_at":1741892091,"status":"failed","model":"gpt-4o-mini","output":[]}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -5741,7 +5716,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[{"type":"message","id":"msg_001","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Annotated text","annotations":[{"type":"file_citation","file_id":"file_123","start_index":0,"end_index":14}]}]}]}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -5816,7 +5790,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_001","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[{"type":"function_call","id":"fc_001","call_id":"call_123","name":"get_weather","arguments":"{\"city\":\"Paris\"}","status":"completed"},{"type":"function_call_output","id":"fc_output_001","call_id":"call_123","output":"25°C and sunny"},{"type":"message","id":"msg_001","status":"completed","role":"assistant","content":[{"type":"output_text","text":"It's 25°C and sunny in Paris.","annotations":[]}]}],"usage":{"input_tokens":10,"output_tokens":15,"total_tokens":25}}}
 
-            
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -6219,7 +6192,6 @@ public class OpenAIResponseClientTests
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_def456","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-2024-11-20","output":[{"type":"image_generation_call","id":"img_call_def456","image_result_b64":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="}],"usage":{"input_tokens":15,"output_tokens":0,"total_tokens":15}}}
 
-
             """;
 
         using VerbatimHttpHandler handler = new(Input, Output);
@@ -6335,7 +6307,6 @@ public class OpenAIResponseClientTests
 
             event: response.completed
             data: {"type":"response.completed","response":{"id":"resp_ghi789","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-2024-11-20","output":[{"type":"image_generation_call","id":"img_call_ghi789","image_result_b64":"SGVsbG8z"}],"usage":{"input_tokens":18,"output_tokens":0,"total_tokens":18}}}
-
 
             """;
 
@@ -6647,4 +6618,3 @@ public class OpenAIResponseClientTests
         }
     }
 }
-

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAISpeechToTextClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAISpeechToTextClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -12,8 +12,6 @@ using Microsoft.Extensions.Logging;
 using OpenAI;
 using OpenAI.Audio;
 using Xunit;
-
-#pragma warning disable S103 // Lines should not be too long
 
 namespace Microsoft.Extensions.AI;
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientBuilderTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientBuilderTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -98,9 +98,7 @@ public class ChatClientBuilderTest
 
     private sealed class InnerClientCapturingChatClient(string name, IChatClient innerClient) : DelegatingChatClient(innerClient)
     {
-#pragma warning disable S3604 // False positive: Member initializer values should not be redundant
         public string Name { get; } = name;
-#pragma warning restore S3604
         public new IChatClient InnerClient => base.InnerClient;
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientStructuredOutputExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientStructuredOutputExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Xunit;
 
 #pragma warning disable IDE1006 // Naming Styles
-#pragma warning disable S103 // Lines should not be too long
 
 namespace Microsoft.Extensions.AI;
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ImageGeneratingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ImageGeneratingChatClientTests.cs
@@ -298,9 +298,7 @@ public class ImageGeneratingChatClientTests
 
         // Assert
         Assert.Same(chatOptions, capturedOptions);
-#pragma warning disable CA1508
         Assert.NotNull(capturedOptions?.Tools);
-#pragma warning restore CA1508
         Assert.Empty(capturedOptions.Tools);
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatReduction/SummarizingChatReducerTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatReduction/SummarizingChatReducerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#pragma warning disable S103 // Lines should not be too long
 
 using System;
 using System.Collections.Generic;

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/EmbeddingGeneratorBuilderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/EmbeddingGeneratorBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -81,9 +81,7 @@ public class EmbeddingGeneratorBuilderTests
     private sealed class InnerServiceCapturingEmbeddingGenerator(string name, IEmbeddingGenerator<string, Embedding<float>> innerGenerator) :
         DelegatingEmbeddingGenerator<string, Embedding<float>>(innerGenerator)
     {
-#pragma warning disable S3604 // False positive: Member initializer values should not be redundant
         public string Name { get; } = name;
-#pragma warning restore S3604
         public new IEmbeddingGenerator<string, Embedding<float>> InnerGenerator => base.InnerGenerator;
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -16,11 +16,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 #pragma warning disable IDE0004 // Remove Unnecessary Cast
-#pragma warning disable S103 // Lines should not be too long
-#pragma warning disable S107 // Methods should not have too many parameters
-#pragma warning disable S2760 // Sequential tests should not check the same condition
-#pragma warning disable S3358 // Ternary operators should not be nested
-#pragma warning disable S5034 // "ValueTask" should be consumed correctly
 
 namespace Microsoft.Extensions.AI;
 
@@ -250,9 +245,7 @@ public partial class AIFunctionFactoryTest
 
     private sealed class ThrowingAsyncEnumerable : IAsyncEnumerable<int>
     {
-#pragma warning disable S3717 // Track use of "NotImplementedException"
         public IAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default) => throw new NotImplementedException();
-#pragma warning restore S3717 // Track use of "NotImplementedException"
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Image/ImageGeneratorBuilderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Image/ImageGeneratorBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -98,9 +98,7 @@ public class ImageGeneratorBuilderTests
 
     private sealed class InnerGeneratorCapturingImageGenerator(string name, IImageGenerator innerGenerator) : DelegatingImageGenerator(innerGenerator)
     {
-#pragma warning disable S3604 // False positive: Member initializer values should not be redundant
         public string Name { get; } = name;
-#pragma warning restore S3604
         public new IImageGenerator InnerGenerator => base.InnerGenerator;
     }
 }

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SampleUsage.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SampleUsage.cs
@@ -134,8 +134,6 @@ public class SampleUsage : IClassFixture<TestEventListener>
         return Task.FromResult(new SomeInformation { Id = id, Name = name });
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S3398:\"private\" methods called only by inner classes should be moved to those classes",
-        Justification = "Allow future sharing")]
     private static Task<SomeInformationReuse> SomeExpensiveOperationReuseAsync(string name, int id,
         CancellationToken token = default)
     {

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/ServiceConstructionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/ServiceConstructionTests.cs
@@ -577,8 +577,6 @@ public class ServiceConstructionTests : IClassFixture<TestEventListener>
     [InlineData(true, 43, 42, null, true, 45, 44, null, 45, 44)]
     [InlineData(true, 43, 42, null, true, null, 45, null, 43, 45)]
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters",
-        Justification = "Most pragmatic and readable way of expressing multiple scenarios.")]
     public void VerifyCacheEntryOptionsScenarios(
         bool defaultsSpecified, int? defaultExpiration, int? defaultLocalCacheExpiration, HybridCacheEntryFlags? defaultFlags,
         bool perItemSpecified, int? perItemExpiration, int? perItemLocalCacheExpiration, HybridCacheEntryFlags? perItemFlags,

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SizeTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SizeTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
@@ -208,7 +208,6 @@ public class SizeTests(ITestOutputHelper log) : IClassFixture<TestEventListener>
     [InlineData("some value", true, 1, 1, 0, false, false)]
     [InlineData("read fail", true, 1, 1, 0, false, false)]
     [InlineData("write fail", true, 1, 1, 0, true, false, Log.IdSerializationFailure)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Test scenario range; reducing duplication")]
     public async Task BrokenSerializer_Immutable(string value, bool same, int runCount, int serializeCount, int deserializeCount, bool expectKnownFailure, bool withL2,
         params int[] errorIds)
     {

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/StampedeTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/StampedeTests.cs
@@ -82,7 +82,6 @@ public class StampedeTests : IClassFixture<TestEventListener>
     [InlineData(1, true)]
     [InlineData(10, false)]
     [InlineData(10, true)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Critical Code Smell", "S5034:\"ValueTask\" should be consumed correctly", Justification = "False positive, is only awaited once")]
     public async Task MultipleCallsShareExecution_NoCancellation(int callerCount, bool canBeCanceled)
     {
         using var scope = GetDefaultCache(out var cache);
@@ -327,7 +326,6 @@ public class StampedeTests : IClassFixture<TestEventListener>
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Critical Code Smell", "S5034:\"ValueTask\" should be consumed correctly", Justification = "False positive, is only awaited once")]
     public async Task ImmutableTypesShareFinalTask(bool withCancelation)
     {
         using CancellationTokenSource? cts = withCancelation ? new() : null;
@@ -367,7 +365,6 @@ public class StampedeTests : IClassFixture<TestEventListener>
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Critical Code Smell", "S5034:\"ValueTask\" should be consumed correctly", Justification = "False positive, is only awaited once")]
     public async Task ImmutableCustomTypesShareFinalTask(bool withCancelation)
     {
         using var cts = withCancelation ? new CancellationTokenSource() : null;
@@ -411,7 +408,6 @@ public class StampedeTests : IClassFixture<TestEventListener>
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Critical Code Smell", "S5034:\"ValueTask\" should be consumed correctly", Justification = "False positive, is only awaited once")]
     public async Task MutableTypesNeverShareFinalTask(bool withCancelation)
     {
         using CancellationTokenSource? cts = withCancelation ? new() : null;

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/TestEventListener.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/TestEventListener.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -158,7 +158,6 @@ public sealed class TestEventListener : EventListener
         }
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Bug", "S1244:Floating point numbers should not be tested for equality", Justification = "Test expects exact zero")]
     public void AssertRemainingCountersZero()
     {
         lock (SyncLock)

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/TypeTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/TypeTests.cs
@@ -60,27 +60,23 @@ public class TypeTests
     {
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Needed to be non-trivial blittable")]
     private struct CustomBlittableStruct(int x)
     {
         public readonly int X => x;
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Needed to force non-blittable")]
     private struct CustomNonBlittableStructNoAttrib(string x)
     {
         public readonly string X => x;
     }
 
     [ImmutableObject(false)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Needed to force non-blittable")]
     private struct CustomNonBlittableStructAttribFalse(string x)
     {
         public readonly string X => x;
     }
 
     [ImmutableObject(true)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Needed to force non-blittable")]
     private struct CustomNonBlittableStructAttribTrue(string x)
     {
         public readonly string X => x;

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/UnreliableL2Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/UnreliableL2Tests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
@@ -196,7 +196,6 @@ public class UnreliableL2Tests(ITestOutputHelper testLog) : IClassFixture<TestEv
 
         private static Task? ThrowIfBrokenAsync(BreakType breakType) => ThrowIfBrokenAsync<int>(breakType);
 
-        [SuppressMessage("Critical Bug", "S4586:Non-async \"Task/Task<T>\" methods should not return null", Justification = "Intentional for propagation")]
         private static Task<T>? ThrowIfBrokenAsync<T>(BreakType breakType)
         {
             switch (breakType)

--- a/test/Libraries/Microsoft.Extensions.Compliance.Abstractions.Tests/Classification/DataClassificationSetTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Compliance.Abstractions.Tests/Classification/DataClassificationSetTests.cs
@@ -26,9 +26,7 @@ public static class DataClassificationSetTests
         var dc6 = dc1.Union(FakeTaxonomy.PrivateData);
         Assert.NotEqual(dc1, dc6);
 
-#pragma warning disable CA1508 // Avoid dead conditional code
         Assert.False(dc1.Equals(null));
-#pragma warning restore CA1508 // Avoid dead conditional code
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.Compliance.Abstractions.Tests/Classification/DataClassificationTypeConverterTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Compliance.Abstractions.Tests/Classification/DataClassificationTypeConverterTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -172,11 +172,7 @@ public class DataClassificationTypeConverterTests
 
     private class TestOptions
     {
-#pragma warning disable S3459 // Unassigned members should be removed
-#pragma warning disable S1144 // Unused private types or members should be removed
         public DataClassification? Example { get; set; }
-#pragma warning restore S1144 // Unused private types or members should be removed
-#pragma warning restore S3459 // Unassigned members should be removed
         public IDictionary<string, DataClassification> Facts { get; set; } = new Dictionary<string, DataClassification>();
     }
 }

--- a/test/Libraries/Microsoft.Extensions.Compliance.Redaction.Tests/HmacRedactorTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Compliance.Redaction.Tests/HmacRedactorTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -148,10 +148,7 @@ public class HmacRedactorTest
         public string Hash { get; init; } = string.Empty;
     }
 
-#pragma warning disable S103 // Lines should not be too long
-#pragma warning disable S3257 // Declarations and initializations should be as concise as possible
     public static readonly HmacExample[] HmacExamples = new HmacExample[]
-#pragma warning restore S3257 // Declarations and initializations should be as concise as possible
     {
         new()
         {
@@ -281,5 +278,4 @@ public class HmacRedactorTest
             Hash = "101:SOP5zMpCSRn9N9/Y3/KPxg==",
         }
     };
-#pragma warning restore S103 // Lines should not be too long
 }

--- a/test/Libraries/Microsoft.Extensions.DataIngestion.Tests/IngestionPipelineTests.cs
+++ b/test/Libraries/Microsoft.Extensions.DataIngestion.Tests/IngestionPipelineTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -17,8 +17,6 @@ using OpenTelemetry.Trace;
 using Xunit;
 
 namespace Microsoft.Extensions.DataIngestion.Tests;
-
-#pragma warning disable S881 // Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
 
 public sealed class IngestionPipelineTests : IDisposable
 {

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -42,7 +42,6 @@ public sealed class AcceptanceTest
 
     [ConditionalFact]
     [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX, SkipReason = "Linux specific tests")]
-    [SuppressMessage("Minor Code Smell", "S3257:Declarations and initializations should be as concise as possible", Justification = "Broken analyzer.")]
     public void Adding_Linux_Resource_Utilization_Can_Be_Configured_With_Section()
     {
         var cpuRefresh = TimeSpan.FromMinutes(13);
@@ -94,7 +93,6 @@ public sealed class AcceptanceTest
 
     [ConditionalFact]
     [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX, SkipReason = "Linux specific tests")]
-    [SuppressMessage("Minor Code Smell", "S3257:Declarations and initializations should be as concise as possible", Justification = "Broken analyzer.")]
     public void Adding_Linux_Resource_Utilization_With_Section_Registers_SnapshotProvider_Cgroupv1()
     {
         var cpuRefresh = TimeSpan.FromMinutes(13);
@@ -143,7 +141,6 @@ public sealed class AcceptanceTest
 
     [ConditionalFact]
     [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX, SkipReason = "Linux specific tests")]
-    [SuppressMessage("Minor Code Smell", "S3257:Declarations and initializations should be as concise as possible", Justification = "Broken analyzer.")]
     public void Adding_Linux_Resource_Utilization_With_Section_Registers_SnapshotProvider_Cgroupv2()
     {
         var cpuRefresh = TimeSpan.FromMinutes(13);
@@ -484,7 +481,6 @@ public sealed class AcceptanceTest
             return;
         }
 
-#pragma warning disable S1067 // Expressions should not be too complex
         if (instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization ||
             instrument.Name == ResourceUtilizationInstruments.ProcessMemoryUtilization ||
             instrument.Name == ResourceUtilizationInstruments.ContainerCpuTime ||
@@ -495,10 +491,8 @@ public sealed class AcceptanceTest
         {
             meterListener.EnableMeasurementEvents(instrument);
         }
-#pragma warning restore S1067 // Expressions should not be too complex
     }
 
-#pragma warning disable S107 // Methods should not have too many parameters
     private static void OnMeasurementReceived(Instrument instrument,
         double value,
         ReadOnlySpan<KeyValuePair<string, object?>> tags,
@@ -509,7 +503,6 @@ public sealed class AcceptanceTest
         ref double cpuRequestFromGauge,
         ref double memoryFromGauge,
         ref double memoryLimitFromGauge)
-#pragma warning restore S107 // Methods should not have too many parameters
     {
         if (instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization)
         {

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -49,7 +49,6 @@ public class LinuxCountersTests
                 "   0: 030011AC:8AF7 C1B17827:01BB 0B 00000000:00000000 02:000000D1 00000000   472        0 2481276 2 00000000c62511cb 28 4 26 10 -1\r\n"
             },
             {
-#pragma warning disable S103 // Lines should not be too long - disabled for better readability
                 new FileInfo("/proc/net/tcp6"),
                 "  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\r\n" +
                 "   0: 00000000000000000000000000000000:0BB8 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000   472        0 2455375 1 00000000f4cb7621 100 0 0 10 0\r\n" +

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV1Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV1Tests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -169,7 +169,6 @@ public sealed class LinuxUtilizationParserCgroupV1Tests
     [InlineData("MB", 287, 300_941_312)]
     [InlineData("GB", 372, 399_431_958_528)]
     [InlineData("TB", 2, 219_902_325_555_2)]
-    [SuppressMessage("Critical Code Smell", "S3937:Number patterns should be regular", Justification = "Its OK.")]
     public void When_Calling_GetHostAvailableMemory_Parser_Correctly_Transforms_Supported_Units_To_Bytes(string unit, int value, ulong bytes)
     {
         var f = new HardcodedValueFileSystem(new Dictionary<FileInfo, string>

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/FakePerformanceCounter.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/FakePerformanceCounter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -7,9 +7,7 @@ namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Test;
 
 public class FakePerformanceCounter(string instanceName, float[] values) : IPerformanceCounter
 {
-#pragma warning disable S3604 // Member initializer values should not be redundant
     private readonly object _lock = new();
-#pragma warning restore S3604
     private int _index;
 
     public string InstanceName => instanceName;

--- a/test/Libraries/Microsoft.Extensions.Hosting.Testing.Tests/FakeHostTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Hosting.Testing.Tests/FakeHostTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -180,9 +180,7 @@ public class FakeHostTests
 
         var sut = new FakeHost(hostMock.Object, new FakeHostOptions()) { TimeProvider = new FakeTimeProvider() };
         sut.Dispose();
-#pragma warning disable S3966
         sut.Dispose();
-#pragma warning restore S3966
 
         hostMock.Verify(x => x.Dispose(), Times.Once);
     }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Internal/RandomizerTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Internal/RandomizerTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -17,14 +17,12 @@ public class RandomizerTest
         var randomizer = new Randomizer();
         var actions = Enumerable.Range(0, 1000).Select(_ =>
         {
-#pragma warning disable S3257 // Declarations and initializations should be as concise as possible
             return new Action(() =>
             {
                 randomizer.NextInt(10000);
                 randomizer.NextDouble(10000);
             });
         }).ToArray();
-#pragma warning restore S3257 // Declarations and initializations should be as concise as possible
 
         Parallel.Invoke(actions);
     }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Polly/HttpCircuitBreakerStrategyOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Polly/HttpCircuitBreakerStrategyOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -16,7 +16,6 @@ namespace Microsoft.Extensions.Http.Resilience.Test.Polly;
 
 public class HttpCircuitBreakerStrategyOptionsTests
 {
-#pragma warning disable S2330
     public static readonly IEnumerable<object[]> HandledExceptionsClassified = new[]
     {
         new object[] { new InvalidCastException(), false },

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Polly/HttpClientResiliencePredicatesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Polly/HttpClientResiliencePredicatesTests.cs
@@ -13,14 +13,12 @@ namespace Microsoft.Extensions.Http.Resilience.Test.Polly;
 
 public class HttpClientResiliencePredicatesTests
 {
-#pragma warning disable S2330 // Array covariance should not be used
     public static readonly IEnumerable<object[]> HandledExceptionsClassified = new[]
     {
         new object[] { new InvalidCastException(), false },
         new object[] { new HttpRequestException(), true },
         new object[] { new TimeoutRejectedException(), true },
     };
-#pragma warning restore S2330 // Array covariance should not be used
 
     [Fact]
     public void IsTransientHttpException_NullException_ShouldThrow()

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Polly/HttpRateLimiterStrategyOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Polly/HttpRateLimiterStrategyOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.RateLimiting;
@@ -9,7 +9,6 @@ namespace Microsoft.Extensions.Http.Resilience.Test.Polly;
 
 public class HttpRateLimiterStrategyOptionsTests
 {
-#pragma warning disable S2330
     private readonly HttpRateLimiterStrategyOptions _testObject;
 
     public HttpRateLimiterStrategyOptionsTests()

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Polly/HttpRetryStrategyOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Polly/HttpRetryStrategyOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -18,7 +18,6 @@ namespace Microsoft.Extensions.Http.Resilience.Test.Polly;
 
 public class HttpRetryStrategyOptionsTests
 {
-#pragma warning disable S2330
     public static readonly IEnumerable<object[]> HandledExceptionsClassified = new[]
     {
         new object[] { new InvalidCastException(), null!, false },

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Polly/HttpTimeoutStrategyOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Polly/HttpTimeoutStrategyOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -9,7 +9,6 @@ namespace Microsoft.Extensions.Http.Resilience.Test.Polly;
 
 public class HttpTimeoutStrategyOptionsTests
 {
-#pragma warning disable S2330
     private readonly HttpTimeoutStrategyOptions _testObject;
 
     public HttpTimeoutStrategyOptionsTests()

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Latency/Internal/LatencyContextTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Latency/Internal/LatencyContextTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
@@ -35,10 +35,8 @@ public class LatencyContextTests
         Assert.False(latencyContext.IsDisposed);
         latencyContext.Dispose();
         Assert.True(latencyContext.IsDisposed);
-#pragma warning disable S3966 // Objects should not be disposed more than once
         latencyContext.Dispose();
         latencyContext.Dispose();
-#pragma warning restore S3966 // Objects should not be disposed more than once
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Logging/ExtendedLoggerFactoryTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Logging/ExtendedLoggerFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -47,9 +47,7 @@ public static class ExtendedLoggerFactoryTests
     {
         var factory = Utils.CreateLoggerFactory();
         factory.Dispose();
-#pragma warning disable S3966 // Objects should not be disposed more than once
         factory.Dispose();
-#pragma warning restore S3966 // Objects should not be disposed more than once
 
         // just trying to make sure we didn't crash
         Assert.True(true);

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Logging/JustInTimeRedactorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Logging/JustInTimeRedactorTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -10,7 +10,6 @@ namespace Microsoft.Extensions.Logging.Test;
 
 public static class JustInTimeRedactorTests
 {
-#pragma warning disable S103
     [Theory]
     [InlineData("ABC", "", "ABC")]
     [InlineData("ABC", "123", "ABC:123")]
@@ -82,7 +81,6 @@ public static class JustInTimeRedactorTests
         r.Return();
 #endif
     }
-#pragma warning restore S103
 
     private sealed class Formattable : IFormattable
     {

--- a/test/Shared/JsonSchemaExporter/TestTypes.cs
+++ b/test/Shared/JsonSchemaExporter/TestTypes.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -19,14 +19,11 @@ using System.Xml.Linq;
 
 #pragma warning disable SA1118 // Parameter should not span multiple lines
 #pragma warning disable JSON001 // Comments not allowed
-#pragma warning disable S2344 // Enumeration type names should not have "Flags" or "Enum" suffixes
 #pragma warning disable SA1502 // Element should not be on a single line
 #pragma warning disable SA1136 // Enum values should be on separate lines
 #pragma warning disable SA1133 // Do not combine attributes
-#pragma warning disable S3604 // Member initializer values should not be redundant
 #pragma warning disable SA1515 // Single-line comment should be preceded by blank line
 #pragma warning disable CA1052 // Static holder types should be Static or NotInheritable
-#pragma warning disable S1121 // Assignments should not be made from within sub-expressions
 #pragma warning disable IDE0073 // The file header is missing or not located at the top of the file
 
 namespace Microsoft.Extensions.AI.JsonSchemaExporter;

--- a/test/Shared/Throw/DoubleTests.cs
+++ b/test/Shared/Throw/DoubleTests.cs
@@ -1,12 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Xunit;
 
 namespace Microsoft.Shared.Diagnostics.Test;
-
-#pragma warning disable S3236 // Caller information arguments should not be provided explicitly
 
 public class DoubleTests
 {

--- a/test/Shared/Throw/IntegerTests.cs
+++ b/test/Shared/Throw/IntegerTests.cs
@@ -1,12 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Xunit;
 
 namespace Microsoft.Shared.Diagnostics.Test;
-
-#pragma warning disable S3236 // Caller information arguments should not be provided explicitly
 
 public class IntegerTests
 {

--- a/test/Shared/Throw/LongTests.cs
+++ b/test/Shared/Throw/LongTests.cs
@@ -1,12 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Xunit;
 
 namespace Microsoft.Shared.Diagnostics.Test;
-
-#pragma warning disable S3236 // Caller information arguments should not be provided explicitly
 
 public class LongTests
 {

--- a/test/Shared/Throw/ThrowTest.cs
+++ b/test/Shared/Throw/ThrowTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.Shared.Diagnostics.Test;
-
-#pragma warning disable S3236 // Caller information arguments should not be provided explicitly
 
 public class ThrowTest
 {


### PR DESCRIPTION
Address dotnet/extensions#7012 by removing the SonarAnalyzer.CSharp package (SymbolicExecutionRunner ~30s analyzer time) and disabling CA1508 (dead conditional code, ~5s, was only suggestion-level).

Cleanup: removed all in-source Sonar pragma suppressions (142 files), SuppressMessage attributes (44 files), Sonar rules from 6 .editorconfig files, S3236 NoWarn from Directory.Build.targets, and CA1508 pragmas from 2 test files.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7357)