### PR TITLE
Bump the project template package reference versions for OpenTelemetry and Agent Framework

### DIFF
--- a/eng/packages/ProjectTemplates.props
+++ b/eng/packages/ProjectTemplates.props
@@ -18,11 +18,11 @@
     <PackageVersion Include="Azure.Search.Documents" Version="11.7.0" />
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.0.0-beta.444" />
     <PackageVersion Include="CommunityToolkit.Aspire.OllamaSharp" Version="13.0.0-beta.444" />
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.0.0-rc1" />
-    <PackageVersion Include="Microsoft.Agents.AI.DevUI" Version="1.0.0-preview.260219.1" />
-    <PackageVersion Include="Microsoft.Agents.AI.Hosting" Version="1.0.0-preview.260219.1" />
-    <PackageVersion Include="Microsoft.Agents.AI.Hosting.OpenAI" Version="1.0.0-alpha.260219.1" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.0.0-rc1" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.DevUI" Version="1.3.0-preview.260423.1" />
+    <PackageVersion Include="Microsoft.Agents.AI.Hosting" Version="1.3.0-preview.260423.1" />
+    <PackageVersion Include="Microsoft.Agents.AI.Hosting.OpenAI" Version="1.3.0-alpha.260423.1" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.3.0" />
     <PackageVersion Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="$(MicrosoftMLTokenizersVersion)" />
     <PackageVersion Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="$(MicrosoftMLTokenizersVersion)" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.67.1-preview" />
@@ -31,11 +31,11 @@
     <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.12" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="PdfPig" Version="0.1.12" />
   </ItemGroup>
 </Project>

--- a/eng/packages/ProjectTemplates.props
+++ b/eng/packages/ProjectTemplates.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.12" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />

--- a/src/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.csproj
+++ b/src/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.csproj
@@ -10,7 +10,7 @@
 
     <!-- Set the version info to align with Microsoft.Agents.AI packages -->
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MinorVersion>3</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
 

--- a/src/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates/templates/AIAgentWebApi-CSharp/AIAgentWebApi-CSharp.csproj-in
+++ b/src/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates/templates/AIAgentWebApi-CSharp/AIAgentWebApi-CSharp.csproj-in
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="${PackageVersion:Microsoft.Agents.AI}" />
 <!--#endif -->
     <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="${PackageVersion:Microsoft.Agents.AI.Workflows}" />
+    <PackageReference Include="OpenTelemetry.Api" Version="${PackageVersion:OpenTelemetry.Api}" />
 <!--#if (IsOllama) -->
     <PackageReference Include="OllamaSharp" Version="${PackageVersion:OllamaSharp}" />
 <!--#endif -->

--- a/test/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.IntegrationTests/Snapshots/aiagent-webapi/aiagent-webapi._defaults.verified/aiagent-webapi/aiagent-webapi.csproj
+++ b/test/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.IntegrationTests/Snapshots/aiagent-webapi/aiagent-webapi._defaults.verified/aiagent-webapi/aiagent-webapi.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Agents.AI.Hosting.OpenAI" Version="{VERSION}" />
     <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="{VERSION}" />
     <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="{VERSION}" />
+    <PackageReference Include="OpenTelemetry.Api" Version="{VERSION}" />
   </ItemGroup>
 
 </Project>

--- a/test/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.IntegrationTests/Snapshots/aiagent-webapi/aiagent-webapi.aoai_ID_F.verified/aiagent-webapi/aiagent-webapi.csproj
+++ b/test/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.IntegrationTests/Snapshots/aiagent-webapi/aiagent-webapi.aoai_ID_F.verified/aiagent-webapi/aiagent-webapi.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Agents.AI.Hosting.OpenAI" Version="{VERSION}" />
     <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="{VERSION}" />
     <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="{VERSION}" />
+    <PackageReference Include="OpenTelemetry.Api" Version="{VERSION}" />
   </ItemGroup>
 
 </Project>

--- a/test/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.IntegrationTests/Snapshots/aiagent-webapi/aiagent-webapi.aoai_ID_T.verified/aiagent-webapi/aiagent-webapi.csproj
+++ b/test/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.IntegrationTests/Snapshots/aiagent-webapi/aiagent-webapi.aoai_ID_T.verified/aiagent-webapi/aiagent-webapi.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Agents.AI.Hosting.OpenAI" Version="{VERSION}" />
     <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="{VERSION}" />
     <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="{VERSION}" />
+    <PackageReference Include="OpenTelemetry.Api" Version="{VERSION}" />
   </ItemGroup>
 
 </Project>

--- a/test/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.IntegrationTests/Snapshots/aiagent-webapi/aiagent-webapi.o.verified/aiagent-webapi/aiagent-webapi.csproj
+++ b/test/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.IntegrationTests/Snapshots/aiagent-webapi/aiagent-webapi.o.verified/aiagent-webapi/aiagent-webapi.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Agents.AI.Hosting" Version="{VERSION}" />
     <PackageReference Include="Microsoft.Agents.AI.Hosting.OpenAI" Version="{VERSION}" />
     <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="{VERSION}" />
+    <PackageReference Include="OpenTelemetry.Api" Version="{VERSION}" />
     <PackageReference Include="OllamaSharp" Version="{VERSION}" />
   </ItemGroup>
 

--- a/test/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.IntegrationTests/Snapshots/aiagent-webapi/aiagent-webapi.oai.verified/aiagent-webapi/aiagent-webapi.csproj
+++ b/test/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.IntegrationTests/Snapshots/aiagent-webapi/aiagent-webapi.oai.verified/aiagent-webapi/aiagent-webapi.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Agents.AI.Hosting.OpenAI" Version="{VERSION}" />
     <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="{VERSION}" />
     <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="{VERSION}" />
+    <PackageReference Include="OpenTelemetry.Api" Version="{VERSION}" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This addresses test failures in the project template integration tests caused by OpenTelemetry packages recently marked as vulnerable. This also updates the Agent Framework package versions used by the aiagent-webapi project template to get to the latest version of each of those packages. An explicit package reference to OpenTelemetry.Api is added to force that project template to use a non-vulnerable version of that package during package restore.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7491)