### PR TITLE
Add OpenAIRequestPolicies extension hook for MEAI OpenAI clients

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/Microsoft.Extensions.AI.OpenAI.json
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/Microsoft.Extensions.AI.OpenAI.json
@@ -1,5 +1,5 @@
 {
-  "Name": "Microsoft.Extensions.AI.OpenAI, Version=10.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Name": "Microsoft.Extensions.AI.OpenAI, Version=10.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
   "Types": [
     {
       "Type": "static class OpenAI.Assistants.MicrosoftExtensionsAIAssistantsExtensions",
@@ -205,6 +205,20 @@
       "Properties": [
         {
           "Member": "Microsoft.Extensions.AI.RealtimeSessionOptions? Microsoft.Extensions.AI.OpenAIRealtimeClientSession.Options { get; private set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.AI.OpenAIRequestPolicies",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.OpenAIRequestPolicies.OpenAIRequestPolicies();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void Microsoft.Extensions.AI.OpenAIRequestPolicies.AddPolicy(System.ClientModel.Primitives.PipelinePolicy policy, System.ClientModel.Primitives.PipelinePosition position = System.ClientModel.Primitives.PipelinePosition.PerCall);",
           "Stage": "Experimental"
         }
       ]

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -22,6 +22,7 @@ using OpenAI.Chat;
 #pragma warning disable CA1308 // Normalize strings to uppercase
 #pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 #pragma warning disable SA1204 // Static elements should appear before instance elements
+#pragma warning disable MEAI001 // OpenAIRequestPolicies is experimental
 
 namespace Microsoft.Extensions.AI;
 
@@ -55,6 +56,9 @@ internal sealed partial class OpenAIChatClient : IChatClient
     /// <summary>The underlying <see cref="ChatClient" />.</summary>
     private readonly ChatClient _chatClient;
 
+    /// <summary>Caller-registered policies applied to every <see cref="RequestOptions"/>.</summary>
+    private readonly OpenAIRequestPolicies _requestPolicies = new();
+
     /// <summary>Initializes a new instance of the <see cref="OpenAIChatClient"/> class for the specified <see cref="ChatClient"/>.</summary>
     /// <param name="chatClient">The underlying client.</param>
     /// <exception cref="ArgumentNullException"><paramref name="chatClient"/> is <see langword="null"/>.</exception>
@@ -76,6 +80,7 @@ internal sealed partial class OpenAIChatClient : IChatClient
             serviceKey is not null ? null :
             serviceType == typeof(ChatClientMetadata) ? _metadata :
             serviceType == typeof(ChatClient) ? _chatClient :
+            serviceType == typeof(OpenAIRequestPolicies) ? _requestPolicies :
             serviceType.IsInstanceOfType(this) ? this :
             null;
     }
@@ -94,7 +99,7 @@ internal sealed partial class OpenAIChatClient : IChatClient
 
         // Make the call to OpenAI.
         var task = _completeChatAsync is not null ?
-            _completeChatAsync(_chatClient, openAIChatMessages, openAIOptions, cancellationToken.ToRequestOptions(streaming: false)) :
+            _completeChatAsync(_chatClient, openAIChatMessages, openAIOptions, cancellationToken.ToRequestOptions(streaming: false, _requestPolicies)) :
             _chatClient.CompleteChatAsync(openAIChatMessages, openAIOptions, cancellationToken);
         var response = await task.ConfigureAwait(false);
 
@@ -115,7 +120,7 @@ internal sealed partial class OpenAIChatClient : IChatClient
 
         // Make the call to OpenAI.
         var chatCompletionUpdates = _completeChatStreamingAsync is not null ?
-            _completeChatStreamingAsync(_chatClient, openAIChatMessages, openAIOptions, cancellationToken.ToRequestOptions(streaming: true)) :
+            _completeChatStreamingAsync(_chatClient, openAIChatMessages, openAIOptions, cancellationToken.ToRequestOptions(streaming: true, _requestPolicies)) :
             _chatClient.CompleteChatStreamingAsync(openAIChatMessages, openAIOptions, cancellationToken);
 
         return FromOpenAIStreamingChatCompletionAsync(chatCompletionUpdates, openAIOptions, cancellationToken);

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIEmbeddingGenerator.cs
@@ -13,6 +13,7 @@ using Microsoft.Shared.Diagnostics;
 using OpenAI.Embeddings;
 
 #pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+#pragma warning disable MEAI001 // OpenAIRequestPolicies is experimental
 
 namespace Microsoft.Extensions.AI;
 
@@ -40,6 +41,9 @@ internal sealed class OpenAIEmbeddingGenerator : IEmbeddingGenerator<string, Emb
     /// <summary>The number of dimensions produced by the generator.</summary>
     private readonly int? _dimensions;
 
+    /// <summary>Caller-registered policies applied to every <see cref="RequestOptions"/>.</summary>
+    private readonly OpenAIRequestPolicies _requestPolicies = new();
+
     /// <summary>Initializes a new instance of the <see cref="OpenAIEmbeddingGenerator"/> class.</summary>
     /// <param name="embeddingClient">The underlying client.</param>
     /// <param name="defaultModelDimensions">The number of dimensions to generate in each embedding.</param>
@@ -66,7 +70,7 @@ internal sealed class OpenAIEmbeddingGenerator : IEmbeddingGenerator<string, Emb
         OpenAI.Embeddings.EmbeddingGenerationOptions? openAIOptions = ToOpenAIOptions(options);
 
         var t = _generateEmbeddingsAsync is not null ?
-            _generateEmbeddingsAsync(_embeddingClient, values, openAIOptions, cancellationToken.ToRequestOptions(streaming: false)) :
+            _generateEmbeddingsAsync(_embeddingClient, values, openAIOptions, cancellationToken.ToRequestOptions(streaming: false, _requestPolicies)) :
             _embeddingClient.GenerateEmbeddingsAsync(values, openAIOptions, cancellationToken);
         var embeddings = (await t.ConfigureAwait(false)).Value;
 
@@ -104,6 +108,7 @@ internal sealed class OpenAIEmbeddingGenerator : IEmbeddingGenerator<string, Emb
             serviceKey is not null ? null :
             serviceType == typeof(EmbeddingGeneratorMetadata) ? _metadata :
             serviceType == typeof(EmbeddingClient) ? _embeddingClient :
+            serviceType == typeof(OpenAIRequestPolicies) ? _requestPolicies :
             serviceType.IsInstanceOfType(this) ? this :
             null;
     }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIRequestPolicies.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIRequestPolicies.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>
+/// Provides an extension hook for adding <see cref="PipelinePolicy"/> instances to the
+/// <see cref="RequestOptions"/> built by Microsoft.Extensions.AI for every outbound OpenAI request
+/// made through the owning <c>IChatClient</c> or <c>IEmbeddingGenerator</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Retrieve the instance via <see cref="IChatClient.GetService(System.Type, object?)"/>
+/// (or the equivalent on other Microsoft.Extensions.AI client interfaces) using
+/// <see cref="OpenAIRequestPolicies"/> as the service type. The instance is per-client and
+/// reachable through any <c>ChatClientBuilder</c> decorator chain.
+/// </para>
+/// <para>
+/// Customer-registered policies are appended <em>after</em> Microsoft.Extensions.AI's own internal
+/// policies, so a policy that calls <c>message.Request.Headers.Set("User-Agent", ...)</c>
+/// replaces the existing value, while one that calls <c>Headers.Add(...)</c> stacks an
+/// additional value.
+/// </para>
+/// <para>
+/// Registration is intended for one-time configuration at startup, but is safe to call
+/// concurrently with in-flight requests.
+/// </para>
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.AIOpenAIRequestPolicies, UrlFormat = DiagnosticIds.UrlFormat)]
+public sealed class OpenAIRequestPolicies
+{
+    private static readonly Entry[] _empty = Array.Empty<Entry>();
+
+    private Entry[] _entries = _empty;
+
+    /// <summary>Initializes a new instance of the <see cref="OpenAIRequestPolicies"/> class.</summary>
+    public OpenAIRequestPolicies()
+    {
+    }
+
+    /// <summary>
+    /// Adds a <see cref="PipelinePolicy"/> to be applied to every <see cref="RequestOptions"/>
+    /// produced for outbound OpenAI requests by the owning Microsoft.Extensions.AI client.
+    /// </summary>
+    /// <param name="policy">The pipeline policy to register. Must not be <see langword="null"/>.</param>
+    /// <param name="position">
+    /// The position in the pipeline at which to place the policy. Defaults to
+    /// <see cref="PipelinePosition.PerCall"/>, which runs the policy once per logical request
+    /// (for example, to stamp a User-Agent or correlation header).
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="policy"/> is <see langword="null"/>.</exception>
+    public void AddPolicy(PipelinePolicy policy, PipelinePosition position = PipelinePosition.PerCall)
+    {
+        _ = Throw.IfNull(policy);
+
+        var newEntry = new Entry(policy, position);
+
+        // Lock-free append: copy-on-write with CAS retry.
+        while (true)
+        {
+            var current = Volatile.Read(ref _entries);
+            var updated = new Entry[current.Length + 1];
+            Array.Copy(current, updated, current.Length);
+            updated[current.Length] = newEntry;
+
+            if (Interlocked.CompareExchange(ref _entries, updated, current) == current)
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Applies all registered policies to the supplied <see cref="RequestOptions"/>.
+    /// Called by the Microsoft.Extensions.AI OpenAI clients after their own internal policies
+    /// have been registered.
+    /// </summary>
+    internal void ApplyTo(RequestOptions requestOptions)
+    {
+        var snapshot = Volatile.Read(ref _entries);
+        for (int i = 0; i < snapshot.Length; i++)
+        {
+            var entry = snapshot[i];
+            requestOptions.AddPolicy(entry.Policy, entry.Position);
+        }
+    }
+
+    private readonly struct Entry
+    {
+        public Entry(PipelinePolicy policy, PipelinePosition position)
+        {
+            Policy = policy;
+            Position = position;
+        }
+
+        public PipelinePolicy Policy { get; }
+        public PipelinePosition Position { get; }
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -24,6 +24,7 @@ using OpenAI.Responses;
 #pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 #pragma warning disable S3254 // Default parameter values should not be passed as arguments
 #pragma warning disable SA1204 // Static elements should appear before instance elements
+#pragma warning disable MEAI001 // OpenAIRequestPolicies is experimental
 
 namespace Microsoft.Extensions.AI;
 
@@ -59,6 +60,9 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
     /// <summary>The default model ID to use for the chat client.</summary>
     private readonly string? _defaultModelId;
 
+    /// <summary>Caller-registered policies applied to every <see cref="RequestOptions"/>.</summary>
+    private readonly OpenAIRequestPolicies _requestPolicies = new();
+
     /// <summary>Initializes a new instance of the <see cref="OpenAIResponsesChatClient"/> class for the specified <see cref="ResponsesClient"/>.</summary>
     /// <param name="responseClient">The underlying client.</param>
     /// <param name="defaultModelId">The default model ID to use for the chat client.</param>
@@ -82,6 +86,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
             serviceKey is not null ? null :
             serviceType == typeof(ChatClientMetadata) ? _metadata :
             serviceType == typeof(ResponsesClient) ? _responseClient :
+            serviceType == typeof(OpenAIRequestPolicies) ? _requestPolicies :
             serviceType.IsInstanceOfType(this) ? this :
             null;
     }
@@ -100,7 +105,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
         // Provided continuation token signals that an existing background response should be fetched.
         if (GetContinuationToken(messages, options) is { } token)
         {
-            var getTask = _responseClient.GetResponseAsync(token.ResponseId, include: null, stream: null, startingAfter: null, includeObfuscation: null, cancellationToken.ToRequestOptions(streaming: false));
+            var getTask = _responseClient.GetResponseAsync(token.ResponseId, include: null, stream: null, startingAfter: null, includeObfuscation: null, cancellationToken.ToRequestOptions(streaming: false, _requestPolicies));
             var response = (ResponseResult)await getTask.ConfigureAwait(false);
             return FromOpenAIResponse(response, openAIOptions, openAIConversationId);
         }
@@ -111,7 +116,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
         }
 
         // Make the call to the ResponsesClient.
-        var createTask = _responseClient.CreateResponseAsync((BinaryContent)openAIOptions, cancellationToken.ToRequestOptions(streaming: false));
+        var createTask = _responseClient.CreateResponseAsync((BinaryContent)openAIOptions, cancellationToken.ToRequestOptions(streaming: false, _requestPolicies));
         var openAIResponsesResult = (ResponseResult)await createTask.ConfigureAwait(false);
 
         // Convert the response to a ChatResponse.
@@ -330,7 +335,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
 
             Debug.Assert(_getResponseStreamingAsync is not null, $"Unable to find {nameof(_getResponseStreamingAsync)} method");
             IAsyncEnumerable<StreamingResponseUpdate> getUpdates = _getResponseStreamingAsync is not null ?
-                _getResponseStreamingAsync(_responseClient, getOptions, cancellationToken.ToRequestOptions(streaming: true)) :
+                _getResponseStreamingAsync(_responseClient, getOptions, cancellationToken.ToRequestOptions(streaming: true, _requestPolicies)) :
                 _responseClient.GetResponseStreamingAsync(getOptions, cancellationToken);
 
             return FromOpenAIStreamingResponseUpdatesAsync(getUpdates, openAIOptions, openAIConversationId, token.ResponseId, cancellationToken);
@@ -343,7 +348,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
 
         Debug.Assert(_createResponseStreamingAsync is not null, $"Unable to find {nameof(_createResponseStreamingAsync)} method");
         AsyncCollectionResult<StreamingResponseUpdate> createUpdates = _createResponseStreamingAsync is not null ?
-            _createResponseStreamingAsync(_responseClient, openAIOptions, cancellationToken.ToRequestOptions(streaming: true)) :
+            _createResponseStreamingAsync(_responseClient, openAIOptions, cancellationToken.ToRequestOptions(streaming: true, _requestPolicies)) :
             _responseClient.CreateResponseStreamingAsync(openAIOptions, cancellationToken);
 
         return FromOpenAIStreamingResponseUpdatesAsync(createUpdates, openAIOptions, openAIConversationId, cancellationToken: cancellationToken);

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/RequestOptionsExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/RequestOptionsExtensions.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 #pragma warning disable CA1307 // Specify StringComparison
+#pragma warning disable MEAI001 // OpenAIRequestPolicies is experimental
 
 namespace Microsoft.Extensions.AI;
 
@@ -15,7 +16,15 @@ namespace Microsoft.Extensions.AI;
 internal static class RequestOptionsExtensions
 {
     /// <summary>Creates a <see cref="RequestOptions"/> configured for use with OpenAI.</summary>
-    public static RequestOptions ToRequestOptions(this CancellationToken cancellationToken, bool streaming)
+    public static RequestOptions ToRequestOptions(this CancellationToken cancellationToken, bool streaming) =>
+        ToRequestOptions(cancellationToken, streaming, policies: null);
+
+    /// <summary>
+    /// Creates a <see cref="RequestOptions"/> configured for use with OpenAI, applying any
+    /// caller-registered <see cref="OpenAIRequestPolicies"/> after Microsoft.Extensions.AI's own
+    /// internal policies.
+    /// </summary>
+    public static RequestOptions ToRequestOptions(this CancellationToken cancellationToken, bool streaming, OpenAIRequestPolicies? policies)
     {
         RequestOptions requestOptions = new()
         {
@@ -24,6 +33,8 @@ internal static class RequestOptionsExtensions
         };
 
         requestOptions.AddPolicy(MeaiUserAgentPolicy.Instance, PipelinePosition.PerCall);
+
+        policies?.ApplyTo(requestOptions);
 
         return requestOptions;
     }

--- a/src/Shared/DiagnosticIds/DiagnosticIds.cs
+++ b/src/Shared/DiagnosticIds/DiagnosticIds.cs
@@ -61,6 +61,7 @@ internal static class DiagnosticIds
         internal const string AIToolSearch = AIExperiments;
         internal const string AIRealTime = AIExperiments;
         internal const string AIFiles = AIExperiments;
+        internal const string AIOpenAIRequestPolicies = AIExperiments;
 
         // These diagnostic IDs are defined by the OpenAI package for its experimental APIs.
         // We use the same IDs so consumers do not need to suppress additional diagnostics

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIRequestPoliciesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIRequestPoliciesTests.cs
@@ -1,0 +1,213 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using OpenAI;
+using Xunit;
+
+#pragma warning disable OPENAI001 // Experimental OpenAI APIs
+#pragma warning disable MEAI001  // OpenAIRequestPolicies is experimental
+
+namespace Microsoft.Extensions.AI;
+
+public class OpenAIRequestPoliciesTests
+{
+    [Fact]
+    public void AddPolicy_NullPolicy_Throws()
+    {
+        var policies = new OpenAIRequestPolicies();
+        Assert.Throws<ArgumentNullException>("policy", () => policies.AddPolicy(null!));
+    }
+
+    [Fact]
+    public void GetService_OpenAIChatClient_ReturnsStableInstance()
+    {
+        IChatClient client = NewChatClient();
+
+        var first = client.GetService<OpenAIRequestPolicies>();
+        var second = client.GetService<OpenAIRequestPolicies>();
+
+        Assert.NotNull(first);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetService_OpenAIResponseClient_ReturnsInstance()
+    {
+        IChatClient client = new OpenAIClient(new ApiKeyCredential("k")).GetResponsesClient().AsIChatClient("m");
+        Assert.NotNull(client.GetService<OpenAIRequestPolicies>());
+    }
+
+    [Fact]
+    public void GetService_OpenAIEmbeddingGenerator_ReturnsInstance()
+    {
+        IEmbeddingGenerator<string, Embedding<float>> generator =
+            new OpenAIClient(new ApiKeyCredential("k")).GetEmbeddingClient("m").AsIEmbeddingGenerator();
+
+        Assert.NotNull(generator.GetService<OpenAIRequestPolicies>());
+    }
+
+    [Fact]
+    public void GetService_PerClientIsolation()
+    {
+        var openAi = new OpenAIClient(new ApiKeyCredential("k"));
+
+        var policiesA = openAi.GetChatClient("m").AsIChatClient().GetService<OpenAIRequestPolicies>();
+        var policiesB = openAi.GetChatClient("m").AsIChatClient().GetService<OpenAIRequestPolicies>();
+
+        Assert.NotSame(policiesA, policiesB);
+    }
+
+    [Fact]
+    public void GetService_ReachableThroughDecoratorChain()
+    {
+        IChatClient inner = NewChatClient();
+        var innerPolicies = inner.GetService<OpenAIRequestPolicies>();
+
+        using IChatClient pipeline = inner
+            .AsBuilder()
+            .UseFunctionInvocation()
+            .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
+            .Build();
+
+        Assert.Same(innerPolicies, pipeline.GetService<OpenAIRequestPolicies>());
+    }
+
+    [Fact]
+    public async Task AddPolicy_CustomUserAgent_ReplacesMeaiHeader()
+    {
+        using var handler = new ThrowUserAgentExceptionHandler();
+        using var http = new HttpClient(handler);
+        IChatClient client = NewChatClient(http);
+
+        client.GetService<OpenAIRequestPolicies>()!.AddPolicy(new SetUserAgentPolicy("my-sdk/1.0"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetResponseAsync("hi"));
+
+        // Customer policy ran after MEAI's UA policy and replaced the value.
+        Assert.Contains("my-sdk/1.0", ex.Message);
+        Assert.DoesNotContain("MEAI", ex.Message);
+    }
+
+    [Fact]
+    public async Task AddPolicy_CustomHeaderAdd_StacksWithMeaiUserAgent()
+    {
+        using var handler = new ThrowUserAgentExceptionHandler();
+        using var http = new HttpClient(handler);
+        IChatClient client = NewChatClient(http);
+
+        client.GetService<OpenAIRequestPolicies>()!.AddPolicy(new AddUserAgentPolicy("extra-sdk/9.9"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetResponseAsync("hi"));
+
+        Assert.Contains("MEAI", ex.Message);
+        Assert.Contains("extra-sdk/9.9", ex.Message);
+    }
+
+    [Fact]
+    public async Task NoPolicyRegistered_MeaiUserAgentStillEmitted()
+    {
+        using var handler = new ThrowUserAgentExceptionHandler();
+        using var http = new HttpClient(handler);
+        IChatClient client = NewChatClient(http);
+
+        Assert.NotNull(client.GetService<OpenAIRequestPolicies>()); // touch but don't register
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetResponseAsync("hi"));
+
+        Assert.Contains("MEAI", ex.Message);
+    }
+
+    [Fact]
+    public async Task AddPolicy_Concurrent_AllPoliciesRetained()
+    {
+        var policies = new OpenAIRequestPolicies();
+
+        const int Count = 200;
+        await Task.WhenAll(Enumerable.Range(0, Count).Select(i =>
+            Task.Run(() => policies.AddPolicy(new NoopPolicy()))));
+
+        // Verify nothing was lost across CAS races.
+        var entries = (Array)typeof(OpenAIRequestPolicies)
+            .GetField("_entries", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(policies)!;
+        Assert.Equal(Count, entries.Length);
+    }
+
+    private static IChatClient NewChatClient(HttpClient? http = null)
+    {
+        OpenAIClientOptions options = http is null
+            ? new OpenAIClientOptions()
+            : new OpenAIClientOptions { Transport = new HttpClientPipelineTransport(http) };
+
+        return new OpenAIClient(new ApiKeyCredential("k"), options)
+            .GetChatClient("gpt-4o-mini")
+            .AsIChatClient();
+    }
+
+    private sealed class NoopPolicy : PipelinePolicy
+    {
+        public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+        {
+            ProcessNext(message, pipeline, currentIndex);
+        }
+
+        public override ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+        {
+            return ProcessNextAsync(message, pipeline, currentIndex);
+        }
+    }
+
+    private sealed class SetUserAgentPolicy : PipelinePolicy
+    {
+        private readonly string _value;
+
+        public SetUserAgentPolicy(string value)
+        {
+            _value = value;
+        }
+
+        public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+        {
+            message.Request.Headers.Set("User-Agent", _value);
+            ProcessNext(message, pipeline, currentIndex);
+        }
+
+        public override ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+        {
+            message.Request.Headers.Set("User-Agent", _value);
+            return ProcessNextAsync(message, pipeline, currentIndex);
+        }
+    }
+
+    private sealed class AddUserAgentPolicy : PipelinePolicy
+    {
+        private readonly string _value;
+
+        public AddUserAgentPolicy(string value)
+        {
+            _value = value;
+        }
+
+        public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+        {
+            message.Request.Headers.Add("User-Agent", _value);
+            ProcessNext(message, pipeline, currentIndex);
+        }
+
+        public override ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+        {
+            message.Request.Headers.Add("User-Agent", _value);
+            return ProcessNextAsync(message, pipeline, currentIndex);
+        }
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIRequestPoliciesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIRequestPoliciesTests.cs
@@ -85,46 +85,48 @@ public class OpenAIRequestPoliciesTests
     [Fact]
     public async Task AddPolicy_CustomUserAgent_ReplacesMeaiHeader()
     {
-        using var handler = new ThrowUserAgentExceptionHandler();
+        using var handler = new CapturingUserAgentHandler();
         using var http = new HttpClient(handler);
         IChatClient client = NewChatClient(http);
 
         client.GetService<OpenAIRequestPolicies>()!.AddPolicy(new SetUserAgentPolicy("my-sdk/1.0"));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetResponseAsync("hi"));
+        await Assert.ThrowsAnyAsync<Exception>(() => client.GetResponseAsync("hi"));
 
         // Customer policy ran after MEAI's UA policy and replaced the value.
-        Assert.Contains("my-sdk/1.0", ex.Message);
-        Assert.DoesNotContain("MEAI", ex.Message);
+        Assert.NotNull(handler.CapturedUserAgent);
+        Assert.Equal("my-sdk/1.0", handler.CapturedUserAgent);
     }
 
     [Fact]
     public async Task AddPolicy_CustomHeaderAdd_StacksWithMeaiUserAgent()
     {
-        using var handler = new ThrowUserAgentExceptionHandler();
+        using var handler = new CapturingUserAgentHandler();
         using var http = new HttpClient(handler);
         IChatClient client = NewChatClient(http);
 
         client.GetService<OpenAIRequestPolicies>()!.AddPolicy(new AddUserAgentPolicy("extra-sdk/9.9"));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetResponseAsync("hi"));
+        await Assert.ThrowsAnyAsync<Exception>(() => client.GetResponseAsync("hi"));
 
-        Assert.Contains("MEAI", ex.Message);
-        Assert.Contains("extra-sdk/9.9", ex.Message);
+        Assert.NotNull(handler.CapturedUserAgent);
+        Assert.Contains("MEAI", handler.CapturedUserAgent);
+        Assert.Contains("extra-sdk/9.9", handler.CapturedUserAgent);
     }
 
     [Fact]
     public async Task NoPolicyRegistered_MeaiUserAgentStillEmitted()
     {
-        using var handler = new ThrowUserAgentExceptionHandler();
+        using var handler = new CapturingUserAgentHandler();
         using var http = new HttpClient(handler);
         IChatClient client = NewChatClient(http);
 
         Assert.NotNull(client.GetService<OpenAIRequestPolicies>()); // touch but don't register
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetResponseAsync("hi"));
+        await Assert.ThrowsAnyAsync<Exception>(() => client.GetResponseAsync("hi"));
 
-        Assert.Contains("MEAI", ex.Message);
+        Assert.NotNull(handler.CapturedUserAgent);
+        Assert.Contains("MEAI", handler.CapturedUserAgent);
     }
 
     [Fact]
@@ -152,6 +154,20 @@ public class OpenAIRequestPoliciesTests
         return new OpenAIClient(new ApiKeyCredential("k"), options)
             .GetChatClient("gpt-4o-mini")
             .AsIChatClient();
+    }
+
+    private sealed class CapturingUserAgentHandler : HttpMessageHandler
+    {
+        public string? CapturedUserAgent { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        {
+            // Capture the User-Agent values exactly as they appear on the outgoing request.
+            CapturedUserAgent = request.Headers.UserAgent.ToString();
+
+            // Short-circuit; the test only cares about what was sent.
+            throw new InvalidOperationException("captured");
+        }
     }
 
     private sealed class NoopPolicy : PipelinePolicy


### PR DESCRIPTION
## Summary

Adds a new experimental `OpenAIRequestPolicies` type that downstream SDKs can use to append `System.ClientModel.PipelinePolicy` instances to the `RequestOptions` built by `Microsoft.Extensions.AI` for every outbound OpenAI request. The motivating scenario: an SDK author is handed an `IChatClient` constructed by a customer from an `OpenAIClient` they do not own, and needs to brand the outgoing `User-Agent` header (or attach correlation metadata) without mutating the customer's pipeline.

## Surface

The type is reachable via `GetService<T>` on the three MEAI OpenAI clients that already funnel through the `ToRequestOptions` chokepoint (`OpenAIChatClient`, `OpenAIEmbeddingGenerator`, `OpenAIResponsesChatClient`):

```csharp
[Experimental(""MEAI001"")]
public sealed class OpenAIRequestPolicies
{
    public void AddPolicy(PipelinePolicy policy, PipelinePosition position = PipelinePosition.PerCall);
}

// Usage:
chatClient.GetService<OpenAIRequestPolicies>()?.AddPolicy(myUserAgentPolicy);
```

Customer policies run **after** MEAI's internal User-Agent policy, so `message.Request.Headers.Set(""User-Agent"", ...)` replaces the value and `Headers.Add(...)` stacks an additional value, with predictable last-writer-wins semantics. The instance is per client (no shared state, no weak tables) and reachable through any `ChatClientBuilder` decorator chain via the standard `GetService` traversal.

## Design choices

* **Append-only**: the surface is a single `AddPolicy` method. `Remove` and `Clear` are intentionally deferred until a real consumer asks; the experimental attribute keeps that door open.
* **Locked-down access**: callers cannot reach the underlying `RequestOptions`, so `CancellationToken`, `BufferResponse`, and MEAI's own User-Agent policy stay safe from accidental tampering.
* **Storage**: lock-free reads on a copy-on-write `T[]` swapped via `Interlocked.CompareExchange`. No `System.Collections.Immutable` dependency (would not flow through netstandard2.0 / net462).
* **Diagnostic ID**: reuses the generic `MEAI001` (`AIExperiments`) alias rather than `OPENAI001`. `OPENAI001` is reserved for surfaces that wrap the OpenAI SDK's experimental APIs; this hook is generic MEAI extensibility.
* **Scope**: limited to the three clients with the existing `ToRequestOptions` chokepoint. The other OpenAI MEAI clients (Realtime, S2T, T2S, Image, Assistants, HostedFile) bypass `ToRequestOptions` today, do not currently receive MEAI's User-Agent either, and would each require their own refactor (or a websocket-specific story for Realtime). Out of scope here; revisit if asked.

## Why not configure the underlying `OpenAIClient`?

The OpenAI .NET SDK already supports `OpenAIClientOptions.AddPolicy` at construction time. That is the right path when you control construction. This PR addresses the case where you do not, the SDK author receives only an `IChatClient` and must add behavior without reaching into the customer's pipeline configuration.

## Tests

New `OpenAIRequestPoliciesTests` (10 tests, all passing on net462 / net8 / net9 / net10):

* `AddPolicy(null)` throws `ArgumentNullException`.
* `GetService<OpenAIRequestPolicies>()` returns a stable per-client instance on each of the three wired client types.
* Two MEAI client wrappers around the same `OpenAIClient` get distinct `OpenAIRequestPolicies` instances.
* The instance is reachable through a `ChatClientBuilder` decorator chain.
* A custom policy that calls `Headers.Set(""User-Agent"", ...)` replaces MEAI's value (proves ordering: customer-after-MEAI).
* A custom policy that calls `Headers.Add(""User-Agent"", ...)` stacks alongside MEAI's value.
* When no policy is registered, MEAI's own User-Agent is still emitted (regression guard).
* 200 concurrent `AddPolicy` invocations retain all entries (CAS-loop concurrency smoke).

Existing 356 `Microsoft.Extensions.AI.OpenAI.Tests` continue to pass.

## API baseline

`Microsoft.Extensions.AI.OpenAI.json` regenerated via `./scripts/MakeApiBaselines.ps1`. The version line moves from `10.5.0.0` to `10.6.0.0` because the previous baseline predates a repo-wide `MinorVersion` bump in `eng/Versions.props`; the sibling `Abstractions.json` baseline was already at `10.6.0.0`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7495)