### PR TITLE
Fix test warnings

### DIFF
--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
@@ -611,7 +611,7 @@ public class ChatResponseUpdateExtensionsTests
                     {
                         foreach (bool gapBeginningEnd in new[] { false, true })
                         {
-                            yield return new object[] { useAsync, numSequences, sequenceLength, gapLength, false };
+                            yield return new object[] { useAsync, numSequences, sequenceLength, gapLength, gapBeginningEnd };
                         }
                     }
                 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/ToolApprovalRequestContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/ToolApprovalRequestContentTests.cs
@@ -28,7 +28,7 @@ public class ToolApprovalRequestContentTests
     };
 
     [Theory]
-    [MemberData(nameof(ToolCallContentInstances))]
+    [MemberData(nameof(ToolCallContentInstances), DisableDiscoveryEnumeration = true)]
     public void Constructor_Roundtrips(ToolCallContent toolCall)
     {
         string id = "req-1";
@@ -39,7 +39,7 @@ public class ToolApprovalRequestContentTests
     }
 
     [Theory]
-    [MemberData(nameof(ToolCallContentInstances))]
+    [MemberData(nameof(ToolCallContentInstances), DisableDiscoveryEnumeration = true)]
     public void CreateResponse_ReturnsExpectedResponse(ToolCallContent toolCall)
     {
         string id = "req-1";
@@ -76,7 +76,7 @@ public class ToolApprovalRequestContentTests
     }
 
     [Theory]
-    [MemberData(nameof(ToolCallContentInstances))]
+    [MemberData(nameof(ToolCallContentInstances), DisableDiscoveryEnumeration = true)]
     public void Serialization_Roundtrips(ToolCallContent toolCall)
     {
         var content = new ToolApprovalRequestContent("request123", toolCall);

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/ToolApprovalResponseContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/ToolApprovalResponseContentTests.cs
@@ -28,7 +28,7 @@ public class ToolApprovalResponseContentTests
     };
 
     [Theory]
-    [MemberData(nameof(ToolCallContentInstances))]
+    [MemberData(nameof(ToolCallContentInstances), DisableDiscoveryEnumeration = true)]
     public void Constructor_Roundtrips(ToolCallContent toolCall)
     {
         ToolApprovalResponseContent content = new("req-1", true, toolCall);
@@ -45,7 +45,7 @@ public class ToolApprovalResponseContentTests
     }
 
     [Theory]
-    [MemberData(nameof(ToolCallContentInstances))]
+    [MemberData(nameof(ToolCallContentInstances), DisableDiscoveryEnumeration = true)]
     public void Serialization_Roundtrips(ToolCallContent toolCall)
     {
         var content = new ToolApprovalResponseContent("request123", true, toolCall)

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/SpeechToText/SpeechToTextResponseUpdateExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/SpeechToText/SpeechToTextResponseUpdateExtensionsTests.cs
@@ -24,7 +24,7 @@ public class SpeechToTextResponseUpdateExtensionsTests
                     {
                         foreach (bool gapBeginningEnd in new[] { false, true })
                         {
-                            yield return new object[] { useAsync, numSequences, sequenceLength, gapLength, false };
+                            yield return new object[] { useAsync, numSequences, sequenceLength, gapLength, gapBeginningEnd };
                         }
                     }
                 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
@@ -588,7 +588,7 @@ public static partial class AIJsonUtilitiesTests
     }
 
     [Theory]
-    [MemberData(nameof(TestTypes.GetTestDataUsingAllValues), MemberType = typeof(TestTypes))]
+    [MemberData(nameof(TestTypes.GetTestDataUsingAllValues), MemberType = typeof(TestTypes), DisableDiscoveryEnumeration = true)]
     public static void CreateJsonSchema_ValidateWithTestData(ITestData testData)
     {
         // Stress tests the schema generation method using types from the JsonSchemaExporter test battery.
@@ -1730,7 +1730,7 @@ public static partial class AIJsonUtilitiesTests
     }
 
     [Theory]
-    [MemberData(nameof(TestTypes.GetTestDataUsingAllValues), MemberType = typeof(TestTypes))]
+    [MemberData(nameof(TestTypes.GetTestDataUsingAllValues), MemberType = typeof(TestTypes), DisableDiscoveryEnumeration = true)]
     public static void TransformJsonSchema_ValidateWithTestData(ITestData testData)
     {
         // Stress tests the schema generation method using types from the JsonSchemaExporter test battery.


### PR DESCRIPTION
- Fix duplicate test case IDs caused by unused gapBeginningEnd loop variable (test bug)
- Suppress non-serializable data warnings with DisableDiscoveryEnumeration

These flood the test log.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7369)