### PR TITLE
Handle F# optional parameters in AIFunctionFactory schema generation

### DIFF
--- a/eng/build.proj
+++ b/eng/build.proj
@@ -4,6 +4,7 @@
     <_ProjectsToBuild Include="$(MSBuildThisFileDirectory)..\src\**\*.csproj" />
     <!-- We recursively add all of the test projects -->
     <_ProjectsToBuild Include="$(MSBuildThisFileDirectory)..\test\**\*.csproj" />
+    <_ProjectsToBuild Include="$(MSBuildThisFileDirectory)..\test\**\*.fsproj" />
     <_ProjectsToBuild Include="$(MSBuildThisFileDirectory)..\bench\**\*.csproj" />
     <!-- Additionally, include the transport project that is not defined as a csproj -->
     <_ProjectsToBuild Include="$(MSBuildThisFileDirectory)..\src\Packages\Microsoft.Internal.Extensions.DotNetApiDocs.Transport\Microsoft.Internal.Extensions.DotNetApiDocs.Transport.proj" />

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.Create.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.Create.cs
@@ -848,7 +848,45 @@ public static partial class AIJsonUtilities
             return true;
         }
 
+        // Handle parameters that are optional but don't have a declared default value,
+        // e.g. F# optional parameters declared using the ?param syntax, or COM interop parameters
+        // annotated with [Optional]. These should be treated as having a null default value.
+        if (parameterInfo.IsOptional || IsFSharpOptionalParameter(parameterInfo))
+        {
+            defaultValue = null;
+            return true;
+        }
+
         defaultValue = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether a parameter is an F# optional parameter declared with the ?param syntax.
+    /// F# optional parameters are annotated with Microsoft.FSharp.Core.OptionalArgumentAttribute
+    /// but do not have the ParameterAttributes.Optional flag set, so ParameterInfo.IsOptional returns false.
+    /// The parameter type is always FSharpOption&lt;T&gt; so we use fast pre-checks to avoid
+    /// scanning attributes for non-F# parameters.
+    /// </summary>
+    private static bool IsFSharpOptionalParameter(ParameterInfo parameterInfo)
+    {
+        // F# optional parameters are always typed as Microsoft.FSharp.Core.FSharpOption`1<T>.
+        // Use fast pre-checks to avoid attribute scanning and string allocation for non-F# parameters.
+        Type paramType = parameterInfo.ParameterType;
+        if (!paramType.IsGenericType ||
+            paramType.GetGenericTypeDefinition().FullName != "Microsoft.FSharp.Core.FSharpOption`1")
+        {
+            return false;
+        }
+
+        foreach (object attr in parameterInfo.GetCustomAttributes(inherit: true))
+        {
+            if (attr.GetType().FullName == "Microsoft.FSharp.Core.OptionalArgumentAttribute")
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.FSharp.Tests/FSharpOptionalParameterTests.fs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.FSharp.Tests/FSharpOptionalParameterTests.fs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AI.FSharpTests
+
+open System.Text.Json
+open Microsoft.Extensions.AI
+open Xunit
+
+/// F# type containing methods with F# optional parameter syntax.
+type FSharpToolMethods() =
+    /// Method with an F# optional parameter using the ?param syntax.
+    /// In IL this compiles to a parameter of type FSharpOption&lt;int&gt; with [Optional] and [OptionalArgument] attributes.
+    static member AddWithOptional(a: int, ?b: int) : int =
+        let bFinal = defaultArg b 42
+        a + bFinal
+
+    /// Method with multiple optional parameters.
+    static member MultipleOptionals(a: int, ?b: int, ?c: string) : string =
+        let bFinal = defaultArg b 0
+        let cFinal = defaultArg c "default"
+        $"{a + bFinal}: {cFinal}"
+
+module FSharpOptionalParameterTests =
+
+    let private createFunc name =
+        let m = typeof<FSharpToolMethods>.GetMethod(name)
+        AIFunctionFactory.Create(m, target = null, name = null, description = null)
+
+    [<Fact>]
+    let ``F# optional parameter is not marked as required in schema`` () =
+        let func = createFunc "AddWithOptional"
+        let schemaText = func.JsonSchema.ToString()
+        let doc = JsonDocument.Parse(schemaText)
+        let root = doc.RootElement
+
+        // Schema should have properties for both 'a' and 'b'
+        let props = root.GetProperty("properties")
+        let mutable aProp = Unchecked.defaultof<JsonElement>
+        let mutable bProp = Unchecked.defaultof<JsonElement>
+        Assert.True(props.TryGetProperty("a", &aProp), "Expected 'a' in properties")
+        Assert.True(props.TryGetProperty("b", &bProp), "Expected 'b' in properties")
+
+        // Only 'a' should be in the required array
+        let mutable requiredProp = Unchecked.defaultof<JsonElement>
+        Assert.True(root.TryGetProperty("required", &requiredProp), "Expected a 'required' property in schema")
+
+        let requiredItems = [| for i in 0 .. requiredProp.GetArrayLength() - 1 -> string requiredProp[i] |]
+        Assert.Contains("a", requiredItems)
+        Assert.DoesNotContain("b", requiredItems)
+
+    [<Fact>]
+    let ``F# optional parameter schema includes default null`` () =
+        let func = createFunc "AddWithOptional"
+        let schemaText = func.JsonSchema.ToString()
+
+        // The optional parameter 'b' should have a "default": null entry
+        let doc = JsonDocument.Parse(schemaText)
+        let bProp = doc.RootElement.GetProperty("properties").GetProperty("b")
+        let mutable defaultProp = Unchecked.defaultof<JsonElement>
+        Assert.True(bProp.TryGetProperty("default", &defaultProp), "Expected 'b' parameter to have a 'default' property")
+        Assert.Equal(JsonValueKind.Null, defaultProp.ValueKind)
+
+    [<Fact>]
+    let ``F# optional parameter can be omitted when invoking`` () = task {
+        let func = createFunc "AddWithOptional"
+
+        // Invoke with only 'a', omitting optional 'b'
+        let args = AIFunctionArguments(dict [ ("a", box 5) ])
+        let! result = func.InvokeAsync(args)
+
+        // b defaults to 42 in the F# method, so result should be 5 + 42 = 47
+        let resultElement = result :?> JsonElement
+        Assert.Equal(47, resultElement.GetInt32())
+    }
+
+    [<Fact>]
+    let ``F# optional parameter can be provided when invoking`` () = task {
+        let func = createFunc "AddWithOptional"
+
+        // Invoke with both 'a' and 'b'
+        let args = AIFunctionArguments(dict [ ("a", box 5); ("b", box 10) ])
+        let! result = func.InvokeAsync(args)
+
+        let resultElement = result :?> JsonElement
+        Assert.Equal(15, resultElement.GetInt32())
+    }
+
+    [<Fact>]
+    let ``Multiple F# optional parameters can all be omitted`` () = task {
+        let func = createFunc "MultipleOptionals"
+
+        // Invoke with only required 'a'
+        let args = AIFunctionArguments(dict [ ("a", box 10) ])
+        let! result = func.InvokeAsync(args)
+
+        let resultElement = result :?> JsonElement
+        Assert.Equal("10: default", resultElement.GetString())
+    }
+
+    [<Fact>]
+    let ``Multiple F# optional parameters schema only requires non-optional`` () =
+        let func = createFunc "MultipleOptionals"
+        let schemaText = func.JsonSchema.ToString()
+        let doc = JsonDocument.Parse(schemaText)
+        let root = doc.RootElement
+
+        let mutable requiredProp = Unchecked.defaultof<JsonElement>
+        Assert.True(root.TryGetProperty("required", &requiredProp), "Expected a 'required' property in schema")
+
+        let requiredItems = [| for i in 0 .. requiredProp.GetArrayLength() - 1 -> string requiredProp[i] |]
+        Assert.Contains("a", requiredItems)
+        Assert.DoesNotContain("b", requiredItems)
+        Assert.DoesNotContain("c", requiredItems)

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.FSharp.Tests/Microsoft.Extensions.AI.Abstractions.FSharp.Tests.fsproj
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.FSharp.Tests/Microsoft.Extensions.AI.Abstractions.FSharp.Tests.fsproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>F# tests for Microsoft.Extensions.AI.Abstractions.</Description>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Suppress F# nullability warnings when interoperating with nullable C# APIs -->
+    <NoWarn>$(NoWarn);FS3261</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="FSharpOptionalParameterTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AI.Abstractions\Microsoft.Extensions.AI.Abstractions.csproj" ProjectUnderTest="true" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

F# optional parameters declared with the `?param` syntax are compiled with `Microsoft.FSharp.Core.OptionalArgumentAttribute` but do **not** set the `ParameterAttributes.Optional` flag, so `ParameterInfo.IsOptional` returns `false`. This caused `AIFunctionFactory` to treat them as required parameters, producing incorrect JSON schemas and throwing `ArgumentException` when the parameter was omitted during invocation.

## Changes

### Fix (`AIJsonUtilities.Schema.Create.cs`)

Updated `TryGetEffectiveDefaultValue` to:
1. Check `parameterInfo.IsOptional` (covers COM interop `[Optional]` parameters)
2. Check for `OptionalArgumentAttribute` by name via `IsFSharpOptionalParameter()` -- avoids a hard dependency on FSharp.Core
3. When either is detected, return `true` with a `null` default value (equivalent to `FSharpOption.None`)

This single change fixes both schema generation (parameter no longer in the `required` array, gets `"default": null`) and invocation (marshaller returns `null` instead of throwing).

### New F# test project

Added `test/Libraries/Microsoft.Extensions.AI.Abstractions.FSharp.Tests/` with 6 tests covering:
- Schema correctly marks F# optional parameters as not required
- Schema includes `"default": null` for optional parameters
- Invocation works when optional parameters are both omitted and provided
- Multiple optional parameters work correctly

## Test Results

- **6/6** new F# tests pass
- **664/664** existing AI tests pass
- **1611/1611** existing AI Abstractions tests pass

## Context

Addresses [modelcontextprotocol/csharp-sdk#1476 (comment)](https://github.com/modelcontextprotocol/csharp-sdk/issues/1476#issuecomment-4154810720) -- F# MCP tool methods with optional parameters threw errors when clients omitted those parameters.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7439)