### PR TITLE
Fix InvalidOperationException in CoalesceWebSearchToolCallContent

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
@@ -258,6 +258,7 @@ public static class ChatResponseExtensions
                                       [.. existing.Queries, .. webSearchCall.Queries],
                             RawRepresentation = existing.RawRepresentation ?? webSearchCall.RawRepresentation,
                             AdditionalProperties = existing.AdditionalProperties ?? webSearchCall.AdditionalProperties,
+                            Annotations = existing.Annotations ?? webSearchCall.Annotations,
                         };
                     }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
@@ -237,11 +237,11 @@ public static class ChatResponseExtensions
 
         for (int i = 0; i < contents.Count; i++)
         {
-            if (contents[i] is WebSearchToolCallContent webSearchCall && !string.IsNullOrEmpty(webSearchCall.CallId))
+            if (contents[i] is WebSearchToolCallContent webSearchCall)
             {
                 webSearchCallIndexById ??= new(StringComparer.Ordinal);
 
-                if (webSearchCallIndexById.TryGetValue(webSearchCall.CallId!, out int existingIndex))
+                if (webSearchCallIndexById.TryGetValue(webSearchCall.CallId, out int existingIndex))
                 {
                     // Create a new merged content rather than mutating the original content objects.
                     // The same content objects may be shared across multiple ToChatResponse calls
@@ -267,7 +267,7 @@ public static class ChatResponseExtensions
                 }
                 else
                 {
-                    webSearchCallIndexById[webSearchCall.CallId!] = i;
+                    webSearchCallIndexById[webSearchCall.CallId] = i;
                 }
             }
         }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseExtensions.cs
@@ -243,26 +243,23 @@ public static class ChatResponseExtensions
 
                 if (webSearchCallIndexById.TryGetValue(webSearchCall.CallId!, out int existingIndex))
                 {
-                    // Merge data from the new item into the existing one.
+                    // Create a new merged content rather than mutating the original content objects.
+                    // The same content objects may be shared across multiple ToChatResponse calls
+                    // (e.g. FunctionInvokingChatClient and the caller both call ToChatResponse on
+                    // the same streaming updates), and in-place mutation would corrupt subsequent calls.
                     var existing = (WebSearchToolCallContent)contents[existingIndex];
 
-                    if (webSearchCall.Queries is { Count: > 0 })
+                    if (!ReferenceEquals(existing, webSearchCall))
                     {
-                        if (existing.Queries is null)
+                        contents[existingIndex] = new WebSearchToolCallContent(existing.CallId)
                         {
-                            existing.Queries = webSearchCall.Queries;
-                        }
-                        else
-                        {
-                            foreach (var query in webSearchCall.Queries)
-                            {
-                                existing.Queries.Add(query);
-                            }
-                        }
+                            Queries = webSearchCall.Queries is not { Count: > 0 } ? existing.Queries :
+                                      existing.Queries is not { Count: > 0 } ? webSearchCall.Queries :
+                                      [.. existing.Queries, .. webSearchCall.Queries],
+                            RawRepresentation = existing.RawRepresentation ?? webSearchCall.RawRepresentation,
+                            AdditionalProperties = existing.AdditionalProperties ?? webSearchCall.AdditionalProperties,
+                        };
                     }
-
-                    existing.RawRepresentation ??= webSearchCall.RawRepresentation;
-                    existing.AdditionalProperties ??= webSearchCall.AdditionalProperties;
 
                     contents[i] = null!;
                     hasRemovals = true;

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateExtensionsTests.cs
@@ -1095,6 +1095,51 @@ public class ChatResponseUpdateExtensionsTests
         Assert.Equal(3, webSearchCalls.Length);
     }
 
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ToChatResponse_CoalescesWebSearchToolCallContent_CallingToChatResponseTwiceOnSameUpdates(bool useAsync, bool firstHasQueries)
+    {
+        object rawRepresentation = new();
+        string[] expectedQueries = firstHasQueries ? ["first query", "dotnet extensions"] : ["dotnet extensions"];
+
+        var inProgress = new WebSearchToolCallContent("ws1")
+        {
+            RawRepresentation = rawRepresentation,
+            Queries = firstHasQueries ? ["first query"] : null,
+        };
+
+        ChatResponseUpdate[] updates =
+        {
+            new(null, "Searching the web..."),
+
+            // In-progress: mirrors StreamingResponseWebSearchCallInProgressUpdate.
+            // With the OpenAI provider this has null Queries, but exercise both paths.
+            new() { Contents = [inProgress] },
+
+            // Done: queries populated (mirrors StreamingResponseOutputItemDoneUpdate with WebSearchCallResponseItem)
+            new() { Contents = [new WebSearchToolCallContent("ws1") { Queries = ["dotnet extensions"] }] },
+
+            // Function call in the same response (this is what triggers FunctionInvokingChatClient
+            // to call ToChatResponse internally before the caller does)
+            new() { Contents = [new FunctionCallContent("fc1", "SearchTool", new Dictionary<string, object?> { ["q"] = "test" })] },
+        };
+
+        // First call — simulates FunctionInvokingChatClient's internal ToChatResponse.
+        ChatResponse response1 = useAsync ? await YieldAsync(updates).ToChatResponseAsync() : updates.ToChatResponse();
+        var ws1First = Assert.Single(response1.Messages.SelectMany(m => m.Contents).OfType<WebSearchToolCallContent>());
+        Assert.Equal(expectedQueries, ws1First.Queries);
+        Assert.Same(rawRepresentation, ws1First.RawRepresentation);
+
+        // Second call — simulates the caller's ToChatResponse on the same updates.
+        ChatResponse response2 = useAsync ? await YieldAsync(updates).ToChatResponseAsync() : updates.ToChatResponse();
+        var ws1Second = Assert.Single(response2.Messages.SelectMany(m => m.Contents).OfType<WebSearchToolCallContent>());
+        Assert.Equal(expectedQueries, ws1Second.Queries);
+        Assert.Same(rawRepresentation, ws1Second.RawRepresentation);
+    }
+
     private static async IAsyncEnumerable<ChatResponseUpdate> YieldAsync(IEnumerable<ChatResponseUpdate> updates)
     {
         foreach (ChatResponseUpdate update in updates)


### PR DESCRIPTION
## Fix InvalidOperationException in CoalesceWebSearchToolCallContent

Fixes https://github.com/dotnet/extensions/issues/7414

### Problem

`CoalesceWebSearchToolCallContent` merged streaming updates by mutating the original content objects in-place. In particular, `existing.Queries = webSearchCall.Queries` made two objects share the same `Queries` list instance. This is a problem because `ToChatResponse` can be called multiple times on the same streaming updates: `FunctionInvokingChatClient` calls it internally to process function calls (line 666), and the caller (e.g. `ChatClientAgent` from the Agents Framework) calls it again on the same collected updates. On the second call, both content objects now have non-null `Queries` pointing to the same list, so the foreach-merge path tries to iterate and add to the same list simultaneously, throwing `InvalidOperationException: Collection was modified; enumeration operation may not execute.`

### Fix

Create a new `WebSearchToolCallContent` with the merged data instead of mutating the originals. This matches the pattern used by all the other coalescing methods (`Coalesce<T>` for `TextContent`, `CodeInterpreterToolCallContent`, etc.), which create new objects via factory delegates. When `existing` and `webSearchCall` are the same object instance (a degenerate case), the duplicate is simply removed without creating a new object.

### Tests

Added a regression test that mirrors the real-world scenario: streaming updates with an in-progress web search (null Queries), a done web search (populated Queries), and a function call, with `ToChatResponse` called twice on the same updates. Parameterized over sync/async and whether the first item has queries (exercising both the reference-assignment and list-combining branches).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7419)