### PR TITLE
Add netstandard2.0 and net462 TFM support to AmbientMetadata.Build

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.Build/Microsoft.Extensions.AmbientMetadata.Build.csproj
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.Build/Microsoft.Extensions.AmbientMetadata.Build.csproj
@@ -4,7 +4,9 @@
     <RootNamespace>Microsoft.Extensions.AmbientMetadata</RootNamespace>
     <Description>Runtime information provider for Build ambient metadata.</Description>
     <Workstream>Fundamentals</Workstream>
-    <TargetFrameworks>$(NetCoreTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreTargetFrameworks);netstandard2.0;net462</TargetFrameworks>
+
+
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #7415 


## Summary

Added `netstandard2.0` and `net462` target frameworks to `Microsoft.Extensions.AmbientMetadata.Build` package to match the `Microsoft.Extensions.AmbientMetadata.Application` package, which already supports these TFMs.

## Changes

- Updated `TargetFrameworks` in `Microsoft.Extensions.AmbientMetadata.Build.csproj` from `$(NetCoreTargetFrameworks)` to `$(NetCoreTargetFrameworks);netstandard2.0;net462`

## Context

The `Application` package already targets `netstandard2.0` and `net462`, but the `Build` package did not, preventing usage in projects targeting these frameworks. As noted in the issue, there is no specific code preventing this package from working on these platforms.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7463)