### PR TITLE
Enable CFSClean* policies for extensions-ci-official pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean2
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     featureFlags:
       binskimScanAllExtensions: true
     sdl:


### PR DESCRIPTION
## Enable CFSClean* policies for extensions-ci-official pipeline

This PR adds `CFSClean` to the `networkIsolationPolicy` setting in the 1ES Official pipeline template configuration.

### Change
```diff
-      networkIsolationPolicy: Permissive,CFSClean2
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
```

### Context
- **Pipeline**: [extensions-ci-official (ID: 179)](https://dev.azure.com/dnceng/internal/_build?definitionId=179)
- **Violation**: `dotnet.exe` accessing `api.nuget.org` during the `SourceIndexStage1` job
- **Policy**: CFSClean (network isolation compliance)
- **Reference**: [dotnet/arcade#16430](https://github.com/dotnet/arcade/commit/73f33656f47897bbe0d49b37d2a703dab7eb7d7d) (same pattern applied to arcade)

### Test Build
- A test build was queued ([Build 2929219](https://dev.azure.com/dnceng/internal/_build/results?buildId=2929219)) but the Build stage was blocked by resource authorization checks (common for manual builds from feature branches). The `SDLSources` and `Correctness` stages both completed successfully.
- The change is a single-line addition to the network isolation policy, matching the well-established pattern from the arcade reference commit.

### Validation
- YAML syntax verified locally
- Change follows the exact pattern from the [arcade reference commit](https://github.com/dotnet/arcade/commit/73f33656f47897bbe0d49b37d2a703dab7eb7d7d)
- The `SDLSources` and `Correctness` stages passed in the test build
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7403)