### PR TITLE
Fix: Mark both TARC and TAResp FunctionCallContent as InformationalOnly after approval processing

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -1349,7 +1349,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     private (List<ApprovalResultWithRequestMessage>? approvals, List<ApprovalResultWithRequestMessage>? rejections) ExtractAndRemoveApprovalRequestsAndResponses(
         List<ChatMessage> messages)
     {
-        Dictionary<string, ChatMessage>? allApprovalRequestsMessages = null;
+        Dictionary<string, (ChatMessage Message, ToolApprovalRequestContent RequestContent)>? allApprovalRequestsMessages = null;
         List<ToolApprovalResponseContent>? allApprovalResponses = null;
         HashSet<string>? approvalRequestCallIds = null;
         HashSet<string>? functionResultCallIds = null;
@@ -1376,7 +1376,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                     case ToolApprovalRequestContent tarc when tarc.ToolCall is FunctionCallContent { InformationalOnly: false }:
                         // Validation: Capture each call id for each approval request to ensure later we have a matching response.
                         _ = (approvalRequestCallIds ??= []).Add(tarc.ToolCall.CallId);
-                        (allApprovalRequestsMessages ??= []).Add(tarc.RequestId, message);
+                        (allApprovalRequestsMessages ??= []).Add(tarc.RequestId, (message, tarc));
                         break;
 
                     case ToolApprovalResponseContent tarc when tarc.ToolCall is FunctionCallContent { InformationalOnly: false }:
@@ -1451,9 +1451,14 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                 ref List<ApprovalResultWithRequestMessage>? targetList = ref approvalResponse.Approved ? ref approvedFunctionCalls : ref rejectedFunctionCalls;
 
                 ChatMessage? requestMessage = null;
-                _ = allApprovalRequestsMessages?.TryGetValue(approvalResponse.RequestId, out requestMessage);
+                ToolApprovalRequestContent? requestContent = null;
+                if (allApprovalRequestsMessages?.TryGetValue(approvalResponse.RequestId, out var requestInfo) is true)
+                {
+                    requestMessage = requestInfo.Message;
+                    requestContent = requestInfo.RequestContent;
+                }
 
-                (targetList ??= []).Add(new() { Response = approvalResponse, RequestMessage = requestMessage });
+                (targetList ??= []).Add(new() { Response = approvalResponse, Request = requestContent, RequestMessage = requestMessage });
             }
         }
 
@@ -1469,7 +1474,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
         rejections is { Count: > 0 } ?
             rejections.ConvertAll(m =>
             {
-                LogFunctionRejected(m.FunctionCallContent.Name, m.Response.Reason);
+                LogFunctionRejected(m.ResponseFunctionCallContent.Name, m.Response.Reason);
 
                 string result = "Tool call invocation rejected.";
                 if (!string.IsNullOrWhiteSpace(m.Response.Reason))
@@ -1477,9 +1482,13 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                     result = $"{result} {m.Response.Reason}";
                 }
 
-                // Mark the function call as purely informational since we're handling it (by rejecting it)
-                m.FunctionCallContent.InformationalOnly = true;
-                return (AIContent)new FunctionResultContent(m.FunctionCallContent.CallId, result);
+                // Mark the function call as purely informational since we're handling it (by rejecting it).
+                // We mark both the response and request FunctionCallContent to ensure consistency
+                // across serialization boundaries where they may be separate object instances.
+                m.ResponseFunctionCallContent.InformationalOnly = true;
+                _ = m.RequestFunctionCallContent?.InformationalOnly = true;
+
+                return (AIContent)new FunctionResultContent(m.ResponseFunctionCallContent.CallId, result);
             }) :
             null;
 
@@ -1708,6 +1717,13 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                 originalMessages, options, notInvokedApprovals.Select(x => x.Response.ToolCall).OfType<FunctionCallContent>().ToList(), 0, consecutiveErrorCount, isStreaming, cancellationToken);
             consecutiveErrorCount = modeAndMessages.NewConsecutiveErrorCount;
 
+            // Also mark the request's FCC as InformationalOnly to ensure consistency
+            // across serialization boundaries where they may be separate object instances.
+            foreach (var approval in notInvokedApprovals)
+            {
+                _ = approval.RequestFunctionCallContent?.InformationalOnly = true;
+            }
+
             return (modeAndMessages.MessagesAdded, modeAndMessages.ShouldTerminate, consecutiveErrorCount);
         }
 
@@ -1788,7 +1804,9 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     private readonly struct ApprovalResultWithRequestMessage
     {
         public ToolApprovalResponseContent Response { get; init; }
+        public ToolApprovalRequestContent? Request { get; init; }
         public ChatMessage? RequestMessage { get; init; }
-        public FunctionCallContent FunctionCallContent => (FunctionCallContent)Response.ToolCall;
+        public FunctionCallContent ResponseFunctionCallContent => (FunctionCallContent)Response.ToolCall;
+        public FunctionCallContent? RequestFunctionCallContent => Request?.ToolCall as FunctionCallContent;
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -1385,6 +1385,12 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                         (allApprovalResponses ??= []).Add(tarc);
                         break;
 
+                    case ToolApprovalResponseContent tarc when tarc.ToolCall is FunctionCallContent { InformationalOnly: true }:
+                        // Remove from validation set to handle sessions serialized before the fix
+                        // for https://github.com/dotnet/extensions/pull/7468.
+                        _ = approvalRequestCallIds?.Remove(tarc.ToolCall.CallId);
+                        goto default;
+
                     case FunctionResultContent frc:
                         // Maintain a list of function calls that have already been invoked to avoid invoking them twice.
                         _ = (functionResultCallIds ??= []).Add(frc.CallId);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
@@ -766,7 +766,7 @@ public class FunctionInvokingChatClientApprovalsTests
     [InlineData(true)]
     public async Task RejectionSetsInformationalOnlyOnBothRequestAndResponseFccInstancesAsync(bool streaming)
     {
-        // Create two separate FCC objects for the same call — simulating deserialization
+        // Create two separate FCC objects for the same call â€” simulating deserialization
         // where TARC and TAResp hold different FCC instances with the same CallId.
         var requestFcc = new FunctionCallContent("callId1", "Func1");
         var responseFcc = new FunctionCallContent("callId1", "Func1");

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
@@ -755,6 +755,74 @@ public class FunctionInvokingChatClientApprovalsTests
     }
 
     /// <summary>
+    /// After serialization/deserialization, the TARC and TAResp may contain separate FCC object instances
+    /// for the same call. When a rejection is processed, GenerateRejectedFunctionResults must set
+    /// InformationalOnly=true on BOTH the TAResp's FCC and the TARC's FCC to ensure consistency
+    /// across serialization boundaries. This test verifies that both FCC instances are correctly
+    /// marked after rejection processing.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RejectionSetsInformationalOnlyOnBothRequestAndResponseFccInstancesAsync(bool streaming)
+    {
+        // Create two separate FCC objects for the same call — simulating deserialization
+        // where TARC and TAResp hold different FCC instances with the same CallId.
+        var requestFcc = new FunctionCallContent("callId1", "Func1");
+        var responseFcc = new FunctionCallContent("callId1", "Func1");
+
+        Assert.False(requestFcc.InformationalOnly);
+        Assert.False(responseFcc.InformationalOnly);
+
+        var options = new ChatOptions
+        {
+            Tools =
+            [
+                new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => "Result 1", "Func1")),
+            ]
+        };
+
+        List<ChatMessage> input =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+            new ChatMessage(ChatRole.Assistant,
+            [
+                new ToolApprovalRequestContent("ficc_callId1", requestFcc),
+            ]) { MessageId = "resp1" },
+            new ChatMessage(ChatRole.User,
+            [
+                new ToolApprovalResponseContent("ficc_callId1", false, responseFcc),
+            ]),
+        ];
+
+        using var innerClient = new TestChatClient
+        {
+            GetResponseAsyncCallback = (contents, actualOptions, actualCancellationToken) =>
+                Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "world")])),
+            GetStreamingResponseAsyncCallback = (contents, actualOptions, actualCancellationToken) =>
+                YieldAsync(new ChatResponse([new ChatMessage(ChatRole.Assistant, "world")]).ToChatResponseUpdates()),
+        };
+
+        IChatClient service = innerClient.AsBuilder()
+            .Use(s => new FunctionInvokingChatClient(s))
+            .Build();
+
+        if (streaming)
+        {
+            await service.GetStreamingResponseAsync(input, options).ToChatResponseAsync();
+        }
+        else
+        {
+            await service.GetResponseAsync(input, options);
+        }
+
+        // The fix ensures both FCC instances are marked InformationalOnly=true,
+        // even when they are separate objects (as happens after serialization).
+        Assert.True(requestFcc.InformationalOnly);
+        Assert.True(responseFcc.InformationalOnly);
+    }
+
+    /// <summary>
     /// This verifies the following scenario:
     /// 1. We are streaming (also including non-streaming in the test for completeness).
     /// 2. There is one function that requires approval and one that does not.

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
@@ -823,6 +823,80 @@ public class FunctionInvokingChatClientApprovalsTests
     }
 
     /// <summary>
+    /// After serialization/deserialization, the TARC and TAResp may contain separate FCC object instances
+    /// for the same call. When a rejection is processed, GenerateRejectedFunctionResults must set
+    /// InformationalOnly=true on BOTH the TAResp's FCC and the TARC's FCC to ensure consistency
+    /// across serialization boundaries. Previously, this was not always happening, so adding
+    /// a test to ensure that this case does not throw.
+    /// See https://github.com/dotnet/extensions/pull/7468.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task MixedInformationalOnlyDoesNotThrowAsync(bool streaming)
+    {
+        // Create two separate FCC objects for the same call — simulating deserialization
+        // where TARC and TAResp hold different FCC instances with the same CallId.
+        var request1Fcc = new FunctionCallContent("callId1", "Func1");
+        var response1Fcc = new FunctionCallContent("callId1", "Func1") { InformationalOnly = true };
+
+        var request2Fcc = new FunctionCallContent("callId2", "Func1");
+
+        Assert.False(request1Fcc.InformationalOnly);
+        Assert.True(response1Fcc.InformationalOnly);
+
+        var options = new ChatOptions
+        {
+            Tools =
+            [
+                new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => "Result 1", "Func1")),
+            ]
+        };
+
+        List<ChatMessage> input =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+            new ChatMessage(ChatRole.Assistant,
+            [
+                new ToolApprovalRequestContent("ficc_callId1", request1Fcc),
+            ]) { MessageId = "resp1" },
+            new ChatMessage(ChatRole.User,
+            [
+                new ToolApprovalResponseContent("ficc_callId1", false, response1Fcc),
+            ]),
+            new ChatMessage(ChatRole.Assistant,
+            [
+                new ToolApprovalRequestContent("ficc_callId2", request2Fcc),
+            ]) { MessageId = "resp2" },
+            new ChatMessage(ChatRole.User,
+            [
+                new ToolApprovalResponseContent("ficc_callId2", false, request2Fcc),
+            ]),
+        ];
+
+        using var innerClient = new TestChatClient
+        {
+            GetResponseAsyncCallback = (contents, actualOptions, actualCancellationToken) =>
+                Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "world")])),
+            GetStreamingResponseAsyncCallback = (contents, actualOptions, actualCancellationToken) =>
+                YieldAsync(new ChatResponse([new ChatMessage(ChatRole.Assistant, "world")]).ToChatResponseUpdates()),
+        };
+
+        IChatClient service = innerClient.AsBuilder()
+            .Use(s => new FunctionInvokingChatClient(s))
+            .Build();
+
+        if (streaming)
+        {
+            await service.GetStreamingResponseAsync(input, options).ToChatResponseAsync();
+        }
+        else
+        {
+            await service.GetResponseAsync(input, options);
+        }
+    }
+
+    /// <summary>
     /// This verifies the following scenario:
     /// 1. We are streaming (also including non-streaming in the test for completeness).
     /// 2. There is one function that requires approval and one that does not.


### PR DESCRIPTION
## Problem

Fixes https://github.com/microsoft/agent-framework/issues/5189

`FunctionInvokingChatClient.ExtractAndRemoveApprovalRequestsAndResponses` throws `InvalidOperationException` when conversation history contains a `ToolApprovalRequestContent` (TARC) / `ToolApprovalResponseContent` (TAResp) pair whose `FunctionCallContent` objects have inconsistent `InformationalOnly` flags — a situation that reliably occurs after session serialization/deserialization.

### Root Cause

FICC relies on **shared object references** between the `FunctionCallContent` (FCC) inside a TARC and the FCC inside the corresponding TAResp. When `GenerateRejectedFunctionResults` sets `FCC.InformationalOnly = true`, it only mutates the TAResp's FCC. Without serialization this works because TARC and TAResp share the same FCC object. After serialization, they are separate instances and the TARC's FCC retains `InformationalOnly = false`.

### Turn-by-turn reproduction

**Turn 1** — User sends a message. Model returns `FunctionCallContent("call1")`. FICC wraps it in `ToolApprovalRequestContent` and returns it. End-of-run persistence stores `[user_msg, TARC(FCC)]`.

**Session serialize → deserialize** — The stored TARC now contains a **new** FCC object (`FCC_D`, `InformationalOnly = false`). The caller still holds the **original** FCC (`FCC_OLD`) from the response.

**Turn 2** — User rejects the approval using the original TARC reference, creating `TAResp(FCC_OLD)`. Messages sent to FICC:

| Content | FCC Object | InformationalOnly |
|---------|-----------|-------------------|
| `TARC` (from deserialized history) | `FCC_D` | `false` |
| `TAResp` (from user input) | `FCC_OLD` | `false` |

FICC processes successfully — both match the `InformationalOnly: false` pattern. `GenerateRejectedFunctionResults` sets `FCC_OLD.InformationalOnly = true`. **But `FCC_D` is a different object and is NOT mutated.** Model retries → returns new `FCC("call2")` → wrapped in `TARC2`.

End-of-run persistence stores:

| Content | FCC | InformationalOnly |
|---------|-----|-------------------|
| `TARC(call1)` | `FCC_D` | ❌ `false` (never mutated!) |
| `TAResp(call1)` | `FCC_OLD` | ✅ `true` (mutated) |
| `FRC(call1, "rejected")` | — | — |
| `TARC2(call2)` | new FCC | `false` |

**Turn 3** — User rejects call2. FICC's `ExtractAndRemoveApprovalRequestsAndResponses` processes history:

1. `TARC(FCC_D, InformationalOnly=false)` → **matches pattern** → adds `"call1"` to `approvalRequestCallIds`
2. `TAResp(FCC_OLD, InformationalOnly=true)` → **SKIPPED** (doesn't match `InformationalOnly: false` guard)
3. `TARC2(call2, InformationalOnly=false)` → matches → adds `"call2"`
4. `TAResp2(call2, InformationalOnly=false)` → matches → removes `"call2"`

**Result:** `approvalRequestCallIds = {"call1"}` — validation throws:
```
InvalidOperationException: ToolApprovalRequestContent found with FunctionCall.CallId(s) 'call1' 
that have no matching ToolApprovalResponseContent.
```

## Fix

Mark **both** the request and response `FunctionCallContent` as `InformationalOnly = true` at every approval processing point, ensuring consistency regardless of object identity:

1. **`ApprovalResultWithRequestMessage`** — Now stores the `ToolApprovalRequestContent` alongside the response, exposing both `ResponseFunctionCallContent` and `RequestFunctionCallContent`.

2. **`ExtractAndRemoveApprovalRequestsAndResponses`** — The approval request dictionary now stores the TARC content alongside the message, and passes it through to `ApprovalResultWithRequestMessage.Request`.

3. **`GenerateRejectedFunctionResults`** — Marks both `ResponseFunctionCallContent` and `RequestFunctionCallContent` as `InformationalOnly = true`.

4. **`InvokeApprovedFunctionApprovalResponsesAsync`** — Also marks the request FCC for the approved path, since the same identity split exists after serialization.

5. **Tests** — `CloneInput` now deep-clones `FunctionCallContent`, `ToolApprovalRequestContent`, and `ToolApprovalResponseContent`, simulating the serialization effect (separate FCC instances) so existing tests exercise the previously broken codepath.

CC @stephentoub
