### PR TITLE
Add npmAuthenticate task to fix npm E401 errors on CI agents

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -167,6 +167,16 @@ steps:
               $(_OfficialBuildIdArgs)
       displayName: Pack docs transport package
 
+    - task: npmAuthenticate@0
+      inputs:
+        workingFile: $(Build.SourcesDirectory)/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/.npmrc
+      displayName: Authenticate npm for Azure DevOps plugin (root)
+
+    - task: npmAuthenticate@0
+      inputs:
+        workingFile: $(Build.SourcesDirectory)/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/azure-devops-report/tasks/PublishAIEvaluationReport/.npmrc
+      displayName: Authenticate npm for Azure DevOps plugin (task)
+
     - pwsh: |
           $(Build.SourcesDirectory)/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/azure-devops-report/build.ps1 -OutputPath $(Build.Arcade.VSIXOutputPath)
       displayName: Build Azure DevOps plugin


### PR DESCRIPTION
## Problem

Some `NetCore-Public` pool agents have stale npm auth tokens in `C:\Users\cloudtest\.npmrc`. When `npm ci` runs against the public `dotnet-public-npm` feed, npm sends these stale credentials instead of using anonymous access, resulting in E401 errors. This has been blocking PR #7361 (Dependabot security fix) for 2 days.

## Fix

Add `npmAuthenticate@0` pipeline task before the Build Azure DevOps plugin step in `eng/pipelines/templates/BuildAndTest.yml`. This provides a fresh valid token on every build, overriding any stale agent-level credentials.

## Evidence

Two different agents failed across separate builds while others succeeded in the same build:
- Agent 109: E401 / Agent 126: passed (same build 20260306.1)
- Agent 68: E401 (build 20260305.12)

Fixes #7362
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7364)