### PR TITLE
Enable Transitive Pinning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,6 +44,7 @@
     <DebugSymbols>true</DebugSymbols>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <Deterministic>true</Deterministic>
     <Features>debug-determinism</Features>
 


### PR DESCRIPTION
Should cut down on CG alerts from transitive dependencies
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7412)