### PR TITLE
Honor UnmappedMemberHandling in AIFunctionFactory parameter binding

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -631,19 +631,38 @@ public static partial class AIFunctionFactory
                 // If the configured serializer options request strict handling of unmapped members,
                 // verify that every argument key corresponds to a declared parameter name. This mirrors
                 // JsonSerializerOptions.UnmappedMemberHandling behavior for object deserialization by
-                // applying the same policy to top-level AIFunction argument binding.
-                if (FunctionDescriptor.JsonSerializerOptions.UnmappedMemberHandling == JsonUnmappedMemberHandling.Disallow &&
+                // applying the same policy to top-level AIFunction argument binding. Argument name matching
+                // honors the comparer of the supplied AIFunctionArguments dictionary (ordinal by default).
+                if (FunctionDescriptor.JsonSerializerOptions.UnmappedMemberHandling is JsonUnmappedMemberHandling.Disallow &&
                     arguments.Count > 0 &&
                     FunctionDescriptor.ExpectedArgumentNames is { } expectedNames)
                 {
-                    foreach (KeyValuePair<string, object?> kvp in arguments)
+                    int matched = 0;
+                    foreach (string name in expectedNames)
                     {
-                        if (!expectedNames.Contains(kvp.Key))
+                        if (arguments.ContainsKey(name))
                         {
-                            Throw.ArgumentException(
-                                nameof(arguments),
-                                $"The arguments dictionary contains an unexpected key '{kvp.Key}' that does not correspond to any parameter of '{Name}'.");
+                            matched++;
                         }
+                    }
+
+                    if (matched != arguments.Count)
+                    {
+                        foreach (KeyValuePair<string, object?> kvp in arguments)
+                        {
+                            if (!expectedNames.Contains(kvp.Key))
+                            {
+                                Throw.ArgumentException(
+                                    nameof(arguments),
+                                    $"The arguments dictionary contains an unexpected key '{kvp.Key}' that does not correspond to any parameter of '{Name}'.");
+                            }
+                        }
+
+                        // Fallback for comparer mismatches (e.g. case-insensitive arguments dictionary
+                        // with duplicate-casing keys aliasing to the same parameter).
+                        Throw.ArgumentException(
+                            nameof(arguments),
+                            $"The arguments dictionary contains keys that do not correspond to any parameter of '{Name}'.");
                     }
                 }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -633,10 +633,15 @@ public static partial class AIFunctionFactory
                 // JsonSerializerOptions.UnmappedMemberHandling behavior for object deserialization by
                 // applying the same policy to top-level AIFunction argument binding. Argument name matching
                 // honors the comparer of the supplied AIFunctionArguments dictionary (ordinal by default).
+                //
+                // Validation is skipped when custom ParameterBindingOptions.BindParameter callbacks are in
+                // use, since those may legitimately source values from argument keys that do not correspond
+                // to the .NET parameter names.
                 if (FunctionDescriptor.JsonSerializerOptions.UnmappedMemberHandling is JsonUnmappedMemberHandling.Disallow &&
                     arguments.Count > 0 &&
-                    FunctionDescriptor.ExpectedArgumentNames is { } expectedNames)
+                    !FunctionDescriptor.HasCustomParameterBinding)
                 {
+                    HashSet<string> expectedNames = FunctionDescriptor.ExpectedArgumentNames;
                     int matched = 0;
                     foreach (string name in expectedNames)
                     {
@@ -772,7 +777,8 @@ public static partial class AIFunctionFactory
 
             // Get marshaling delegates for parameters.
             ParameterMarshallers = parameters.Length > 0 ? new Func<AIFunctionArguments, CancellationToken, object?>[parameters.Length] : [];
-            HashSet<string>? expectedArgumentNames = null;
+            HashSet<string> expectedArgumentNames = new(StringComparer.Ordinal);
+            bool hasCustomParameterBinding = false;
             for (int i = 0; i < parameters.Length; i++)
             {
                 if (boundParameters?.TryGetValue(parameters[i], out AIFunctionFactoryOptions.ParameterBindingOptions options) is not true)
@@ -782,22 +788,30 @@ public static partial class AIFunctionFactory
 
                 ParameterMarshallers[i] = GetParameterMarshaller(serializerOptions, options, parameters[i]);
 
+                if (options.BindParameter is not null)
+                {
+                    // Custom BindParameter callbacks can legally source their value from arbitrary keys in the
+                    // AIFunctionArguments dictionary, so we cannot know in advance which keys are "expected".
+                    // Note this down so that strict unmapped-member validation is skipped in InvokeCoreAsync.
+                    hasCustomParameterBinding = true;
+                }
+
                 // Collect the set of parameter names that are potentially sourced from the arguments dictionary.
                 // Infrastructure parameters (CancellationToken, AIFunctionArguments, IServiceProvider) are always
-                // bound from dedicated sources and are never resolved by argument name, so they are excluded.
-                // Custom BindParameter callbacks may read arbitrary keys from the arguments dictionary, so we
-                // include their parameter name as a permitted argument name rather than flagging it as unmapped.
+                // bound from dedicated sources and are never resolved by argument name, so they are excluded from
+                // the permitted set.
                 Type pType = parameters[i].ParameterType;
                 if (pType != typeof(CancellationToken) &&
                     pType != typeof(AIFunctionArguments) &&
                     pType != typeof(IServiceProvider) &&
                     !string.IsNullOrEmpty(parameters[i].Name))
                 {
-                    _ = (expectedArgumentNames ??= new HashSet<string>(StringComparer.Ordinal)).Add(parameters[i].Name!);
+                    _ = expectedArgumentNames.Add(parameters[i].Name!);
                 }
             }
 
             ExpectedArgumentNames = expectedArgumentNames;
+            HasCustomParameterBinding = hasCustomParameterBinding;
 
             ReturnParameterMarshaller = GetReturnParameterMarshaller(key, serializerOptions, out Type? returnType);
             Method = key.Method;
@@ -826,7 +840,8 @@ public static partial class AIFunctionFactory
         public JsonElement? ReturnJsonSchema { get; }
         public Func<AIFunctionArguments, CancellationToken, object?>[] ParameterMarshallers { get; }
         public Func<object?, CancellationToken, ValueTask<object?>> ReturnParameterMarshaller { get; }
-        public HashSet<string>? ExpectedArgumentNames { get; }
+        public HashSet<string> ExpectedArgumentNames { get; }
+        public bool HasCustomParameterBinding { get; }
         public ReflectionAIFunction? CachedDefaultInstance { get; set; }
 
         private static string GetFunctionName(MethodInfo method)

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -15,6 +15,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -627,6 +628,25 @@ public static partial class AIFunctionFactory
                 var paramMarshallers = FunctionDescriptor.ParameterMarshallers;
                 object?[] args = paramMarshallers.Length != 0 ? new object?[paramMarshallers.Length] : [];
 
+                // If the configured serializer options request strict handling of unmapped members,
+                // verify that every argument key corresponds to a declared parameter name. This mirrors
+                // JsonSerializerOptions.UnmappedMemberHandling behavior for object deserialization by
+                // applying the same policy to top-level AIFunction argument binding.
+                if (FunctionDescriptor.JsonSerializerOptions.UnmappedMemberHandling == JsonUnmappedMemberHandling.Disallow &&
+                    arguments.Count > 0 &&
+                    FunctionDescriptor.ExpectedArgumentNames is { } expectedNames)
+                {
+                    foreach (KeyValuePair<string, object?> kvp in arguments)
+                    {
+                        if (!expectedNames.Contains(kvp.Key))
+                        {
+                            Throw.ArgumentException(
+                                nameof(arguments),
+                                $"The arguments dictionary contains an unexpected key '{kvp.Key}' that does not correspond to any parameter of '{Name}'.");
+                        }
+                    }
+                }
+
                 for (int i = 0; i < args.Length; i++)
                 {
                     args[i] = paramMarshallers[i](arguments, cancellationToken);
@@ -733,6 +753,7 @@ public static partial class AIFunctionFactory
 
             // Get marshaling delegates for parameters.
             ParameterMarshallers = parameters.Length > 0 ? new Func<AIFunctionArguments, CancellationToken, object?>[parameters.Length] : [];
+            HashSet<string>? expectedArgumentNames = null;
             for (int i = 0; i < parameters.Length; i++)
             {
                 if (boundParameters?.TryGetValue(parameters[i], out AIFunctionFactoryOptions.ParameterBindingOptions options) is not true)
@@ -741,7 +762,23 @@ public static partial class AIFunctionFactory
                 }
 
                 ParameterMarshallers[i] = GetParameterMarshaller(serializerOptions, options, parameters[i]);
+
+                // Collect the set of parameter names that are potentially sourced from the arguments dictionary.
+                // Infrastructure parameters (CancellationToken, AIFunctionArguments, IServiceProvider) are always
+                // bound from dedicated sources and are never resolved by argument name, so they are excluded.
+                // Custom BindParameter callbacks may read arbitrary keys from the arguments dictionary, so we
+                // include their parameter name as a permitted argument name rather than flagging it as unmapped.
+                Type pType = parameters[i].ParameterType;
+                if (pType != typeof(CancellationToken) &&
+                    pType != typeof(AIFunctionArguments) &&
+                    pType != typeof(IServiceProvider) &&
+                    !string.IsNullOrEmpty(parameters[i].Name))
+                {
+                    _ = (expectedArgumentNames ??= new HashSet<string>(StringComparer.Ordinal)).Add(parameters[i].Name!);
+                }
             }
+
+            ExpectedArgumentNames = expectedArgumentNames;
 
             ReturnParameterMarshaller = GetReturnParameterMarshaller(key, serializerOptions, out Type? returnType);
             Method = key.Method;
@@ -770,6 +807,7 @@ public static partial class AIFunctionFactory
         public JsonElement? ReturnJsonSchema { get; }
         public Func<AIFunctionArguments, CancellationToken, object?>[] ParameterMarshallers { get; }
         public Func<object?, CancellationToken, ValueTask<object?>> ReturnParameterMarshaller { get; }
+        public HashSet<string>? ExpectedArgumentNames { get; }
         public ReflectionAIFunction? CachedDefaultInstance { get; set; }
 
         private static string GetFunctionName(MethodInfo method)

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactoryOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactoryOptions.cs
@@ -29,21 +29,10 @@ public sealed class AIFunctionFactoryOptions
     /// If no value has been specified, the <see cref="AIJsonUtilities.DefaultOptions"/> instance will be used.
     /// </para>
     /// <para>
-    /// When <see cref="JsonSerializerOptions.UnmappedMemberHandling"/> is set to
-    /// <see cref="System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow"/>, the produced
-    /// <see cref="AIFunction"/> will throw at invocation time if the <see cref="AIFunctionArguments"/>
-    /// dictionary contains keys that do not correspond to a bindable function parameter. This mirrors
-    /// the handling of unmapped properties during object deserialization and enables strict validation of
-    /// tool call arguments. For this validation, only parameters populated from <see cref="AIFunctionArguments"/>
-    /// are considered valid argument names; infrastructure parameters such as <see cref="System.Threading.CancellationToken"/>,
-    /// <see cref="AIFunctionArguments"/>, and <see cref="IServiceProvider"/> are excluded, so argument keys
-    /// matching those parameter names are still treated as unexpected even if the underlying method declares
-    /// parameters with those names.
-    /// </para>
-    /// <para>
-    /// This strict validation is based on the function's parameter metadata and is not applied to functions
-    /// that use custom parameter binding configured through <see cref="ConfigureParameterBinding"/>, since
-    /// such callbacks may legitimately source parameter values from arbitrary argument keys.
+    /// The <see cref="JsonSerializerOptions.UnmappedMemberHandling"/> setting is honored by the function parameter
+    /// binder: when set to <see cref="System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow"/>, invoking
+    /// the produced <see cref="AIFunction"/> throws if the supplied <see cref="AIFunctionArguments"/> contains keys
+    /// that do not correspond to a bindable parameter of the underlying method.
     /// </para>
     /// </remarks>
     public JsonSerializerOptions? SerializerOptions { get; set; }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactoryOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactoryOptions.cs
@@ -25,7 +25,17 @@ public sealed class AIFunctionFactoryOptions
 
     /// <summary>Gets or sets the <see cref="JsonSerializerOptions"/> used to marshal .NET values being passed to the underlying delegate.</summary>
     /// <remarks>
+    /// <para>
     /// If no value has been specified, the <see cref="AIJsonUtilities.DefaultOptions"/> instance will be used.
+    /// </para>
+    /// <para>
+    /// When <see cref="JsonSerializerOptions.UnmappedMemberHandling"/> is set to
+    /// <see cref="System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow"/>, the produced
+    /// <see cref="AIFunction"/> will throw at invocation time if the <see cref="AIFunctionArguments"/>
+    /// dictionary contains keys that do not correspond to any of the function's parameters. This mirrors
+    /// the handling of unmapped properties during object deserialization and enables strict validation of
+    /// tool call arguments.
+    /// </para>
     /// </remarks>
     public JsonSerializerOptions? SerializerOptions { get; set; }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactoryOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactoryOptions.cs
@@ -32,9 +32,18 @@ public sealed class AIFunctionFactoryOptions
     /// When <see cref="JsonSerializerOptions.UnmappedMemberHandling"/> is set to
     /// <see cref="System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow"/>, the produced
     /// <see cref="AIFunction"/> will throw at invocation time if the <see cref="AIFunctionArguments"/>
-    /// dictionary contains keys that do not correspond to any of the function's parameters. This mirrors
+    /// dictionary contains keys that do not correspond to a bindable function parameter. This mirrors
     /// the handling of unmapped properties during object deserialization and enables strict validation of
-    /// tool call arguments.
+    /// tool call arguments. For this validation, only parameters populated from <see cref="AIFunctionArguments"/>
+    /// are considered valid argument names; infrastructure parameters such as <see cref="System.Threading.CancellationToken"/>,
+    /// <see cref="AIFunctionArguments"/>, and <see cref="IServiceProvider"/> are excluded, so argument keys
+    /// matching those parameter names are still treated as unexpected even if the underlying method declares
+    /// parameters with those names.
+    /// </para>
+    /// <para>
+    /// This strict validation is based on the function's parameter metadata and is not applied to functions
+    /// that use custom parameter binding configured through <see cref="ConfigureParameterBinding"/>, since
+    /// such callbacks may legitimately source parameter values from arbitrary argument keys.
     /// </para>
     /// </remarks>
     public JsonSerializerOptions? SerializerOptions { get; set; }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
@@ -1533,6 +1533,56 @@ public partial class AIFunctionFactoryTest
         Assert.Contains("PHASE", ex.Message);
     }
 
+    [Fact]
+    public async Task Parameters_UnmappedMemberHandlingDisallow_ParameterlessMethod_ThrowsOnAnyArgument_Async()
+    {
+        JsonSerializerOptions strictOptions = new(AIJsonUtilities.DefaultOptions)
+        {
+            UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        };
+
+        AIFunction func = AIFunctionFactory.Create(
+            () => "ok",
+            new AIFunctionFactoryOptions { SerializerOptions = strictOptions });
+
+        // No args is fine.
+        AssertExtensions.EqualFunctionCallResults("ok", await func.InvokeAsync());
+
+        // Any extra key is flagged.
+        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>("arguments", async () =>
+            await func.InvokeAsync(new() { ["phase"] = "completed" }));
+        Assert.Contains("phase", ex.Message);
+    }
+
+    [Fact]
+    public async Task Parameters_UnmappedMemberHandlingDisallow_CustomBindParameter_SkipsStrictValidation_Async()
+    {
+        JsonSerializerOptions strictOptions = new(AIJsonUtilities.DefaultOptions)
+        {
+            UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        };
+
+        // A custom BindParameter callback sources its value from a key that does not correspond
+        // to the .NET parameter name. Strict validation must be skipped so such binders keep working.
+        AIFunction func = AIFunctionFactory.Create(
+            (string update) => $"update:{update}",
+            new AIFunctionFactoryOptions
+            {
+                SerializerOptions = strictOptions,
+                ConfigureParameterBinding = _ => new()
+                {
+                    BindParameter = (_, args) => args["aliasedKey"],
+                },
+            });
+
+        object? result = await func.InvokeAsync(new()
+        {
+            ["aliasedKey"] = "hello",
+            ["anotherKey"] = "world",
+        });
+        AssertExtensions.EqualFunctionCallResults("update:hello", result);
+    }
+
     [JsonSerializable(typeof(IAsyncEnumerable<int>))]
     [JsonSerializable(typeof(int[]))]
     [JsonSerializable(typeof(string))]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
@@ -1501,6 +1501,38 @@ public partial class AIFunctionFactoryTest
         AssertExtensions.EqualFunctionCallResults("Done:False", result);
     }
 
+    [Fact]
+    public async Task Parameters_UnmappedMemberHandlingDisallow_HonorsArgumentsComparer_Async()
+    {
+        JsonSerializerOptions strictOptions = new(AIJsonUtilities.DefaultOptions)
+        {
+            UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        };
+
+        AIFunction func = AIFunctionFactory.Create(
+            (string update, bool markComplete = false) => $"{update}:{markComplete}",
+            new AIFunctionFactoryOptions { SerializerOptions = strictOptions });
+
+        // Case-insensitive arguments dictionary: casing variations of the parameter name must not be
+        // flagged as unmapped, since the binding lookup itself is case-insensitive.
+        AIFunctionArguments caseInsensitive = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["UPDATE"] = "Done",
+            ["MarkComplete"] = true,
+        };
+        AssertExtensions.EqualFunctionCallResults("Done:True", await func.InvokeAsync(caseInsensitive));
+
+        // A genuinely unmapped key is still flagged even with a case-insensitive comparer.
+        AIFunctionArguments withExtra = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["update"] = "Done",
+            ["PHASE"] = "completed",
+        };
+        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>("arguments", async () =>
+            await func.InvokeAsync(withExtra));
+        Assert.Contains("PHASE", ex.Message);
+    }
+
     [JsonSerializable(typeof(IAsyncEnumerable<int>))]
     [JsonSerializable(typeof(int[]))]
     [JsonSerializable(typeof(string))]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
@@ -1455,6 +1455,52 @@ public partial class AIFunctionFactoryTest
 #endif
     }
 
+    [Fact]
+    public async Task Parameters_UnmappedMemberHandlingDisallow_ThrowsOnExtraArgument_Async()
+    {
+        JsonSerializerOptions strictOptions = new(AIJsonUtilities.DefaultOptions)
+        {
+            UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        };
+
+        AIFunction func = AIFunctionFactory.Create(
+            (string taskId, string update, bool markComplete = false) => $"{taskId}:{update}:{markComplete}",
+            new AIFunctionFactoryOptions { SerializerOptions = strictOptions });
+
+        // Extra, unrecognized argument causes a throw.
+        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>("arguments", async () =>
+            await func.InvokeAsync(new()
+            {
+                ["taskId"] = "abc",
+                ["update"] = "Done",
+                ["phase"] = "completed",
+            }));
+        Assert.Contains("phase", ex.Message);
+
+        // Still succeeds when no unexpected arguments are present (optional parameter omitted).
+        object? result = await func.InvokeAsync(new()
+        {
+            ["taskId"] = "abc",
+            ["update"] = "Done",
+        });
+        AssertExtensions.EqualFunctionCallResults("abc:Done:False", result);
+    }
+
+    [Fact]
+    public async Task Parameters_UnmappedMemberHandlingDefault_IgnoresExtraArgument_Async()
+    {
+        // Default behavior (Skip) should preserve pre-existing lenient binding.
+        AIFunction func = AIFunctionFactory.Create(
+            (string update, bool markComplete = false) => $"{update}:{markComplete}");
+
+        object? result = await func.InvokeAsync(new()
+        {
+            ["update"] = "Done",
+            ["phase"] = "completed",
+        });
+        AssertExtensions.EqualFunctionCallResults("Done:False", result);
+    }
+
     [JsonSerializable(typeof(IAsyncEnumerable<int>))]
     [JsonSerializable(typeof(int[]))]
     [JsonSerializable(typeof(string))]


### PR DESCRIPTION
Follow-up to the discussion in modelcontextprotocol/csharp-sdk#1508.

Today, `AIFunctionFactory` silently ignores keys in the `AIFunctionArguments` dictionary that do not correspond to any declared parameter of the underlying method. This matches STJ's default lenient handling of unmapped properties, but it prevents tool servers from opting in to strict validation when an LLM hallucinates an extra argument name (e.g. `markComplete` vs `phase` in the linked issue).

This change wires `JsonSerializerOptions.UnmappedMemberHandling` into top-level parameter binding:

- When the serializer options have `UnmappedMemberHandling = Disallow`, invoking the `AIFunction` now throws `ArgumentException` if `AIFunctionArguments` contains a key that doesn't match any method parameter (infrastructure parameters `CancellationToken` / `AIFunctionArguments` / `IServiceProvider` are excluded from the permitted set, as they are never addressed by name).
- The default behavior (`Skip`) is unchanged, so this is opt-in and non-breaking.
- Documented on `AIFunctionFactoryOptions.SerializerOptions`.
- Added unit tests for both the strict and default code paths.

Closes the MEAI side of modelcontextprotocol/csharp-sdk#1508.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7474)