### PR TITLE
Remove stale user-level .npmrc instead of npmAuthenticate

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -167,19 +167,16 @@ steps:
               $(_OfficialBuildIdArgs)
       displayName: Pack docs transport package
 
-    - task: npmAuthenticate@0
-      inputs:
-        workingFile: $(Build.SourcesDirectory)/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/.npmrc
-      displayName: Authenticate npm for Azure DevOps plugin (root)
-
-    - task: npmAuthenticate@0
-      inputs:
-        workingFile: $(Build.SourcesDirectory)/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/azure-devops-report/tasks/PublishAIEvaluationReport/.npmrc
-      displayName: Authenticate npm for Azure DevOps plugin (task)
-
     - pwsh: |
           $(Build.SourcesDirectory)/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/azure-devops-report/build.ps1 -OutputPath $(Build.Arcade.VSIXOutputPath)
       displayName: Build Azure DevOps plugin
+      env:
+        # Some CI agents have stale npm auth tokens in the user-level .npmrc
+        # (e.g. C:\Users\cloudtest\.npmrc). npm sends these stale credentials
+        # to the public dotnet-public-npm feed, causing E401 errors. Override
+        # the user config path to a non-existent file so npm ignores stale
+        # credentials and uses anonymous access for the public feed.
+        NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/.npmrc-not-exists
 
     - script: ${{ parameters.buildScript }}
               -restore


### PR DESCRIPTION
## Problem

PR #7364 added `npmAuthenticate@0` tasks to fix E401 errors, but PR #7361 is **still failing** ([build 1323658](https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_build/results?buildId=1323658)). The `npmAuthenticate` tasks succeed but npm still sends stale credentials from the user-level `C:\Users\cloudtest\.npmrc`, overriding the project-level tokens.

## Fix

Replace the two `npmAuthenticate@0` tasks with a single step that removes the stale user-level `.npmrc`. Since the `dotnet-public-npm` feed is **public**, no authentication is needed — the problem was stale credentials being sent unnecessarily.

## Why npmAuthenticate didn't work

npm merges config from multiple `.npmrc` files. The `npmAuthenticate` task writes fresh tokens to the **project-level** `.npmrc`, but npm also reads the **user-level** `~/.npmrc` which has stale auth tokens for the same registry. The stale tokens get sent, causing E401.

Fixes #7365
Related: #7361, #7362, #7364
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7366)