### PR TITLE
Add a Release-Notes skill

### DIFF
--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -2,7 +2,7 @@
 name: release-notes
 description: 'Draft release notes for a dotnet/extensions release. Gathers merged PRs, assigns them to packages by file path, categorizes by area and impact, tracks experimental API changes, and produces formatted markdown suitable for a GitHub release. Handles both monthly full releases and targeted intra-month patch releases.'
 agent: 'agent'
-tools: ['github/*']
+tools: ['github/*', 'sql', 'ask_user']
 ---
 
 # Release Notes

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: release-notes
+description: 'Draft release notes for a dotnet/extensions release. Gathers merged PRs, assigns them to packages by file path, categorizes by area and impact, tracks experimental API changes, and produces formatted markdown suitable for a GitHub release. Handles both monthly full releases and targeted intra-month patch releases.'
+agent: 'agent'
+tools: ['github/*']
+---
+
+# Release Notes
+
+Draft release notes for a `dotnet/extensions` release. This skill gathers merged PRs between two tags, maps them to affected packages by examining changed file paths, categorizes entries by area and impact, audits experimental API changes, and produces concise markdown suitable for a GitHub release.
+
+> **User confirmation required: This skill NEVER publishes a GitHub release without explicit user confirmation.** The user must review and approve the draft before any release is created.
+
+## Context
+
+The `dotnet/extensions` repository ships NuGet packages across many functional areas (AI, HTTP Resilience, Diagnostics, Compliance, Telemetry, etc.). Releases come in two forms:
+
+- **Monthly full releases** — all packages ship together with a minor version bump (e.g. v10.3.0 → v10.4.0)
+- **Intra-month patch releases** — a targeted subset of packages ships with a patch version bump (e.g. v10.3.1), typically addressing specific bug fixes or urgent changes
+
+The repository does not follow Semantic Versioning. Major versions align with annual .NET releases, minor versions increment monthly, and patch versions are for intra-month fixes.
+
+The repository makes heavy use of `[Experimental]` attributes. Experimental diagnostic IDs are documented in [`docs/list-of-diagnostics.md`](../../docs/list-of-diagnostics.md). Breaking changes to experimental APIs are expected and acceptable. Graduation of experimental APIs to stable is a noteworthy positive event.
+
+The repository uses `release/` branches (e.g. `release/10.4`) where release tags are associated with commits on those branches. When determining the commit range for a release, ensure the previous and target tags are resolved against the appropriate release branch history.
+
+## Execution Guidelines
+
+- **Do not write intermediate files to disk.** Use the **SQL tool** for structured storage and querying (see [references/sql-storage.md](references/sql-storage.md) for schema).
+- **Do not run linters, formatters, or validators** on the output.
+- **Maximize parallel tool calls.** Fetch multiple PR and issue details in a single response.
+- **Package assignment is file-path-driven.** Determine which packages a PR affects by examining which `src/Libraries/{PackageName}/` paths it touches. See [references/package-areas.md](references/package-areas.md) for the mapping. Use `area-*` labels only as a fallback.
+
+## Process
+
+Work through each step sequentially. Present findings at each step and get user confirmation before proceeding.
+
+### Step 1: Determine Release Scope
+
+The user may provide:
+- **Two tags** (previous and target) — use these directly
+- **A target tag only** — determine the previous release from `gh release list --repo dotnet/extensions --exclude-drafts`
+- **No context** — show the last 5 published releases and ask the user to select
+
+Once the range is established:
+
+1. Determine if this is a **full release** (minor version bump) or **patch release** (patch version bump) based on the version numbers.
+2. For patch releases, ask the user which packages are included (or infer from the PRs).
+3. Get the merge date range for PR collection.
+
+### Step 2: Collect and Enrich PRs
+
+Follow [references/collect-prs.md](references/collect-prs.md):
+
+1. Search for merged PRs in the date range between the two tags.
+2. For each PR, fetch the file list and assign packages based on `src/Libraries/{PackageName}/` paths.
+3. Enrich with full PR body, reactions, linked issues, and co-author data.
+4. Apply exclusion filters (backports, automated version bumps, etc.).
+5. Mark remaining PRs as candidates.
+
+Store all data using the SQL tool.
+
+### Step 3: Categorize and Group
+
+Follow [references/categorize-entries.md](references/categorize-entries.md):
+
+1. **Assign categories**: What's Changed, Documentation Updates, Test Improvements, or Repository Infrastructure Updates.
+2. **Group by package area**: For "What's Changed" entries, group under descriptive area headings from [references/package-areas.md](references/package-areas.md). Each area heading must clearly identify the packages it covers.
+3. **Order by impact**: Within each area, order entries by impact — breaking changes first, then new features, then bug fixes.
+4. **Order areas by activity**: Place the area with the most entries first.
+
+### Step 4: Audit Experimental API Changes
+
+Follow [references/experimental-features.md](references/experimental-features.md):
+
+1. Scan candidate PRs for changes to `[Experimental]` APIs.
+2. Classify each change: now stable, new experimental, breaking change to experimental, or removed.
+3. Record in the `experimental_changes` SQL table.
+4. Present findings to the user for confirmation.
+
+### Step 5: Determine Package Versions
+
+Build the package version information:
+
+1. For **full releases**: all packages ship at the same version. Note the version number but do not generate a per-package table — it would be repetitive with no value.
+2. For **patch releases**: build a table of only the affected packages and their version numbers.
+3. Present the version information to the user for confirmation. The user may adjust which packages are included in a patch release.
+
+### Step 6: Draft Release Notes
+
+Compose the release notes following [references/format-template.md](references/format-template.md) and [references/editorial-rules.md](references/editorial-rules.md):
+
+1. **Preamble** — Optionally draft 2–3 sentences summarizing the release theme. Suggest a couple of preamble options to the user, but always offer the option of omitting the preamble entirely.
+2. **Packages in this release** — for patch releases, the table of affected packages and versions from Step 5. For full releases, omit this table (all packages ship at the same version and listing them all adds no value).
+3. **Breaking Changes** — stable API breaks only (should be very rare). Include migration guidance.
+4. **Experimental API Changes** — from Step 4 results. Group by change type. Omit empty subsections.
+5. **What's Changed** — area-grouped entries from Step 3. Omit empty areas.
+6. **Documentation Updates** — chronological flat list.
+7. **Test Improvements** — chronological flat list.
+8. **Repository Infrastructure Updates** — chronological flat list.
+9. **Acknowledgements** — new contributors, issue reporters, PR reviewers.
+10. **Full Changelog** — link to the GitHub compare view.
+
+Omit empty sections entirely.
+
+### Step 7: Review and Finalize
+
+Present the complete draft to the user:
+
+1. The full release notes markdown
+2. Summary statistics (number of PRs, packages affected, areas covered)
+3. Any unresolved items (ambiguous PRs, missing package assignments)
+
+Get explicit user confirmation before creating the GitHub release. The user may:
+- **Edit the draft** — make changes and re-present
+- **Approve** — create the GitHub release with the draft as the body
+- **Save as draft** — save the release as a draft for later publishing
+
+## Edge Cases
+
+- **PR spans categories**: Categorize by primary intent; read the title and description.
+- **PR spans multiple areas**: Place under the most central area; mention cross-cutting nature in the description.
+- **Copilot timeline missing**: Fall back to `Co-authored-by` trailers; if unclear, use the PR author.
+- **No breaking changes**: Omit the Breaking Changes section entirely.
+- **No experimental changes**: Omit the Experimental API Changes section entirely.
+- **No user-facing changes**: If all PRs are documentation, tests, or infrastructure, note this in the release notes. The release still proceeds — this repository ships monthly regardless.
+- **Patch release with unclear scope**: Ask the user to confirm which packages are included.
+- **No previous release**: If this is the first release under the current versioning scheme, gather all PRs from the beginning of the tag history.
+- **Version mismatch**: If the tag version doesn't match the version in source files, flag the discrepancy.
+- **Large release (100+ PRs)**: Break the enrichment step into parallel batches. Consider summarizing lower-impact areas more aggressively.
+- **Cross-repo changes**: Some PRs may reference issues or changes in other repos (e.g. `dotnet/runtime`). Use full markdown links for cross-repo references.

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -73,10 +73,11 @@ Follow [references/categorize-entries.md](references/categorize-entries.md):
 
 Follow [references/experimental-features.md](references/experimental-features.md):
 
-1. Scan candidate PRs for changes to `[Experimental]` APIs.
+1. For each candidate PR, **fetch the file list and diff** to identify changes to `[Experimental]` APIs. Do not infer experimental changes from PR titles — always verify against the actual files changed.
 2. Classify each change: now stable, new experimental, breaking change to experimental, or removed.
-3. Record in the `experimental_changes` SQL table.
-4. Present findings to the user for confirmation.
+3. Derive the conceptual feature name from the actual types/members affected in the diff.
+4. Record in the `experimental_changes` SQL table.
+5. Present findings to the user for confirmation.
 
 ### Step 5: Determine Package Versions
 
@@ -90,7 +91,7 @@ Build the package version information:
 
 Compose the release notes following [references/format-template.md](references/format-template.md) and [references/editorial-rules.md](references/editorial-rules.md):
 
-1. **Preamble** — Optionally draft 2–3 sentences summarizing the release theme. Suggest a couple of preamble options to the user, but always offer the option of omitting the preamble entirely.
+1. **Preamble** — Optionally draft 2–3 sentences summarizing the release theme. Present the preamble options to the user using the `ask_user` tool, offering them the choice of: (a) one of the suggested preambles, (b) writing their own, or (c) skipping the preamble entirely.
 2. **Packages in this release** — for patch releases, the table of affected packages and versions from Step 5. For full releases, omit this table (all packages ship at the same version and listing them all adds no value).
 3. **Breaking Changes** — stable API breaks only (should be very rare). Include migration guidance.
 4. **Experimental API Changes** — from Step 4 results. Group by change type. Omit empty subsections.
@@ -111,16 +112,16 @@ Present the complete draft to the user:
 2. Summary statistics (number of PRs, packages affected, areas covered)
 3. Any unresolved items (ambiguous PRs, missing package assignments)
 
-Get explicit user confirmation before creating the GitHub release. The user may:
-- **Edit the draft** — make changes and re-present
-- **Approve** — create the GitHub release with the draft as the body
-- **Save as draft** — save the release as a draft for later publishing
+After the user has reviewed and approved the draft, present the finalization options using the `ask_user` tool:
+- **Create draft release** — create a GitHub release in draft state with the notes as the body
+- **Save to private gist** — save the draft notes to a private GitHub gist for later use
+- **Cancel** — discard the draft without creating anything
 
 ## Edge Cases
 
 - **PR spans categories**: Categorize by primary intent; read the title and description.
 - **PR spans multiple areas**: Place under the most central area; mention cross-cutting nature in the description.
-- **Copilot timeline missing**: Fall back to `Co-authored-by` trailers; if unclear, use the PR author.
+- **Copilot-authored PRs**: If the PR author is Copilot or a bot, check the `copilot_work_started` timeline event for the triggering user, then assignees, then the merger. See [references/editorial-rules.md](references/editorial-rules.md) for the full fallback chain. Never fabricate an attribution — always derive it from the PR data.
 - **No breaking changes**: Omit the Breaking Changes section entirely.
 - **No experimental changes**: Omit the Experimental API Changes section entirely.
 - **No user-facing changes**: If all PRs are documentation, tests, or infrastructure, note this in the release notes. The release still proceeds — this repository ships monthly regardless.

--- a/.github/skills/release-notes/references/categorize-entries.md
+++ b/.github/skills/release-notes/references/categorize-entries.md
@@ -1,0 +1,75 @@
+# Categorize Entries
+
+Sort candidate PRs into sections and group them by package area for the release notes.
+
+## Step 1: Assign categories
+
+For each candidate PR, assign one of these categories based on the primary intent:
+
+| Category | Key | Content |
+|----------|-----|---------|
+| What's Changed | `changed` | Features, bug fixes, API improvements, performance, breaking changes |
+| Documentation Updates | `docs` | PRs whose sole purpose is documentation |
+| Test Improvements | `tests` | Adding, fixing, or improving tests |
+| Repository Infrastructure Updates | `infra` | CI/CD, dependency bumps, version bumps, build system, skills |
+
+**Decision rules:**
+- If a PR modifies files under `src/Libraries/` or `src/Generators/` or `src/Analyzers/`, it is `changed` (even if it also touches docs or tests)
+- If a PR **only** modifies files under `docs/`, XML doc comments, or README files, it is `docs`
+- If a PR **only** modifies files under `test/`, it is `tests`
+- If a PR **only** modifies `eng/`, `scripts/`, `.github/`, CI YAML files, or root config files, it is `infra`
+- When a PR spans multiple categories, assign based on primary intent — read the title and description
+
+Update the SQL record:
+```sql
+UPDATE prs SET category = '<category>' WHERE number = <pr_number>;
+```
+
+## Step 2: Group by package area
+
+For PRs in the `changed` category, group them under their package area headings using the `pr_packages` table. Each area heading uses the descriptive name from [package-areas.md](package-areas.md).
+
+**Area heading selection:**
+- If a PR affects packages in a single area → place under that area
+- If a PR affects packages in multiple areas → place under the area most central to the change, noting the cross-cutting nature in the description if relevant
+- If a `changed` PR has no package assignment (rare — e.g. a cross-cutting change to `Directory.Build.props` that affects all packages) → place under a "Cross-Cutting Changes" heading
+
+**Area ordering in the release notes:**
+Order areas by the number of entries (most active area first), then alphabetically for ties. This naturally highlights the areas with the most changes.
+
+## Step 3: Impact tiering within areas
+
+Within each area, order entries by impact:
+
+1. **Breaking changes** (stable API breaks — should be very rare)
+2. **Experimental API changes** (graduated, removed, breaking — see [experimental-features.md](experimental-features.md))
+3. **New features and significant improvements**
+4. **Bug fixes with community signal** (reported by community members, high reaction count)
+5. **Other bug fixes and improvements**
+
+Use the popularity score from the SQL `prs` + `issues` tables (combined reaction counts) as a tiebreaker within each tier.
+
+## Step 4: Handle documentation, test, and infrastructure categories
+
+These categories are **not** grouped by package area. They appear as flat lists in their own sections at the bottom of the release notes:
+
+- **Documentation Updates** — sorted by merge date
+- **Test Improvements** — sorted by merge date
+- **Repository Infrastructure Updates** — sorted by merge date
+
+## Full vs. patch release considerations
+
+### Full monthly release
+- All areas with changes get their own heading
+- All four category sections appear (omit empty ones)
+- Include the "Experimental API Changes" section if any experimental changes were detected
+
+### Targeted patch release
+- Only the affected areas appear (typically 1–3 areas)
+- The preamble explicitly states which packages are included in the patch
+- The "Experimental API Changes" section still appears if relevant
+- Documentation, test, and infrastructure sections may be shorter or absent
+
+## Multi-faceted PRs
+
+A single PR may deliver a feature, fix bugs, AND improve performance. When writing the entry, describe the full scope — do not reduce it to a single aspect. Read the full PR description, not just the title.

--- a/.github/skills/release-notes/references/categorize-entries.md
+++ b/.github/skills/release-notes/references/categorize-entries.md
@@ -72,4 +72,4 @@ These categories are **not** grouped by package area. They appear as flat lists 
 
 ## Multi-faceted PRs
 
-A single PR may deliver a feature, fix bugs, AND improve performance. When writing the entry, describe the full scope — do not reduce it to a single aspect. Read the full PR description, not just the title.
+A single PR may deliver a feature, fix bugs, AND improve performance. Use the verbatim PR title as the entry description regardless. Read the full PR description, not just the title, to determine the correct category assignment.

--- a/.github/skills/release-notes/references/collect-prs.md
+++ b/.github/skills/release-notes/references/collect-prs.md
@@ -91,6 +91,19 @@ pull_request_read(
 )
 ```
 
+Also fetch reviews for the acknowledgements section:
+
+```
+pull_request_read(
+  method: "get_reviews",
+  owner: "dotnet",
+  repo: "extensions",
+  pullNumber: <number>
+)
+```
+
+Record each reviewer's username and the PR number. See [editorial-rules.md](editorial-rules.md) for exclusion and sorting rules.
+
 ## Discover linked issues
 
 Parse the PR body for issue references:
@@ -99,6 +112,31 @@ Parse the PR body for issue references:
 - Cross-repo references: `dotnet/extensions#1234`
 
 For each discovered issue, fetch details with `issue_read` and insert into the `issues` table.
+
+## Deduplicate against prior release
+
+PRs merged into `main` may include changes that were already included in a prior release via a `release/` branch. The prior release branch may also contain PRs that were merged into it but never covered in that release's notes — those PRs must still be excluded from the current release notes because they shipped in the prior release's packages.
+
+### Fetch release branches
+
+Before deduplication, ensure the relevant release branches are available locally:
+
+1. Identify which local git remote points to `dotnet/extensions` on GitHub (e.g. by checking `git remote -v` for a URL containing `dotnet/extensions`). Use that remote name in subsequent fetch commands.
+2. Identify the prior release branch from the previous release tag (e.g. `v10.3.0` → `release/10.3`).
+3. Fetch it: `git fetch <remote> release/10.3` (using the remote identified in step 1).
+4. If the current release also has a release branch (e.g. `release/10.4`), fetch that too.
+
+### Exclude PRs already shipped
+
+For each candidate PR, check whether it was already included in any prior release — even if the prior release notes didn't mention it:
+
+1. **Check against the prior release tag**: `git merge-base --is-ancestor <pr-merge-commit> <previous-tag>`. If the PR's merge commit is an ancestor of the previous release tag, it shipped in that release — exclude it.
+2. **Check against the prior release branch HEAD**: The release branch may have advanced beyond the release tag (e.g. `release/10.3` may contain commits merged after `v10.3.0` was tagged but before `v10.3.1` or the branch was abandoned). Check: `git merge-base --is-ancestor <pr-merge-commit> <remote>/release/10.3`. If reachable, the PR was part of that release branch's content — exclude it.
+3. **Check the prior release notes body**: Fetch the GitHub release for the previous tag and check if the PR number appears in the release notes body. This catches PRs that were explicitly covered.
+
+> **Why this matters:** A PR can be merged into a `release/` branch, ship in that release's packages, but never appear in that release's notes (e.g. a late-breaking fix). When that PR is later merged into `main`, it appears in the date-range search for the next release. Without branch-aware deduplication, it would be incorrectly included in the new release notes.
+
+This step is critical and must run before marking PRs as candidates.
 
 ## Exclusion filters
 
@@ -111,4 +149,11 @@ Mark remaining PRs as candidates: `UPDATE prs SET is_candidate = 1 WHERE ...`
 
 ## Populate co-author data
 
-For each candidate PR, check the merge commit for `Co-authored-by:` trailers. Record co-authors for use in attribution. Check the `copilot_work_started` timeline event to identify Copilot-assisted PRs.
+For each candidate PR, collect co-authors from **all commits in the PR**, not just the merge commit:
+
+1. **Fetch the PR's commits** using `list_commits` on the PR's head branch, or use `get_commit` for the merge commit SHA from the PR details.
+2. **Parse `Co-authored-by:` trailers** from every commit message in the PR. These trailers follow the format: `Co-authored-by: Name <email>`. Extract the GitHub username from the email (e.g. `123456+username@users.noreply.github.com` → `username`) or match the name against known GitHub users.
+3. **Also check the merge commit** message itself for `Co-authored-by:` trailers, as squash-merged PRs consolidate trailers there.
+4. **Check the `copilot_work_started` timeline event** to identify Copilot-assisted PRs where a human delegated the work.
+
+A common pattern in this repository is a human-authored PR with `Co-authored-by: Copilot <...>` trailers on individual commits — these must be detected to give Copilot co-author attribution. Store all discovered co-authors in the database for use during rendering.

--- a/.github/skills/release-notes/references/collect-prs.md
+++ b/.github/skills/release-notes/references/collect-prs.md
@@ -1,0 +1,114 @@
+# Collect and Filter PRs
+
+Gather all merged PRs between the previous release tag and the target for this release.
+
+## Determine the commit range
+
+1. **Previous release tag**: Use `gh release list --repo dotnet/extensions --exclude-drafts --limit 10` to find the most recent published release. If the user specifies a particular previous version, use that instead.
+2. **Target**: The user provides a target (commit SHA, branch, or tag). If none is specified, use the `HEAD` of the default branch (`main`).
+3. Verify both refs exist: `git rev-parse <previous-tag>` and `git rev-parse <target>`.
+
+## Search for merged PRs
+
+### Primary — GitHub MCP server
+
+Use `search_pull_requests` to find PRs merged in the date range. Keep result sets small to avoid large responses being saved to temp files.
+
+```
+search_pull_requests(
+  owner: "dotnet",
+  repo: "extensions",
+  query: "is:merged merged:<start-date>..<end-date>",
+  perPage: 30
+)
+```
+
+Page through results (incrementing `page`) until all PRs are collected. The `start-date` is the merge date of the previous release tag's PR (or the tag's commit date); the `end-date` is the target commit date.
+
+If the date range yields many results, split by week or use label-scoped queries to keep individual searches small.
+
+### Fallback — GitHub CLI
+
+If the MCP server is unavailable:
+
+```bash
+gh pr list --repo dotnet/extensions --state merged \
+  --search "merged:<start-date>..<end-date>" \
+  --limit 500 --json number,title,labels,author,mergedAt,url
+```
+
+## Assign packages from file paths
+
+For each PR, fetch the list of changed files:
+
+```
+pull_request_read(
+  method: "get_files",
+  owner: "dotnet",
+  repo: "extensions",
+  pullNumber: <number>
+)
+```
+
+Extract package names from file paths matching `src/Libraries/{PackageName}/`. For each matched package, look up the area group from [package-areas.md](package-areas.md).
+
+**Rules:**
+- A PR may affect multiple packages across different areas — record all of them in the `pr_packages` table
+- If a PR only touches `test/Libraries/{PackageName}/`, it still maps to that package's area (useful for the "Test Improvements" category)
+- If a PR only touches `eng/`, `scripts/`, `.github/`, or root-level files, it has no package assignment — categorize as infrastructure
+- If a PR only touches `docs/`, it has no package assignment — categorize as documentation
+
+**Fallback for ambiguous PRs:**
+If a PR has no `src/Libraries/` or `test/Libraries/` file changes but does have `area-*` labels, use those labels to infer the package area. Map `area-Microsoft.Extensions.AI` to the AI area group, etc.
+
+## Store PR data
+
+Insert each discovered PR into the `prs` SQL table. See [sql-storage.md](sql-storage.md) for the schema.
+
+## Enrich PR details
+
+For each PR, fetch the full body and metadata:
+
+```
+pull_request_read(
+  method: "get",
+  owner: "dotnet",
+  repo: "extensions",
+  pullNumber: <number>
+)
+```
+
+Update the `body`, `reactions`, `author_association`, and `labels` columns. Multiple independent PR reads can be issued in parallel.
+
+Also fetch comments to look for Copilot-generated summaries:
+
+```
+pull_request_read(
+  method: "get_comments",
+  owner: "dotnet",
+  repo: "extensions",
+  pullNumber: <number>
+)
+```
+
+## Discover linked issues
+
+Parse the PR body for issue references:
+- Closing keywords: `Fixes #1234`, `Closes #1234`, `Resolves #1234`
+- Full URL links: `https://github.com/dotnet/extensions/issues/1234`
+- Cross-repo references: `dotnet/extensions#1234`
+
+For each discovered issue, fetch details with `issue_read` and insert into the `issues` table.
+
+## Exclusion filters
+
+Before marking PRs as candidates, exclude:
+- PRs labeled `backport`, `servicing`, or `NO-MERGE`
+- PRs whose title starts with `[release/` or contains `backport`
+- PRs that are purely automated version bumps (title matches `Update version to *` and only changes `Directory.Build.props` or version files)
+
+Mark remaining PRs as candidates: `UPDATE prs SET is_candidate = 1 WHERE ...`
+
+## Populate co-author data
+
+For each candidate PR, check the merge commit for `Co-authored-by:` trailers. Record co-authors for use in attribution. Check the `copilot_work_started` timeline event to identify Copilot-assisted PRs.

--- a/.github/skills/release-notes/references/collect-prs.md
+++ b/.github/skills/release-notes/references/collect-prs.md
@@ -151,7 +151,7 @@ Mark remaining PRs as candidates: `UPDATE prs SET is_candidate = 1 WHERE ...`
 
 For each candidate PR, collect co-authors from **all commits in the PR**, not just the merge commit:
 
-1. **Fetch the PR's commits** using `list_commits` on the PR's head branch, or use `get_commit` for the merge commit SHA from the PR details.
+1. **Fetch the PR's commits** via the pull request commits endpoint (for example, using a `pull_request_read` / PR-scoped `list_commits` method), so it works even if the PR's head branch has been deleted. If needed, also use `get_commit` for the merge commit SHA from the PR details.
 2. **Parse `Co-authored-by:` trailers** from every commit message in the PR. These trailers follow the format: `Co-authored-by: Name <email>`. Extract the GitHub username from the email (e.g. `123456+username@users.noreply.github.com` → `username`) or match the name against known GitHub users.
 3. **Also check the merge commit** message itself for `Co-authored-by:` trailers, as squash-merged PRs consolidate trailers there.
 4. **Check the `copilot_work_started` timeline event** to identify Copilot-assisted PRs where a human delegated the work.

--- a/.github/skills/release-notes/references/editorial-rules.md
+++ b/.github/skills/release-notes/references/editorial-rules.md
@@ -1,0 +1,119 @@
+# Editorial Rules
+
+## Tone
+
+- Maintain a **positive tone** — highlight new benefits rather than expressing prior shortcomings
+  - ✅ `Added streaming metrics for time-to-first-chunk and time-per-output-chunk`
+  - ❌ `Previously there was no way to measure streaming latency`
+- When context about the prior state is needed, keep it brief — one clause, not a paragraph — then pivot to the new capability
+
+## Conciseness
+
+- **No code samples** in release notes. This repository ships many packages and the release notes should be scannable, not tutorial-length.
+- Each entry is a **single bullet point** with a brief description of what changed and why it matters.
+- For complex features, use at most 2–3 sentences. Link to the PR for details.
+- If a PR touches multiple concerns, describe the primary change. Do not enumerate every modified file.
+
+## Entry format
+
+Use this format (GitHub auto-links `#PR` and `@user` in release notes):
+
+```
+* Description #PR by @author
+```
+
+For PRs with co-authors (harvested from `Co-authored-by` commit trailers):
+```
+* Description #PR by @author (co-authored by @user1 @user2)
+```
+
+For Dependabot PRs, omit the author:
+```
+* Bump actions/checkout from 5.0.0 to 6.0.0 #1234
+```
+
+For Copilot-authored PRs, check the `copilot_work_started` timeline event to identify the triggering user. That person becomes the primary author; `@Copilot` becomes a co-author:
+```
+* Add trace-level logging for HTTP requests #1234 by @author (co-authored by @Copilot)
+```
+
+## Entry naming
+
+- Prefer a **brief description** of what changed over simply stating an API name
+  - ✅ `Added streaming metrics for time-to-first-chunk`
+  - ✅ `Fixed credential handling in authenticated proxy scenarios`
+  - ❌ `OpenTelemetryChatClient update`
+  - ❌ `HttpClientHandler fix`
+- Start with a verb: Added, Fixed, Updated, Removed, Improved, Renamed
+- Keep entries to one line when possible
+
+## Attribution rules
+
+- **PR author**: The `user.login` from the PR details
+- **Co-authors**: Harvest from `Co-authored-by` trailers in the PR's merge commit
+- **Copilot**: Check the `copilot_work_started` timeline event. If present, the triggering user is the primary author and `@Copilot` is a co-author
+- **Bots to exclude**: `dependabot[bot]`, `dotnet-maestro[bot]`, `github-actions[bot]`, `copilot-swe-agent[bot]`, and any account ending with `[bot]`
+
+## Sorting
+
+Within the **What's Changed** area sections, sort entries by **impact** (see [categorize-entries.md](categorize-entries.md) for the impact tier ordering). Within all other sections (Documentation Updates, Test Improvements, Repository Infrastructure Updates), sort entries by **merge date** (chronological order, oldest first).
+
+## Category definitions
+
+### What's Changed
+Feature work, bug fixes, API improvements, performance enhancements, and any other user-facing changes. This includes:
+- New API surface area
+- Bug fixes that affect runtime behavior
+- Performance improvements
+- Changes that span code + docs (categorize by primary intent)
+
+### Documentation Updates
+PRs whose **sole purpose** is documentation:
+- Fixing typos in docs
+- Updating XML doc comments (when not part of a functional change)
+- README updates
+
+A PR that changes code AND updates docs belongs in "What's Changed."
+
+### Test Improvements
+PRs focused on test quality or coverage:
+- Adding new tests
+- Fixing broken or flaky tests
+- Test infrastructure improvements
+
+### Repository Infrastructure Updates
+PRs that maintain the development environment:
+- Version bumps
+- CI/CD workflow changes
+- Dependency updates (Dependabot)
+- Build system changes
+- Copilot instructions and skill updates
+
+PRs that touch test code should never be categorized as Infrastructure.
+
+## Acknowledgements section
+
+Include an acknowledgements section at the bottom of the release notes:
+
+1. **New contributors** — people making their first contribution in this release
+2. **Issue reporters** — community members whose reported issues were resolved in this release, citing the resolving PR
+3. **PR reviewers** — single bullet listing all reviewers, sorted by review count (no count shown)
+
+Format:
+```
+* @user made their first contribution in #PR
+* @user submitted issue #1234 (resolved by #5678)
+* @user1 @user2 @user3 reviewed pull requests
+```
+
+## Inclusion criteria
+
+Include a feature/fix if:
+- It gives users something new or something that works better
+- It's a community-requested change (high reaction count on backing issue)
+- It changes behavior users need to be aware of
+
+Exclude:
+- Internal refactoring with no user-facing change
+- Test-only changes (these go in "Test Improvements")
+- Build/infrastructure changes (these go in "Repository Infrastructure Updates")

--- a/.github/skills/release-notes/references/editorial-rules.md
+++ b/.github/skills/release-notes/references/editorial-rules.md
@@ -2,17 +2,20 @@
 
 ## Tone
 
-- Maintain a **positive tone** — highlight new benefits rather than expressing prior shortcomings
+- Remain **objective and factual** — describe what was introduced or changed without editorial judgment
+  - ✅ `Introduces new APIs for text-to-speech`
   - ✅ `Added streaming metrics for time-to-first-chunk and time-per-output-chunk`
+  - ❌ `Adds significant advancements in AI capabilities`
   - ❌ `Previously there was no way to measure streaming latency`
+- Avoid superlatives and subjective qualifiers ("significant", "major improvements", "exciting"). Simply state what was added, changed, or fixed.
 - When context about the prior state is needed, keep it brief — one clause, not a paragraph — then pivot to the new capability
 
 ## Conciseness
 
 - **No code samples** in release notes. This repository ships many packages and the release notes should be scannable, not tutorial-length.
-- Each entry is a **single bullet point** with a brief description of what changed and why it matters.
-- For complex features, use at most 2–3 sentences. Link to the PR for details.
-- If a PR touches multiple concerns, describe the primary change. Do not enumerate every modified file.
+- Each entry is a **single bullet point** using the verbatim PR title.
+- Link to the PR for details (via `#PR` auto-link).
+- If a PR touches multiple concerns, the PR title should capture the primary change. Do not rewrite it.
 
 ## Entry format
 
@@ -39,19 +42,20 @@ For Copilot-authored PRs, check the `copilot_work_started` timeline event to ide
 
 ## Entry naming
 
-- Prefer a **brief description** of what changed over simply stating an API name
-  - ✅ `Added streaming metrics for time-to-first-chunk`
-  - ✅ `Fixed credential handling in authenticated proxy scenarios`
-  - ❌ `OpenTelemetryChatClient update`
-  - ❌ `HttpClientHandler fix`
-- Start with a verb: Added, Fixed, Updated, Removed, Improved, Renamed
-- Keep entries to one line when possible
+- Use the **verbatim PR title** as the entry description. Do not rewrite, rephrase, or summarize PR titles.
+- The PR title is the author's chosen description of the change and should be preserved exactly as written.
 
 ## Attribution rules
 
-- **PR author**: The `user.login` from the PR details
-- **Co-authors**: Harvest from `Co-authored-by` trailers in the PR's merge commit
-- **Copilot**: Check the `copilot_work_started` timeline event. If present, the triggering user is the primary author and `@Copilot` is a co-author
+> **Critical: Every attribution must be derived from the stored PR data, never fabricated or assumed.** When writing each release note entry, read the `author` field from the `prs` SQL table and the co-author data collected during enrichment. Do not write an `@username` attribution without having that username in the database for that PR.
+
+- **PR author**: The `user.login` from the PR details — read this from the `prs` table when rendering each entry
+- **Co-authors**: Harvest from `Co-authored-by` trailers in **all commits** in the PR (not just the merge commit). Individual commits often carry `Co-authored-by: Copilot <...>` trailers that are not present in the merge commit message. Fetch the PR's commits and parse trailers from each one. For squash-merged PRs, check the squash commit message which consolidates trailers.
+- **Copilot-authored PRs**: If the PR author is `Copilot`, `copilot-swe-agent[bot]`, or the PR body mentions "Created from Copilot CLI" / "copilot delegate":
+  1. Check the `copilot_work_started` timeline event to identify the triggering user
+  2. If found, the triggering user becomes the primary author and `@Copilot` becomes a co-author
+  3. If the timeline event is missing, check assignees and the merger — the human who delegated and merged the work is the primary author
+  4. As a last resort, attribute to the merger
 - **Bots to exclude**: `dependabot[bot]`, `dotnet-maestro[bot]`, `github-actions[bot]`, `copilot-swe-agent[bot]`, and any account ending with `[bot]`
 
 ## Sorting
@@ -99,10 +103,30 @@ Include an acknowledgements section at the bottom of the release notes:
 2. **Issue reporters** — community members whose reported issues were resolved in this release, citing the resolving PR
 3. **PR reviewers** — single bullet listing all reviewers, sorted by review count (no count shown)
 
-Format:
+### Collecting PR reviewers
+
+For each candidate PR, fetch the reviews:
+
 ```
-* @user made their first contribution in #PR
-* @user submitted issue #1234 (resolved by #5678)
+pull_request_read(
+  method: "get_reviews",
+  owner: "dotnet",
+  repo: "extensions",
+  pullNumber: <number>
+)
+```
+
+Collect all users who submitted a review (any state: APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED). Multiple reviews on the same PR by the same user count as one review for that PR.
+
+**Exclusions — do not list as reviewers:**
+- Bot accounts: any account ending with `[bot]`, `Copilot`, `copilot-swe-agent[bot]`
+- Users who are already listed as PR authors or co-authors elsewhere in the release notes (they are already acknowledged)
+- The PR author themselves (self-reviews)
+
+**Sorting:** Sort reviewers by the number of distinct PRs they reviewed (descending). Do not show the count — just the sorted order.
+
+**Format:** A single bullet with all reviewers listed inline:
+```
 * @user1 @user2 @user3 reviewed pull requests
 ```
 

--- a/.github/skills/release-notes/references/experimental-features.md
+++ b/.github/skills/release-notes/references/experimental-features.md
@@ -14,7 +14,7 @@ An experimental API has its `[Experimental]` attribute removed, making it a stab
 
 **How to detect:**
 - PR removes `[Experimental("...")]` attribute from types or members
-- PR removes the diagnostic ID from the project's `DiagnosticId` list
+- PR updates the project's experimental diagnostic staging properties (for example, removing the ID from `StageDevDiagnosticId` or related MSBuild properties) in line with [`docs/list-of-diagnostics.md`](../../../docs/list-of-diagnostics.md)
 - PR description or title mentions "promote", "graduate", "stabilize", or "remove experimental"
 - The corresponding `.json` API baseline file changes a type's `"Stage"` from `"Experimental"` to `"Stable"`
 

--- a/.github/skills/release-notes/references/experimental-features.md
+++ b/.github/skills/release-notes/references/experimental-features.md
@@ -1,0 +1,109 @@
+# Experimental Feature Tracking
+
+The `dotnet/extensions` repository makes heavy use of the `[Experimental]` attribute to mark APIs that are not yet stable. Experimental APIs have their own diagnostic IDs and may undergo breaking changes, graduation to stable, or removal between releases. These changes are noteworthy and deserve dedicated coverage in release notes.
+
+## Diagnostic ID conventions
+
+Experimental APIs in this repository use diagnostic IDs documented in [`docs/list-of-diagnostics.md`](../../../docs/list-of-diagnostics.md) under the "Experiments" section. Consult that file for the current list of experimental diagnostic IDs and their descriptions. New diagnostic IDs may be added as new experimental features are introduced.
+
+## Types of experimental changes
+
+### Now Stable
+
+An experimental API has its `[Experimental]` attribute removed, making it a stable part of the public API. This is a positive signal — the API has been validated through preview usage and feedback.
+
+**How to detect:**
+- PR removes `[Experimental("...")]` attribute from types or members
+- PR removes the diagnostic ID from the project's `DiagnosticId` list
+- PR description or title mentions "promote", "graduate", "stabilize", or "remove experimental"
+- The corresponding `.json` API baseline file changes a type's `"Stage"` from `"Experimental"` to `"Stable"`
+
+**How to report:**
+Reference the feature by a conceptual name, not individual type names. Do not attribute to an author.
+```markdown
+* <Feature Name> APIs are now stable (previously `EXTEXP0003`) #PR
+```
+
+### Removed
+
+An experimental API is removed entirely. This is acceptable under the experimental API contract — consumers who suppressed the diagnostic accepted this possibility.
+
+**How to detect:**
+- PR deletes types or members that were annotated with `[Experimental]`
+- PR description mentions "remove" along with experimental type names
+- The `.json` API baseline file removes entries that were previously `"Stage": "Experimental"`
+
+**How to report:**
+Reference the feature by a conceptual name, not individual type names. Do not attribute to an author.
+```markdown
+* <Feature Name> experimental APIs removed (was experimental under `MEAI001`) #PR
+```
+
+### Breaking changes to experimental APIs
+
+An experimental API changes its signature, behavior, or contracts. These changes are acceptable under the experimental API policy but consumers need to know.
+
+**How to detect:**
+- PR modifies the signature of types/members annotated with `[Experimental]`
+- PR changes behavior described in XML docs for experimental types
+- PR renames experimental types or changes their namespace
+
+**How to report:**
+```markdown
+* <Feature Name>: `TypeOrMemberName` signature changed (experimental under `EXTEXP0002`) #PR by @author
+```
+
+### New experimental APIs
+
+A new API is introduced with the `[Experimental]` attribute. These are interesting for early adopters.
+
+**How to detect:**
+- PR adds new types or members annotated with `[Experimental]`
+- PR introduces a new diagnostic ID
+- The `.json` API baseline file adds entries with `"Stage": "Experimental"`
+
+**How to report:**
+```markdown
+* New experimental API: <Feature Name> (`MEAI002`) #PR by @author
+```
+
+## Detection strategy
+
+For each candidate PR, detect experimental API changes using the **PR diff** and the **`run-apichief` skill**. Do not rely on PR descriptions or PR labels for detection — they rarely mention experimental changes explicitly.
+
+1. **Check the PR diff** using `pull_request_read` with method `get_files`. Look for changes to files containing `[Experimental` annotations. Specifically:
+   - Files adding or removing `[Experimental("...")]` attributes
+   - Changes to `.json` API baseline files where the `"Stage"` field changes between `"Experimental"` and `"Stable"`
+   - Deletions of types or members that were previously experimental
+2. **Cross-reference with `run-apichief`** — use the `run-apichief` skill's `emit delta` or `check breaking` commands to compare API baselines between the previous release and the current target. This reveals:
+   - New experimental types/members added
+   - Experimental types/members removed
+   - Experimental types/members that changed stage to Stable
+   - Signature changes on experimental types/members
+3. **Cross-reference `docs/list-of-diagnostics.md`** — check if the PR modifies the diagnostics list, which signals addition or removal of experimental diagnostic IDs.
+
+Store detected changes in the `experimental_changes` SQL table (see [sql-storage.md](sql-storage.md)).
+
+## Presentation in release notes
+
+Experimental feature changes appear in a dedicated section near the top of the release notes, after any stable breaking changes (which should be rare) and before the area-grouped "What's Changed" sections.
+
+Group experimental changes by type:
+
+```markdown
+## Experimental API Changes
+
+### Now Stable
+* HTTP Logging Middleware APIs are now stable (previously `EXTEXP0013`) #7380
+
+### New Experimental APIs
+* Realtime Client Sessions (`MEAI001`) #7285 by @author
+
+### Breaking Changes to Experimental APIs
+* AI Function Approvals: `FunctionCallApprovalContext` constructor changed (experimental under `MEAI001`) #7350 by @author
+
+### Removed Experimental APIs
+* AI Tool Reduction experimental APIs removed (was experimental under `MEAI001`) #7300
+```
+
+Omit subsections that have no entries.

--- a/.github/skills/release-notes/references/experimental-features.md
+++ b/.github/skills/release-notes/references/experimental-features.md
@@ -50,7 +50,7 @@ An experimental API changes its signature, behavior, or contracts. These changes
 
 **How to report:**
 ```markdown
-* <Feature Name>: `TypeOrMemberName` signature changed (experimental under `EXTEXP0002`) #PR by @author
+* <Feature Name>: `TypeOrMemberName` signature changed (experimental under `EXTEXP0002`) #PR
 ```
 
 ### New experimental APIs
@@ -64,29 +64,35 @@ A new API is introduced with the `[Experimental]` attribute. These are interesti
 
 **How to report:**
 ```markdown
-* New experimental API: <Feature Name> (`MEAI002`) #PR by @author
+* New experimental API: <Feature Name> (`MEAI002`) #PR
 ```
 
 ## Detection strategy
 
-For each candidate PR, detect experimental API changes using the **PR diff** and the **`run-apichief` skill**. Do not rely on PR descriptions or PR labels for detection — they rarely mention experimental changes explicitly.
+For each candidate PR, detect experimental API changes using the **PR diff** and the **`run-apichief` skill**. Do not rely on PR titles, descriptions, or labels to determine *what* changed — they can be misleading or incomplete.
 
-1. **Check the PR diff** using `pull_request_read` with method `get_files`. Look for changes to files containing `[Experimental` annotations. Specifically:
+> **Critical: Every experimental change description must be derived from the actual file diff, not inferred from PR titles.** PR titles may use imprecise or overloaded terminology (e.g. "Reduction" could refer to chat reduction or tool reduction — entirely different features). Always fetch and inspect the changed files to determine exactly which types and members were affected.
+
+### Step-by-step
+
+1. **Fetch the PR file list** using `pull_request_read` with method `get_files` for every candidate PR. This is mandatory — do not skip it or rely on title-based inference.
+2. **Inspect the diff for experimental annotations.** Look for:
    - Files adding or removing `[Experimental("...")]` attributes
    - Changes to `.json` API baseline files where the `"Stage"` field changes between `"Experimental"` and `"Stable"`
    - Deletions of types or members that were previously experimental
-2. **Cross-reference with `run-apichief`** — use the `run-apichief` skill's `emit delta` or `check breaking` commands to compare API baselines between the previous release and the current target. This reveals:
+3. **Derive the feature name from the actual types affected**, not from the PR title. For example, if the deleted files are `IToolReductionStrategy.cs`, `ToolReducingChatClient.cs`, and `EmbeddingToolReductionStrategy.cs`, the feature name is "Tool Reduction" — even if the PR title says something more generic like "Remove Reduction APIs."
+4. **Cross-reference with `run-apichief`** — use the `run-apichief` skill's `emit delta` or `check breaking` commands to compare API baselines between the previous release and the current target. This reveals:
    - New experimental types/members added
    - Experimental types/members removed
    - Experimental types/members that changed stage to Stable
    - Signature changes on experimental types/members
-3. **Cross-reference `docs/list-of-diagnostics.md`** — check if the PR modifies the diagnostics list, which signals addition or removal of experimental diagnostic IDs.
+5. **Cross-reference `docs/list-of-diagnostics.md`** — check if the PR modifies the diagnostics list, which signals addition or removal of experimental diagnostic IDs.
 
-Store detected changes in the `experimental_changes` SQL table (see [sql-storage.md](sql-storage.md)).
+Store detected changes in the `experimental_changes` SQL table (see [sql-storage.md](sql-storage.md)). The `description` column must reflect the actual types/members found in the diff, not a summary derived from the PR title.
 
 ## Presentation in release notes
 
-Experimental feature changes appear in a dedicated section near the top of the release notes, after any stable breaking changes (which should be rare) and before the area-grouped "What's Changed" sections.
+Experimental feature changes appear in a dedicated section near the top of the release notes, after any stable breaking changes (which should be rare) and before the area-grouped "What's Changed" sections. **Do not include author attributions in this section** — the PRs will still appear with full attribution in the "What's Changed" list.
 
 Group experimental changes by type:
 
@@ -97,10 +103,10 @@ Group experimental changes by type:
 * HTTP Logging Middleware APIs are now stable (previously `EXTEXP0013`) #7380
 
 ### New Experimental APIs
-* Realtime Client Sessions (`MEAI001`) #7285 by @author
+* Realtime Client Sessions (`MEAI001`) #7285
 
 ### Breaking Changes to Experimental APIs
-* AI Function Approvals: `FunctionCallApprovalContext` constructor changed (experimental under `MEAI001`) #7350 by @author
+* AI Function Approvals: `FunctionCallApprovalContext` constructor changed (experimental under `MEAI001`) #7350
 
 ### Removed Experimental APIs
 * AI Tool Reduction experimental APIs removed (was experimental under `MEAI001`) #7300

--- a/.github/skills/release-notes/references/format-template.md
+++ b/.github/skills/release-notes/references/format-template.md
@@ -23,10 +23,10 @@ Use this template when all packages ship together (e.g. v10.3.0 → v10.4.0).
 * <Feature Name> APIs are now stable (previously `DIAGID`) #PR
 
 ### New Experimental APIs
-* New experimental API: <Feature Name> (`DIAGID`) #PR by @author
+* New experimental API: <Feature Name> (`DIAGID`) #PR
 
 ### Breaking Changes to Experimental APIs
-* <Feature Name>: `TypeName` signature changed (experimental under `DIAGID`) #PR by @author
+* <Feature Name>: `TypeName` signature changed (experimental under `DIAGID`) #PR
 
 ### Removed Experimental APIs
 * <Feature Name> experimental APIs removed (was experimental under `DIAGID`) #PR

--- a/.github/skills/release-notes/references/format-template.md
+++ b/.github/skills/release-notes/references/format-template.md
@@ -1,0 +1,119 @@
+# Release Notes Format Template
+
+## Full monthly release
+
+Use this template when all packages ship together (e.g. v10.3.0 → v10.4.0).
+
+```markdown
+[Optional preamble — 2–3 sentences summarizing the release theme. May be omitted.]
+
+## Breaking Changes
+
+[If any stable API breaking changes exist — these should be very rare]
+
+1. **Description #PR**
+   * Detail of the break
+   * Migration guidance
+
+## Experimental API Changes
+
+[Grouped by change type — see experimental-features.md]
+
+### Now Stable
+* <Feature Name> APIs are now stable (previously `DIAGID`) #PR
+
+### New Experimental APIs
+* New experimental API: <Feature Name> (`DIAGID`) #PR by @author
+
+### Breaking Changes to Experimental APIs
+* <Feature Name>: `TypeName` signature changed (experimental under `DIAGID`) #PR by @author
+
+### Removed Experimental APIs
+* <Feature Name> experimental APIs removed (was experimental under `DIAGID`) #PR
+
+## What's Changed
+
+### [Area Name — e.g. "AI"]
+
+* Description #PR by @author (co-authored by @user1 @Copilot)
+* Description #PR by @author
+
+### [Area Name — e.g. "HTTP Resilience and Diagnostics"]
+
+* Description #PR by @author
+
+### [Area Name — e.g. "Diagnostics, Health Checks, and Resource Monitoring"]
+
+* Description #PR by @author
+
+## Documentation Updates
+
+* Description #PR by @author
+
+## Test Improvements
+
+* Description #PR by @author
+
+## Repository Infrastructure Updates
+
+* Description #PR by @author
+
+## Acknowledgements
+
+* @user made their first contribution in #PR
+* @user submitted issue #1234 (resolved by #5678)
+* @user1 @user2 @user3 reviewed pull requests
+
+**Full Changelog**: https://github.com/dotnet/extensions/compare/v10.3.0...v10.4.0
+```
+
+## Targeted patch release
+
+Use this template when only a subset of packages ships (e.g. v10.3.1).
+
+```markdown
+[Optional preamble — state which packages are patched and why. Example: "This patch release addresses issues in the AI and HTTP Resilience packages." May be omitted.]
+
+## Packages in this release
+
+[Only the patched packages]
+
+| Package | Version |
+|---------|---------|
+| Microsoft.Extensions.AI | 10.3.1 |
+| Microsoft.Extensions.AI.Abstractions | 10.3.1 |
+
+## What's Changed
+
+### [Area Name]
+
+* Description #PR by @author
+
+## Acknowledgements
+
+* @user submitted issue #1234 (resolved by #5678)
+* @user1 @user2 reviewed pull requests
+
+**Full Changelog**: https://github.com/dotnet/extensions/compare/v10.3.0...v10.3.1
+```
+
+## Section rules
+
+1. **Preamble** — optional. If included, summarize the release theme. For patch releases, if included, name the affected packages. Suggest a couple of options to the user and always offer the option of omitting it.
+2. **Packages in this release** — for patch releases only. Table of affected packages and versions. Omit for full releases (all packages ship at the same version).
+3. **Breaking Changes** — only for stable API breaks (very rare). Omit if none.
+4. **Experimental API Changes** — omit if no experimental changes. Omit empty subsections within.
+5. **What's Changed** — grouped by area. Order areas by activity (most entries first). Omit areas with no entries.
+6. **Documentation Updates** — flat list. Omit if none.
+7. **Test Improvements** — flat list. Omit if none.
+8. **Repository Infrastructure Updates** — flat list. Omit if none.
+9. **Acknowledgements** — always include. Omit empty sub-items.
+10. **Full Changelog** — always last. Link to the GitHub compare view.
+
+## PR and issue references
+
+Use the format `#number` for PRs and issues in the same repository. GitHub will auto-link these in release notes. Use full markdown links only for cross-repo references:
+
+- ✅ `#7380` (same repo — GitHub auto-links)
+- ✅ `[dotnet/runtime#124264](https://github.com/dotnet/runtime/pull/124264)` (cross-repo)
+- ❌ `[#7380](https://github.com/dotnet/extensions/pull/7380)` (unnecessary — same repo)

--- a/.github/skills/release-notes/references/package-areas.md
+++ b/.github/skills/release-notes/references/package-areas.md
@@ -1,0 +1,118 @@
+# Package Area Definitions
+
+This file maps the libraries in `src/Libraries/` to logical area groups for organizing release notes. Each group name must clearly and unambiguously identify the packages it covers.
+
+## Area groups
+
+### AI
+
+Packages:
+- `Microsoft.Extensions.AI`
+- `Microsoft.Extensions.AI.Abstractions`
+- `Microsoft.Extensions.AI.OpenAI`
+
+### AI Evaluation
+
+Packages:
+- `Microsoft.Extensions.AI.Evaluation`
+- `Microsoft.Extensions.AI.Evaluation.Console`
+- `Microsoft.Extensions.AI.Evaluation.NLP`
+- `Microsoft.Extensions.AI.Evaluation.Quality`
+- `Microsoft.Extensions.AI.Evaluation.Reporting`
+- `Microsoft.Extensions.AI.Evaluation.Reporting.Azure`
+- `Microsoft.Extensions.AI.Evaluation.Safety`
+
+### Data Ingestion
+
+Packages:
+- `Microsoft.Extensions.DataIngestion`
+- `Microsoft.Extensions.DataIngestion.Abstractions`
+- `Microsoft.Extensions.DataIngestion.Markdig`
+- `Microsoft.Extensions.DataIngestion.MarkItDown`
+
+### Diagnostics, Health Checks, and Resource Monitoring
+
+Packages:
+- `Microsoft.Extensions.Diagnostics.ExceptionSummarization`
+- `Microsoft.Extensions.Diagnostics.HealthChecks.Common`
+- `Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization`
+- `Microsoft.Extensions.Diagnostics.Probes`
+- `Microsoft.Extensions.Diagnostics.ResourceMonitoring`
+- `Microsoft.Extensions.Diagnostics.ResourceMonitoring.Kubernetes`
+- `Microsoft.Extensions.Diagnostics.Testing`
+
+### Compliance, Redaction, and Data Classification
+
+Packages:
+- `Microsoft.Extensions.Compliance.Abstractions`
+- `Microsoft.Extensions.Compliance.Redaction`
+- `Microsoft.Extensions.Compliance.Testing`
+
+### HTTP Resilience and Diagnostics
+
+Packages:
+- `Microsoft.Extensions.Http.Resilience`
+- `Microsoft.Extensions.Resilience`
+- `Microsoft.Extensions.Http.Diagnostics`
+
+### Telemetry and Observability
+
+Packages:
+- `Microsoft.Extensions.Telemetry`
+- `Microsoft.Extensions.Telemetry.Abstractions`
+
+### ASP.NET Core Extensions
+
+Packages:
+- `Microsoft.AspNetCore.Diagnostics.Middleware`
+- `Microsoft.AspNetCore.HeaderParsing`
+- `Microsoft.AspNetCore.Testing`
+- `Microsoft.AspNetCore.AsyncState`
+
+### Service Discovery
+
+Packages:
+- `Microsoft.Extensions.ServiceDiscovery`
+- `Microsoft.Extensions.ServiceDiscovery.Abstractions`
+- `Microsoft.Extensions.ServiceDiscovery.Dns`
+- `Microsoft.Extensions.ServiceDiscovery.Yarp`
+
+### Hosting, Configuration, and Ambient Metadata
+
+Packages:
+- `Microsoft.Extensions.Hosting.Testing`
+- `Microsoft.Extensions.Options.Contextual`
+- `Microsoft.Extensions.AmbientMetadata.Application`
+- `Microsoft.Extensions.AmbientMetadata.Build`
+
+### Caching
+
+Packages:
+- `Microsoft.Extensions.Caching.Hybrid`
+
+### Dependency Injection and Object Pooling
+
+Packages:
+- `Microsoft.Extensions.DependencyInjection.AutoActivation`
+- `Microsoft.Extensions.ObjectPool.DependencyInjection`
+
+### Async State
+
+Packages:
+- `Microsoft.Extensions.AsyncState`
+
+### Time Provider Testing
+
+Packages:
+- `Microsoft.Extensions.TimeProvider.Testing`
+
+## Assigning PRs to areas
+
+1. **Primary method — file paths**: Examine the files changed in each PR. Extract package names from paths matching `src/Libraries/{PackageName}/`. Map each package name to its area using the table above.
+2. **Fallback — `area-*` labels**: If a PR has no `src/Libraries/` file changes (e.g. infrastructure PRs), check for `area-*` labels and map those to the closest area group.
+3. **Multi-area PRs**: A single PR may touch multiple packages in different areas. Assign the PR to all affected areas. When writing the release notes entry, place the PR under the area most central to the change and add a brief cross-reference note for other areas if warranted.
+4. **No area match**: PRs that touch only `eng/`, `scripts/`, `.github/`, `docs/`, or `test/` without corresponding `src/Libraries/` changes are infrastructure, documentation, or test PRs — categorize them by type, not by area.
+
+## Maintaining this file
+
+When new libraries are added to `src/Libraries/`, update this file to include them in the appropriate area group. If a new area is needed, choose a name that clearly identifies the packages it contains.

--- a/.github/skills/release-notes/references/sql-storage.md
+++ b/.github/skills/release-notes/references/sql-storage.md
@@ -1,0 +1,114 @@
+# SQL Schema and Patterns
+
+Use the SQL tool for all structured data storage during the release notes pipeline. Do **not** write intermediate files to disk.
+
+## Core tables
+
+```sql
+CREATE TABLE prs (
+    number INTEGER PRIMARY KEY,
+    title TEXT,
+    author TEXT,
+    author_association TEXT,
+    labels TEXT,             -- comma-separated label names
+    merged_at TEXT,
+    body TEXT,
+    reactions INTEGER DEFAULT 0,
+    is_candidate INTEGER DEFAULT 0,
+    category TEXT,           -- 'changed', 'docs', 'tests', 'infra'
+    packages TEXT            -- comma-separated package names from file paths
+);
+
+CREATE TABLE pr_packages (
+    pr_number INTEGER NOT NULL,
+    package_name TEXT NOT NULL,
+    area_group TEXT NOT NULL,
+    PRIMARY KEY (pr_number, package_name)
+);
+
+CREATE TABLE issues (
+    number INTEGER PRIMARY KEY,
+    title TEXT,
+    body TEXT,
+    labels TEXT,
+    reactions INTEGER DEFAULT 0,
+    pr_number INTEGER        -- the PR that references this issue
+);
+
+CREATE TABLE experimental_changes (
+    pr_number INTEGER NOT NULL,
+    package_name TEXT NOT NULL,
+    change_type TEXT NOT NULL,  -- 'graduated', 'removed', 'breaking', 'added'
+    diagnostic_id TEXT,         -- e.g. 'EXTEXP0001', 'MEAI001'
+    description TEXT,
+    PRIMARY KEY (pr_number, package_name, change_type)
+);
+```
+
+## Common queries
+
+### Find candidate PRs
+
+```sql
+SELECT * FROM prs WHERE is_candidate = 1 ORDER BY merged_at;
+```
+
+### PRs by area group
+
+```sql
+SELECT DISTINCT p.number, p.title, p.author, p.merged_at, pp.area_group
+FROM prs p
+JOIN pr_packages pp ON p.number = pp.pr_number
+WHERE p.is_candidate = 1
+ORDER BY pp.area_group, p.merged_at;
+```
+
+### Affected packages (for patch release scope)
+
+```sql
+SELECT DISTINCT package_name, area_group
+FROM pr_packages pp
+JOIN prs p ON pp.pr_number = p.number
+WHERE p.is_candidate = 1
+ORDER BY area_group, package_name;
+```
+
+### Popularity ranking
+
+```sql
+SELECT p.number, p.title, p.reactions,
+       COALESCE(SUM(i.reactions), 0) AS issue_reactions,
+       p.reactions + COALESCE(SUM(i.reactions), 0) AS total_reactions
+FROM prs p
+LEFT JOIN issues i ON i.pr_number = p.number
+WHERE p.is_candidate = 1
+GROUP BY p.number
+ORDER BY total_reactions DESC;
+```
+
+### Experimental feature changes
+
+```sql
+SELECT ec.change_type, ec.package_name, ec.diagnostic_id, ec.description,
+       p.number, p.title, p.author
+FROM experimental_changes ec
+JOIN prs p ON ec.pr_number = p.number
+ORDER BY ec.change_type, ec.package_name;
+```
+
+### Category breakdown
+
+```sql
+SELECT category, COUNT(*) as count
+FROM prs
+WHERE is_candidate = 1
+GROUP BY category;
+```
+
+## Usage notes
+
+- Insert PRs as they are discovered during collection. Update `body`, `reactions`, and `packages` during enrichment.
+- Insert into `pr_packages` after file path analysis determines affected packages (see [package-areas.md](package-areas.md)).
+- Mark candidates with `is_candidate = 1` after filtering.
+- Insert `experimental_changes` during the experimental feature audit step.
+- Additional PRs can be added to the candidate list manually by number.

--- a/.github/skills/release-notes/references/sql-storage.md
+++ b/.github/skills/release-notes/references/sql-storage.md
@@ -43,6 +43,12 @@ CREATE TABLE experimental_changes (
     description TEXT,
     PRIMARY KEY (pr_number, package_name, change_type)
 );
+
+CREATE TABLE pr_reviewers (
+    pr_number INTEGER NOT NULL,
+    reviewer TEXT NOT NULL,
+    PRIMARY KEY (pr_number, reviewer)
+);
 ```
 
 ## Common queries
@@ -105,10 +111,23 @@ WHERE is_candidate = 1
 GROUP BY category;
 ```
 
+### PR reviewers for acknowledgements
+
+```sql
+SELECT reviewer, COUNT(DISTINCT pr_number) as review_count
+FROM pr_reviewers r
+WHERE reviewer NOT LIKE '%[bot]%'
+  AND reviewer != 'Copilot'
+  AND reviewer NOT IN (SELECT DISTINCT author FROM prs WHERE is_candidate = 1)
+GROUP BY reviewer
+ORDER BY review_count DESC;
+```
+
 ## Usage notes
 
 - Insert PRs as they are discovered during collection. Update `body`, `reactions`, and `packages` during enrichment.
 - Insert into `pr_packages` after file path analysis determines affected packages (see [package-areas.md](package-areas.md)).
+- Insert into `pr_reviewers` during enrichment when fetching PR reviews.
 - Mark candidates with `is_candidate = 1` after filtering.
 - Insert `experimental_changes` during the experimental feature audit step.
 - Additional PRs can be added to the candidate list manually by number.

--- a/.github/skills/release-notes/references/sql-storage.md
+++ b/.github/skills/release-notes/references/sql-storage.md
@@ -44,6 +44,12 @@ CREATE TABLE experimental_changes (
     PRIMARY KEY (pr_number, package_name, change_type)
 );
 
+CREATE TABLE pr_coauthors (
+    pr_number INTEGER NOT NULL,
+    coauthor TEXT NOT NULL,
+    PRIMARY KEY (pr_number, coauthor)
+);
+
 CREATE TABLE pr_reviewers (
     pr_number INTEGER NOT NULL,
     reviewer TEXT NOT NULL,
@@ -111,6 +117,27 @@ WHERE is_candidate = 1
 GROUP BY category;
 ```
 
+### All contributors for acknowledgements
+
+```sql
+SELECT contributor, MIN(pr_number) as first_pr FROM (
+    SELECT author AS contributor, number AS pr_number
+    FROM prs
+    WHERE is_candidate = 1
+
+    UNION
+
+    SELECT c.coauthor AS contributor, c.pr_number
+    FROM pr_coauthors c
+    JOIN prs p ON p.number = c.pr_number
+    WHERE p.is_candidate = 1
+)
+WHERE contributor NOT LIKE '%[bot]%'
+  AND contributor != 'Copilot'
+GROUP BY contributor
+ORDER BY first_pr;
+```
+
 ### PR reviewers for acknowledgements
 
 ```sql
@@ -119,6 +146,12 @@ FROM pr_reviewers r
 WHERE reviewer NOT LIKE '%[bot]%'
   AND reviewer != 'Copilot'
   AND reviewer NOT IN (SELECT DISTINCT author FROM prs WHERE is_candidate = 1)
+  AND reviewer NOT IN (
+      SELECT DISTINCT c.coauthor
+      FROM pr_coauthors c
+      JOIN prs p ON p.number = c.pr_number
+      WHERE p.is_candidate = 1
+  )
 GROUP BY reviewer
 ORDER BY review_count DESC;
 ```
@@ -127,6 +160,7 @@ ORDER BY review_count DESC;
 
 - Insert PRs as they are discovered during collection. Update `body`, `reactions`, and `packages` during enrichment.
 - Insert into `pr_packages` after file path analysis determines affected packages (see [package-areas.md](package-areas.md)).
+- Insert into `pr_coauthors` during enrichment when harvesting `Co-authored-by:` trailers from PR commits.
 - Insert into `pr_reviewers` during enrichment when fetching PR reviews.
 - Mark candidates with `is_candidate = 1` after filtering.
 - Insert `experimental_changes` during the experimental feature audit step.


### PR DESCRIPTION
This builds on the [modelcontextprotocol/csharp-sdk](https://github.com/modelcontextprotocol/csharp-sdk/blob/main/.github/skills/prepare-release/SKILL.md) and [dotnet/core](https://github.com/dotnet/core/pull/10282) release notes skills created recently, aligning most closely to the MCP version but updated to reflect the nature of this repo containing many separate features/packages.

It was used to generate the [v10.4.0](https://github.com/dotnet/extensions/releases/tag/v10.4.0) release notes that were just published and to refresh the [v10.3.0](https://github.com/dotnet/extensions/releases/tag/v10.3.0) release notes as the v10.4.0 release notes generation led to identifying that some entries were missing from the v10.3.0 release notes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7390)