### PR TITLE
Rename VectorStoreVectorAttribute dimensions constructor parameter

### DIFF
--- a/src/Libraries/Microsoft.Extensions.VectorData.Abstractions/Microsoft.Extensions.VectorData.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.VectorData.Abstractions/Microsoft.Extensions.VectorData.Abstractions.json
@@ -1256,7 +1256,7 @@
       "Stage": "Stable",
       "Methods": [
         {
-          "Member": "Microsoft.Extensions.VectorData.VectorStoreVectorAttribute.VectorStoreVectorAttribute(int Dimensions);",
+          "Member": "Microsoft.Extensions.VectorData.VectorStoreVectorAttribute.VectorStoreVectorAttribute(int dimensions);",
           "Stage": "Stable"
         }
       ],

--- a/src/Libraries/Microsoft.Extensions.VectorData.Abstractions/RecordAttributes/VectorStoreVectorAttribute.cs
+++ b/src/Libraries/Microsoft.Extensions.VectorData.Abstractions/RecordAttributes/VectorStoreVectorAttribute.cs
@@ -15,21 +15,19 @@ namespace Microsoft.Extensions.VectorData;
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
 public sealed class VectorStoreVectorAttribute : Attribute
 {
-#pragma warning disable IDE1006 // Naming Styles
     /// <summary>
     /// Initializes a new instance of the <see cref="VectorStoreVectorAttribute"/> class.
     /// </summary>
-    /// <param name="Dimensions">The number of dimensions that the vector has.</param>
-    public VectorStoreVectorAttribute(int Dimensions)
+    /// <param name="dimensions">The number of dimensions that the vector has.</param>
+    public VectorStoreVectorAttribute(int dimensions)
     {
-        if (Dimensions <= 0)
+        if (dimensions <= 0)
         {
-            Throw.ArgumentOutOfRangeException(nameof(Dimensions), "Dimensions must be greater than zero.");
+            Throw.ArgumentOutOfRangeException(nameof(dimensions), "Dimensions must be greater than zero.");
         }
 
-        this.Dimensions = Dimensions;
+        Dimensions = dimensions;
     }
-#pragma warning restore IDE1006 // Naming Styles
 
     /// <summary>
     /// Gets the number of dimensions that the vector has.
@@ -47,9 +45,7 @@ public sealed class VectorStoreVectorAttribute : Attribute
     /// The default value varies by database type. See the documentation of your chosen database provider for more information.
     /// </value>
     /// <seealso cref="IndexKind"/>
-#pragma warning disable CA1019 // Define accessors for attribute arguments: The constructor overload that contains this property is obsolete.
     public string? IndexKind { get; init; }
-#pragma warning restore CA1019
 
     /// <summary>
     /// Gets the distance function to use when comparing vectors.
@@ -58,9 +54,7 @@ public sealed class VectorStoreVectorAttribute : Attribute
     /// The default value varies by database type. See the documentation of your chosen database provider for more information.
     /// </value>
     /// <seealso cref="DistanceFunction"/>
-#pragma warning disable CA1019 // Define accessors for attribute arguments: The constructor overload that contains this property is obsolete.
     public string? DistanceFunction { get; init; }
-#pragma warning restore CA1019
 
     /// <summary>
     /// Gets an optional name to use for the property in storage, if different from the property name.

--- a/src/Libraries/Microsoft.Extensions.VectorData.ConformanceTests/DependencyInjectionTests.cs
+++ b/src/Libraries/Microsoft.Extensions.VectorData.ConformanceTests/DependencyInjectionTests.cs
@@ -320,7 +320,7 @@ public abstract class DependencyInjectionTests<TKey>
         [VectorStoreData(StorageName = "number")]
         public int Number { get; set; }
 
-        [VectorStoreVector(Dimensions: 3, StorageName = "embedding")]
+        [VectorStoreVector(dimensions: 3, StorageName = "embedding")]
         public ReadOnlyMemory<float> Floats { get; set; }
     }
 }

--- a/src/Libraries/Microsoft.Extensions.VectorData.ConformanceTests/EmbeddingGenerationTests.cs
+++ b/src/Libraries/Microsoft.Extensions.VectorData.ConformanceTests/EmbeddingGenerationTests.cs
@@ -161,7 +161,7 @@ public abstract class EmbeddingGenerationTests<TKey>(
     {
         [VectorStoreKey]
         public TKey Key { get; set; } = default!;
-        [VectorStoreVector(Dimensions: 3)]
+        [VectorStoreVector(dimensions: 3)]
         public ReadOnlyMemory<float> Embedding { get; set; }
     }
 
@@ -355,7 +355,7 @@ public abstract class EmbeddingGenerationTests<TKey>(
         [VectorStoreKey]
         public TKey Key { get; set; } = default!;
 
-        [VectorStoreVector(Dimensions: 3)]
+        [VectorStoreVector(dimensions: 3)]
         public string? Embedding { get; set; }
 
         [VectorStoreData(IsIndexed = true)]

--- a/src/Libraries/Microsoft.Extensions.VectorData.ConformanceTests/ModelTests/BasicModelTests.cs
+++ b/src/Libraries/Microsoft.Extensions.VectorData.ConformanceTests/ModelTests/BasicModelTests.cs
@@ -517,7 +517,7 @@ public abstract class BasicModelTests<TKey>(BasicModelTests<TKey>.Fixture fixtur
         [VectorStoreData(StorageName = "number")]
         public int Number { get; set; }
 
-        [VectorStoreVector(Dimensions: 3, StorageName = "vector")]
+        [VectorStoreVector(dimensions: 3, StorageName = "vector")]
         public ReadOnlyMemory<float> Vector { get; set; }
 
         public void AssertEqual(Record? other, bool includeVectors, bool compareVectors)

--- a/src/Libraries/Microsoft.Extensions.VectorData.ConformanceTests/ModelTests/NoDataModelTests.cs
+++ b/src/Libraries/Microsoft.Extensions.VectorData.ConformanceTests/ModelTests/NoDataModelTests.cs
@@ -86,7 +86,7 @@ public abstract class NoDataModelTests<TKey>(NoDataModelTests<TKey>.Fixture fixt
 
     public sealed class NoDataRecord : TestRecord<TKey>
     {
-        [VectorStoreVector(Dimensions: 3, StorageName = "embedding")]
+        [VectorStoreVector(dimensions: 3, StorageName = "embedding")]
         public ReadOnlyMemory<float> Floats { get; set; }
 
         public void AssertEqual(NoDataRecord? other, bool includeVectors, bool compareVectors)

--- a/test/Libraries/Microsoft.Extensions.VectorData.Abstractions.Tests/CollectionModelBuilderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.VectorData.Abstractions.Tests/CollectionModelBuilderTests.cs
@@ -333,7 +333,7 @@ public class CollectionModelBuilderTests
         [VectorStoreData]
         public required string Name { get; set; }
 
-        [VectorStoreVector(Dimensions: 3)]
+        [VectorStoreVector(dimensions: 3)]
         public required string Embedding { get; set; }
     }
 
@@ -345,7 +345,7 @@ public class CollectionModelBuilderTests
         [VectorStoreData]
         public required string Name { get; set; }
 
-        [VectorStoreVector(Dimensions: 3)]
+        [VectorStoreVector(dimensions: 3)]
         public ReadOnlyMemory<float> Embedding { get; set; }
     }
 
@@ -357,7 +357,7 @@ public class CollectionModelBuilderTests
         [VectorStoreData]
         public required string Name { get; set; }
 
-        [VectorStoreVector(Dimensions: 3)]
+        [VectorStoreVector(dimensions: 3)]
         public required Customer Embedding { get; set; }
     }
 


### PR DESCRIPTION
This fixes an unfortunate naming mistake that slipped through, and was picked up by code analysis once we moved the code from the SK repo to dotnet/extensions - the constructor parameter `Dimensions` on VectorStoreVectorAttribute should be named `dimensions`.

This is unfortunately a (minor) user-facing breaking change, albeit a source-only one; it's zero-risk, only a tiny bit of work for users, and it's early enough that it seems OK for us to do something like this (but if people have the opposite opinion we can leave it).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7460)