### PR TITLE
Also override global npm config to fix persistent E401

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -168,15 +168,20 @@ steps:
       displayName: Pack docs transport package
 
     - pwsh: |
+          Write-Host "--- npm config diagnostics ---"
+          npm config list
+          Write-Host "--- end diagnostics ---"
           $(Build.SourcesDirectory)/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/TypeScript/azure-devops-report/build.ps1 -OutputPath $(Build.Arcade.VSIXOutputPath)
       displayName: Build Azure DevOps plugin
       env:
-        # Some CI agents have stale npm auth tokens in the user-level .npmrc
-        # (e.g. C:\Users\cloudtest\.npmrc). npm sends these stale credentials
-        # to the public dotnet-public-npm feed, causing E401 errors. Override
-        # the user config path to a non-existent file so npm ignores stale
-        # credentials and uses anonymous access for the public feed.
+        # Some CI agents have stale npm auth tokens in user or global .npmrc
+        # files (e.g. C:\Users\cloudtest\.npmrc). npm sends these stale
+        # credentials to the public dotnet-public-npm feed, causing E401.
+        # Override both user and global config paths to non-existent files
+        # so npm only reads the project-level .npmrc (which has the registry
+        # URL but no auth tokens).
         NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/.npmrc-not-exists
+        NPM_CONFIG_GLOBALCONFIG: $(Agent.TempDirectory)/.npmrc-not-exists
 
     - script: ${{ parameters.buildScript }}
               -restore


### PR DESCRIPTION
## Problem

PR #7366 added \NPM_CONFIG_USERCONFIG\ to bypass stale user-level \.npmrc\ credentials, but [build 1325007](https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_build/results?buildId=1325007) on PR #7361 **still fails with E401** on agents 92 and 93.

The env var override was confirmed present in the merge commit, yet npm still sends stale auth tokens. This means the stale credentials are likely in the **global** \.npmrc\ (\<prefix>/etc/npmrc\), not just the user-level one.

## Fix

- Add \NPM_CONFIG_GLOBALCONFIG\ alongside \NPM_CONFIG_USERCONFIG\, both pointing to a non-existent file. This ensures npm only reads the **project-level** \.npmrc\ (registry URL, no auth tokens).
- Add \
pm config list\ diagnostics before the build so we can confirm the env vars take effect and see exactly which config sources npm is reading.

## Why the previous fix was insufficient

npm reads config from four sources in order: project → user → global → built-in. PR #7366 only overrode the **user** config. If stale \_authToken\ entries exist in the **global** config on these CI agents, they would still be sent.

Fixes #7365
Related: #7361, #7362, #7364, #7366
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7375)