### PR TITLE
fix(ai template): avoid nullable filenameFilter tool schema for Ollama

### DIFF
--- a/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/templates/AIChatWeb-CSharp/AIChatWeb-CSharp.Web/Components/Pages/Chat/Chat.razor
+++ b/src/ProjectTemplates/Microsoft.Extensions.AI.Templates/templates/AIChatWeb-CSharp/AIChatWeb-CSharp.Web/Components/Pages/Chat/Chat.razor
@@ -121,7 +121,7 @@
     [Description("Searches for information using a phrase or keyword. Relies on documents already being loaded.")]
     private async Task<IEnumerable<string>> SearchAsync(
         [Description("The phrase to search for.")] string searchPhrase,
-        [Description("If possible, specify the filename to search that file only. If not provided or empty, the search includes all files.")] string? filenameFilter = null)
+        [Description("If possible, specify the filename to search that file only. If not provided or empty, the search includes all files.")] string filenameFilter = "")
     {
         await InvokeAsync(StateHasChanged);
         var results = await Search.SearchAsync(searchPhrase, filenameFilter, maxResults: 5);


### PR DESCRIPTION
## Summary
- change `SearchAsync`'s `filenameFilter` parameter in the AI Chat Web template from nullable string to non-null string defaulting to empty
- this keeps the generated function schema compatible with OllamaSharp's current mapper expectation for `type: "string"`
- preserves existing behavior because empty string already means "search all files"

## Testing
- Static validation: confirmed the template now emits a non-nullable `string filenameFilter = ""` signature at `Chat.razor` (single-line scoped change)
- Could not run `dotnet build` in this environment because the `dotnet` CLI is not installed (`dotnet: command not found`)

## Related
Fixes #7350