### PR TITLE
Fix ComputerCallResponseItem using Item.Id instead of CallId

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -284,8 +284,8 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                     message.Contents.Add(new ToolResultContent(outputItem.Id) { RawRepresentation = outputItem });
                     break;
 
-                case ComputerCallResponseItem:
-                    message.Contents.Add(new ToolCallContent(outputItem.Id) { RawRepresentation = outputItem });
+                case ComputerCallResponseItem computerCall:
+                    message.Contents.Add(new ToolCallContent(computerCall.CallId) { RawRepresentation = computerCall });
                     break;
 
                 case ComputerCallOutputResponseItem computerCallOutput:
@@ -600,8 +600,8 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                             yield return toolCallUpdate;
                             break;
 
-                        case ComputerCallResponseItem:
-                            yield return CreateUpdate(new ToolCallContent(outputItemDoneUpdate.Item.Id) { RawRepresentation = outputItemDoneUpdate.Item });
+                        case ComputerCallResponseItem computerCall:
+                            yield return CreateUpdate(new ToolCallContent(computerCall.CallId) { RawRepresentation = outputItemDoneUpdate.Item });
                             break;
 
                         case ComputerCallOutputResponseItem computerCallOutput:

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
@@ -1000,7 +1000,7 @@ public class OpenAIConversionTests
         // Eighth update: ComputerCallResponseItem -> ToolCallContent
         ToolCallContent? cuToolCall = updates[7].Contents.OfType<ToolCallContent>().FirstOrDefault();
         Assert.NotNull(cuToolCall);
-        Assert.Equal("cu_123", cuToolCall.CallId);
+        Assert.Equal("call_456", cuToolCall.CallId);
         Assert.Same(computerItem, cuToolCall.RawRepresentation);
 
         // Ninth update: ComputerCallOutputResponseItem -> ToolResultContent
@@ -1288,7 +1288,7 @@ public class OpenAIConversionTests
         Assert.Same(fileSearchItem, fileSearchToolResult.RawRepresentation);
 
         // 10. ComputerCallResponseItem -> ToolCallContent (result comes separately)
-        ToolCallContent? computerToolCall = message.Contents.OfType<ToolCallContent>().FirstOrDefault(c => c.CallId == "cu_123");
+        ToolCallContent? computerToolCall = message.Contents.OfType<ToolCallContent>().FirstOrDefault(c => c.CallId == "call_456");
         Assert.NotNull(computerToolCall);
         Assert.Same(computerItem, computerToolCall.RawRepresentation);
 

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -824,7 +824,7 @@ public class OpenAIResponseClientTests
         Assert.IsType<ComputerCallResponseItem>(computerUserItem.RawRepresentation);
 #pragma warning restore OPENAICUA001
         ToolCallContent computerToolCall = Assert.IsType<ToolCallContent>(computerUserItem);
-        Assert.NotNull(computerToolCall.CallId);
+        Assert.Equal("call_zw3...", computerToolCall.CallId);
         Assert.NotNull(response.Usage);
         Assert.Equal(18, response.Usage.InputTokenCount);
         Assert.Equal(53, response.Usage.OutputTokenCount);
@@ -922,7 +922,7 @@ public class OpenAIResponseClientTests
         }
 
         ToolCallContent content = Assert.IsType<ToolCallContent>(Assert.Single(updates[3].Contents));
-        Assert.NotNull(content.CallId);
+        Assert.Equal("call_p7K8YjFwNjqMgkKhSiExgFH6", content.CallId);
 #pragma warning disable OPENAICUA001 // OpenAI Computer Use is experimental
         var ccri = Assert.IsType<ComputerCallResponseItem>(content.RawRepresentation);
 #pragma warning restore OPENAICUA001


### PR DESCRIPTION
The non-streaming and streaming paths for ComputerCallResponseItem were using the response item Id (e.g. cu_123) instead of CallId (e.g. call_456) when constructing ToolCallContent. This made the CallId inconsistent with the corresponding ComputerCallOutputResponseItem's CallId, breaking the call/result pairing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7446)