### PR TITLE
Fix Namespace gaps in HostedToolSearchTool

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -2716,6 +2716,10 @@
         {
           "Member": "string? Microsoft.Extensions.AI.HostedToolSearchTool.Namespace { get; set; }",
           "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AI.HostedToolSearchTool.NamespaceDescription { get; set; }",
+          "Stage": "Experimental"
         }
       ]
     },

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/HostedToolSearchTool.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Tools/HostedToolSearchTool.cs
@@ -72,6 +72,23 @@ public class HostedToolSearchTool : AITool
     /// When <see langword="null"/> (the default), deferred tools are sent as top-level tools
     /// with <c>defer_loading</c> set individually.
     /// </para>
+    /// <para>
+    /// Use <see cref="NamespaceDescription"/> to supply a description for the namespace.
+    /// </para>
     /// </remarks>
     public string? Namespace { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description for the namespace produced when <see cref="Namespace"/> is specified.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Setting this property alone does not create a namespace.
+    /// </para>
+    /// <para>
+    /// When <see langword="null"/>, no description is emitted on the namespace. The underlying provider
+    /// may require a description when a namespace is supplied.
+    /// </para>
+    /// </remarks>
+    public string? NamespaceDescription { get; set; }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -983,11 +983,24 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
         {
             ToolSearchLookup toolSearchLookup = ToolSearchLookup.Create(tools);
             Dictionary<ToolSearchLookup.Namespace, List<ResponseTool>>? namespaceGroups = null;
+            bool toolSearchAdded = false;
 
             foreach (AITool tool in tools)
             {
                 if (ToResponseTool(tool, options, toolSearchLookup) is { } responseTool)
                 {
+                    // Avoid sending multiple tool_search entries when callers supply more than one
+                    // HostedToolSearchTool; the OpenAI Responses API only accepts one.
+                    if (tool is HostedToolSearchTool)
+                    {
+                        if (toolSearchAdded)
+                        {
+                            continue;
+                        }
+
+                        toolSearchAdded = true;
+                    }
+
                     // When a namespaced HostedToolSearchTool claims this deferred tool,
                     // collect it for later wrapping in a namespace container.
                     string? responseToolName = responseTool is FunctionTool ft ? ft.FunctionName

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -1161,20 +1161,37 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
         public Namespace? GetNamespace(string toolName) =>
             _namespacedToolNames.TryGetValue(toolName, out Namespace? ns) ? ns : null;
 
-        // First-writer-wins per namespace name: the first HostedToolSearchTool to claim a given
-        // namespace name supplies the description used for that namespace's wrapper.
+        // Prefers the first non-empty description supplied for a given namespace name; later
+        // HostedToolSearchTool instances may upgrade a previously-empty description but cannot
+        // overwrite one that's already set.
         private static Namespace GetOrCreateNamespace(Dictionary<string, Namespace> namespacesByName, string name, string? description)
         {
             if (!namespacesByName.TryGetValue(name, out Namespace? existing))
             {
-                existing = new Namespace(name, description);
+                existing = new Namespace(name) { Description = description };
                 namespacesByName[name] = existing;
+            }
+            else if (string.IsNullOrEmpty(existing.Description))
+            {
+                existing.Description = description;
             }
 
             return existing;
         }
 
-        internal sealed record Namespace(string Name, string? Description);
+        // A class (not a record) so that all entries in _namespacedToolNames sharing a namespace
+        // name reference the same instance; updating Description in place propagates to every
+        // tool already grouped under it.
+        internal sealed class Namespace
+        {
+            public Namespace(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; }
+            public string? Description { get; set; }
+        }
     }
 
     internal static ResponseTextFormat? ToOpenAIResponseTextFormat(ChatResponseFormat? format, ChatOptions? options = null) =>

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -869,7 +869,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
     /// Builds a <c>{"type":"namespace"}</c> <see cref="ResponseTool"/> from a name and set of tools.
     /// The OpenAI .NET SDK doesn't expose a NamespaceTool type, so we construct the JSON manually.
     /// </summary>
-    internal static ResponseTool ToNamespaceResponseTool(string name, IEnumerable<ResponseTool> namespacedTools)
+    internal static ResponseTool ToNamespaceResponseTool(string name, string? description, IEnumerable<ResponseTool> namespacedTools)
     {
         using var stream = new System.IO.MemoryStream();
         using (var writer = new Utf8JsonWriter(stream))
@@ -877,6 +877,11 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
             writer.WriteStartObject();
             writer.WriteString("type"u8, "namespace"u8);
             writer.WriteString("name"u8, name);
+
+            if (!string.IsNullOrEmpty(description))
+            {
+                writer.WriteString("description"u8, description);
+            }
 
             writer.WriteStartArray("tools"u8);
             foreach (var namespacedTool in namespacedTools)
@@ -977,7 +982,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
         if (options.Tools is { Count: > 0 } tools)
         {
             ToolSearchLookup toolSearchLookup = ToolSearchLookup.Create(tools);
-            Dictionary<string, List<ResponseTool>>? namespaceGroups = null;
+            Dictionary<ToolSearchLookup.Namespace, List<ResponseTool>>? namespaceGroups = null;
 
             foreach (AITool tool in tools)
             {
@@ -992,7 +997,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                     if (responseToolName is not null
                         && toolSearchLookup.GetNamespace(responseToolName) is { } ns)
                     {
-                        namespaceGroups ??= new(StringComparer.Ordinal);
+                        namespaceGroups ??= new();
                         if (!namespaceGroups.TryGetValue(ns, out var group))
                         {
                             group = new();
@@ -1009,9 +1014,9 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
 
             if (namespaceGroups is not null)
             {
-                foreach (KeyValuePair<string, List<ResponseTool>> kvp in namespaceGroups)
+                foreach (KeyValuePair<ToolSearchLookup.Namespace, List<ResponseTool>> kvp in namespaceGroups)
                 {
-                    result.Tools.Add(ToNamespaceResponseTool(kvp.Key, kvp.Value));
+                    result.Tools.Add(ToNamespaceResponseTool(kvp.Key.Name, kvp.Key.Description, kvp.Value));
                 }
             }
 
@@ -1055,9 +1060,9 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
         private static readonly ToolSearchLookup _empty = new(deferAll: false, deferredToolNames: [], namespacedToolNames: []);
         private readonly bool _deferAll;
         private readonly HashSet<string> _deferredToolNames;
-        private readonly Dictionary<string, string> _namespacedToolNames;
+        private readonly Dictionary<string, Namespace> _namespacedToolNames;
 
-        private ToolSearchLookup(bool deferAll, HashSet<string> deferredToolNames, Dictionary<string, string> namespacedToolNames)
+        private ToolSearchLookup(bool deferAll, HashSet<string> deferredToolNames, Dictionary<string, Namespace> namespacedToolNames)
         {
             _deferAll = deferAll;
             _deferredToolNames = deferredToolNames;
@@ -1089,7 +1094,8 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
 
             bool deferAll = false;
             HashSet<string> deferredToolNames = new(StringComparer.Ordinal);
-            Dictionary<string, string> namespacedToolNames = new(StringComparer.Ordinal);
+            Dictionary<string, Namespace> namespacedToolNames = new(StringComparer.Ordinal);
+            Dictionary<string, Namespace> namespacesByName = new(StringComparer.Ordinal);
             HashSet<string> unclaimedToolNames = new(functionAndMcpToolNames, StringComparer.Ordinal);
 
             foreach (AITool tool in tools)
@@ -1104,8 +1110,9 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                     deferAll = true;
                     deferredToolNames.UnionWith(functionAndMcpToolNames);
 
-                    if (toolSearch.Namespace is { } ns && unclaimedToolNames.Count > 0)
+                    if (toolSearch.Namespace is { } nsName && unclaimedToolNames.Count > 0)
                     {
+                        Namespace ns = GetOrCreateNamespace(namespacesByName, nsName, toolSearch.NamespaceDescription);
                         foreach (string toolName in unclaimedToolNames)
                         {
                             namespacedToolNames[toolName] = ns;
@@ -1125,9 +1132,9 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                     }
 
                     _ = deferredToolNames.Add(deferredTool);
-                    if (toolSearch.Namespace is { } ns && unclaimedToolNames.Remove(deferredTool))
+                    if (toolSearch.Namespace is { } nsName && unclaimedToolNames.Remove(deferredTool))
                     {
-                        namespacedToolNames[deferredTool] = ns;
+                        namespacedToolNames[deferredTool] = GetOrCreateNamespace(namespacesByName, nsName, toolSearch.NamespaceDescription);
                     }
                 }
             }
@@ -1138,8 +1145,23 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
         public bool IsDeferred(string toolName) =>
             _deferAll || _deferredToolNames.Contains(toolName);
 
-        public string? GetNamespace(string toolName) =>
-            _namespacedToolNames.TryGetValue(toolName, out string? ns) ? ns : null;
+        public Namespace? GetNamespace(string toolName) =>
+            _namespacedToolNames.TryGetValue(toolName, out Namespace? ns) ? ns : null;
+
+        // First-writer-wins per namespace name: the first HostedToolSearchTool to claim a given
+        // namespace name supplies the description used for that namespace's wrapper.
+        private static Namespace GetOrCreateNamespace(Dictionary<string, Namespace> namespacesByName, string name, string? description)
+        {
+            if (!namespacesByName.TryGetValue(name, out Namespace? existing))
+            {
+                existing = new Namespace(name, description);
+                namespacesByName[name] = existing;
+            }
+
+            return existing;
+        }
+
+        internal sealed record Namespace(string Name, string? Description);
     }
 
     internal static ResponseTextFormat? ToOpenAIResponseTextFormat(ChatResponseFormat? format, ChatOptions? options = null) =>

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/HostedToolSearchToolTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Tools/HostedToolSearchToolTests.cs
@@ -18,6 +18,7 @@ public class HostedToolSearchToolTests
         Assert.Equal(tool.Name, tool.ToString());
         Assert.Null(tool.DeferredTools);
         Assert.Null(tool.Namespace);
+        Assert.Null(tool.NamespaceDescription);
     }
 
     [Fact]
@@ -68,5 +69,23 @@ public class HostedToolSearchToolTests
     {
         var tool = new HostedToolSearchTool();
         Assert.Null(tool.Namespace);
+    }
+
+    [Fact]
+    public void NamespaceDescription_Roundtrips()
+    {
+        var tool = new HostedToolSearchTool
+        {
+            NamespaceDescription = "Tools for managing my data."
+        };
+
+        Assert.Equal("Tools for managing my data.", tool.NamespaceDescription);
+    }
+
+    [Fact]
+    public void NamespaceDescription_DefaultsToNull()
+    {
+        var tool = new HostedToolSearchTool();
+        Assert.Null(tool.NamespaceDescription);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
@@ -969,4 +969,49 @@ public class OpenAIResponseClientIntegrationTests : ChatClientIntegrationTests
                     ],
                 }));
     }
+
+    [ConditionalFact]
+    public async Task UseToolSearch_NamespaceWithDescription_RoundTrips()
+    {
+        SkipIfNotEnabled();
+
+        if (TestRunnerConfiguration.Instance["OpenAI:ChatModel"]?.StartsWith("gpt-5.4", StringComparison.OrdinalIgnoreCase) is not true)
+        {
+            throw new SkipTestException("Tool search requires gpt-5.4 or later.");
+        }
+
+        AIFunction getWeather = AIFunctionFactory.Create(() => "Sunny, 72°F", "GetWeather", "Gets the current weather.");
+        AIFunction getTime = AIFunctionFactory.Create(() => "3:00 PM", "GetTime", "Gets the current time.");
+
+        using var client = new FunctionInvokingChatClient(ChatClient);
+        var response = await client.GetResponseAsync(
+            "What's the weather like? Just respond with the weather info, nothing else.",
+            new()
+            {
+                Tools =
+                [
+                    new HostedToolSearchTool
+                    {
+                        Namespace = "weather_and_time",
+                        NamespaceDescription = "Tools for getting current weather and time.",
+                        DeferredTools = ["GetWeather", "GetTime"],
+                    },
+                    getWeather,
+                    getTime,
+                ],
+            });
+
+        Assert.NotNull(response);
+        Assert.NotEmpty(response.Text);
+
+        // Verify tool_search response items occurred (the namespace wrapper must have been
+        // accepted by the service for tool search to fire).
+        var rawJsons = response.Messages
+            .SelectMany(m => m.Contents)
+            .Where(c => c.RawRepresentation is ResponseItem)
+            .Select(c => ModelReaderWriter.Write((ResponseItem)c.RawRepresentation!, ModelReaderWriterOptions.Json).ToString())
+            .ToList();
+        Assert.Contains(rawJsons, json => json.Contains("\"type\":\"tool_search_call\"") || json.Contains("\"type\": \"tool_search_call\""));
+        Assert.Contains(rawJsons, json => json.Contains("\"type\":\"tool_search_output\"") || json.Contains("\"type\": \"tool_search_output\""));
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientIntegrationTests.cs
@@ -1014,4 +1014,57 @@ public class OpenAIResponseClientIntegrationTests : ChatClientIntegrationTests
         Assert.Contains(rawJsons, json => json.Contains("\"type\":\"tool_search_call\"") || json.Contains("\"type\": \"tool_search_call\""));
         Assert.Contains(rawJsons, json => json.Contains("\"type\":\"tool_search_output\"") || json.Contains("\"type\": \"tool_search_output\""));
     }
+
+    [ConditionalFact]
+    public async Task UseToolSearch_TwoNamespacesWithDescriptions_RoundTrips()
+    {
+        SkipIfNotEnabled();
+
+        if (TestRunnerConfiguration.Instance["OpenAI:ChatModel"]?.StartsWith("gpt-5.4", StringComparison.OrdinalIgnoreCase) is not true)
+        {
+            throw new SkipTestException("Tool search requires gpt-5.4 or later.");
+        }
+
+        AIFunction getWeather = AIFunctionFactory.Create(() => "Sunny, 72°F", "GetWeather", "Gets the current weather.");
+        AIFunction getTime = AIFunctionFactory.Create(() => "3:00 PM", "GetTime", "Gets the current time.");
+        AIFunction getCustomer = AIFunctionFactory.Create((string id) => $"Customer {id}", "GetCustomer", "Gets a customer by id.");
+
+        using var client = new FunctionInvokingChatClient(ChatClient);
+        var response = await client.GetResponseAsync(
+            "What's the weather like? Just respond with the weather info, nothing else.",
+            new()
+            {
+                Tools =
+                [
+                    new HostedToolSearchTool
+                    {
+                        Namespace = "weather_and_time",
+                        NamespaceDescription = "Tools for getting current weather and time.",
+                        DeferredTools = ["GetWeather", "GetTime"],
+                    },
+                    new HostedToolSearchTool
+                    {
+                        Namespace = "crm",
+                        NamespaceDescription = "Customer relationship management tools.",
+                        DeferredTools = ["GetCustomer"],
+                    },
+                    getWeather,
+                    getTime,
+                    getCustomer,
+                ],
+            });
+
+        Assert.NotNull(response);
+        Assert.NotEmpty(response.Text);
+
+        // Verify tool_search response items occurred (both namespace wrappers must have been
+        // accepted by the service for tool search to fire).
+        var rawJsons = response.Messages
+            .SelectMany(m => m.Contents)
+            .Where(c => c.RawRepresentation is ResponseItem)
+            .Select(c => ModelReaderWriter.Write((ResponseItem)c.RawRepresentation!, ModelReaderWriterOptions.Json).ToString())
+            .ToList();
+        Assert.Contains(rawJsons, json => json.Contains("\"type\":\"tool_search_call\"") || json.Contains("\"type\": \"tool_search_call\""));
+        Assert.Contains(rawJsons, json => json.Contains("\"type\":\"tool_search_output\"") || json.Contains("\"type\": \"tool_search_output\""));
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -7738,9 +7738,6 @@ public class OpenAIResponseClientTests
                         "type": "tool_search"
                     },
                     {
-                        "type": "tool_search"
-                    },
-                    {
                         "type": "namespace",
                         "name": "crm",
                         "tools": [
@@ -7847,9 +7844,6 @@ public class OpenAIResponseClientTests
                         "type": "tool_search"
                     },
                     {
-                        "type": "tool_search"
-                    },
-                    {
                         "type": "namespace",
                         "name": "crm",
                         "tools": [
@@ -7946,9 +7940,6 @@ public class OpenAIResponseClientTests
                     }
                 ],
                 "tools": [
-                    {
-                        "type": "tool_search"
-                    },
                     {
                         "type": "tool_search"
                     },
@@ -8428,9 +8419,6 @@ public class OpenAIResponseClientTests
                     }
                 ],
                 "tools": [
-                    {
-                        "type": "tool_search"
-                    },
                     {
                         "type": "tool_search"
                     },

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -8193,4 +8193,333 @@ public class OpenAIResponseClientTests
         Assert.Equal("Hello!", response.Text);
     }
 
+    [Fact]
+    public async Task ToolSearchTool_NamespaceWithDescription_NonStreaming()
+    {
+        const string Input = """
+            {
+                "model": "gpt-5.4-mini",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "hello"
+                            }
+                        ]
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "tool_search"
+                    },
+                    {
+                        "type": "function",
+                        "name": "ImportantTool",
+                        "description": "An important tool.",
+                        "parameters": {
+                            "type": "object",
+                            "required": [],
+                            "properties": {},
+                            "additionalProperties": false
+                        },
+                        "strict": true
+                    },
+                    {
+                        "type": "namespace",
+                        "name": "crm",
+                        "description": "Customer relationship management tools.",
+                        "tools": [
+                            {
+                                "type": "function",
+                                "name": "GetCustomer",
+                                "description": "Gets a customer.",
+                                "parameters": {
+                                    "type": "object",
+                                    "required": [],
+                                    "properties": {},
+                                    "additionalProperties": false
+                                },
+                                "strict": true,
+                                "defer_loading": true
+                            },
+                            {
+                                "type": "function",
+                                "name": "ListOrders",
+                                "description": "Lists orders.",
+                                "parameters": {
+                                    "type": "object",
+                                    "required": [],
+                                    "properties": {},
+                                    "additionalProperties": false
+                                },
+                                "strict": true,
+                                "defer_loading": true
+                            }
+                        ]
+                    }
+                ]
+            }
+            """;
+
+        const string Output = """
+            {
+              "id": "resp_001",
+              "object": "response",
+              "created_at": 1741892091,
+              "status": "completed",
+              "model": "gpt-5.4-mini",
+              "output": [
+                {
+                  "type": "message",
+                  "id": "msg_001",
+                  "status": "completed",
+                  "role": "assistant",
+                  "content": [{"type": "output_text", "text": "Hello!", "annotations": []}]
+                }
+              ]
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-5.4-mini");
+
+        var getCustomer = AIFunctionFactory.Create(() => 42, "GetCustomer", "Gets a customer.");
+        var listOrders = AIFunctionFactory.Create(() => 42, "ListOrders", "Lists orders.");
+        var importantTool = AIFunctionFactory.Create(() => 42, "ImportantTool", "An important tool.");
+
+        var response = await client.GetResponseAsync("hello", new()
+        {
+            Tools =
+            [
+                new HostedToolSearchTool
+                {
+                    Namespace = "crm",
+                    NamespaceDescription = "Customer relationship management tools.",
+                    DeferredTools = ["GetCustomer", "ListOrders"],
+                },
+                getCustomer,
+                listOrders,
+                importantTool,
+            ],
+            AdditionalProperties = new() { ["strict"] = true },
+        });
+
+        Assert.NotNull(response);
+        Assert.Equal("Hello!", response.Text);
+    }
+
+    [Fact]
+    public async Task ToolSearchTool_NamespaceDescriptionAloneDoesNotWrap_NonStreaming()
+    {
+        const string Input = """
+            {
+                "model": "gpt-5.4-mini",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "hello"
+                            }
+                        ]
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "tool_search"
+                    },
+                    {
+                        "type": "function",
+                        "name": "GetWeather",
+                        "description": "Gets the weather.",
+                        "parameters": {
+                            "type": "object",
+                            "required": [],
+                            "properties": {},
+                            "additionalProperties": false
+                        },
+                        "strict": true,
+                        "defer_loading": true
+                    },
+                    {
+                        "type": "function",
+                        "name": "ImportantTool",
+                        "description": "An important tool.",
+                        "parameters": {
+                            "type": "object",
+                            "required": [],
+                            "properties": {},
+                            "additionalProperties": false
+                        },
+                        "strict": true
+                    }
+                ]
+            }
+            """;
+
+        const string Output = """
+            {
+              "id": "resp_001",
+              "object": "response",
+              "created_at": 1741892091,
+              "status": "completed",
+              "model": "gpt-5.4-mini",
+              "output": [
+                {
+                  "type": "message",
+                  "id": "msg_001",
+                  "status": "completed",
+                  "role": "assistant",
+                  "content": [{"type": "output_text", "text": "Hello!", "annotations": []}]
+                }
+              ]
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-5.4-mini");
+
+        var getWeather = AIFunctionFactory.Create(() => 42, "GetWeather", "Gets the weather.");
+        var importantTool = AIFunctionFactory.Create(() => 42, "ImportantTool", "An important tool.");
+
+        // NamespaceDescription set without Namespace must NOT produce a namespace wrapper.
+        var response = await client.GetResponseAsync("hello", new()
+        {
+            Tools =
+            [
+                new HostedToolSearchTool
+                {
+                    NamespaceDescription = "should not appear in payload",
+                    DeferredTools = ["GetWeather"],
+                },
+                getWeather,
+                importantTool,
+            ],
+            AdditionalProperties = new() { ["strict"] = true },
+        });
+
+        Assert.NotNull(response);
+        Assert.Equal("Hello!", response.Text);
+    }
+
+    [Fact]
+    public async Task ToolSearchTool_NamespaceWithDescription_FirstWins_NonStreaming()
+    {
+        const string Input = """
+            {
+                "model": "gpt-5.4-mini",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "hello"
+                            }
+                        ]
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "tool_search"
+                    },
+                    {
+                        "type": "tool_search"
+                    },
+                    {
+                        "type": "namespace",
+                        "name": "crm",
+                        "description": "first description wins",
+                        "tools": [
+                            {
+                                "type": "function",
+                                "name": "GetCustomer",
+                                "description": "Gets a customer.",
+                                "parameters": {
+                                    "type": "object",
+                                    "required": [],
+                                    "properties": {},
+                                    "additionalProperties": false
+                                },
+                                "strict": true,
+                                "defer_loading": true
+                            },
+                            {
+                                "type": "function",
+                                "name": "ListOrders",
+                                "description": "Lists orders.",
+                                "parameters": {
+                                    "type": "object",
+                                    "required": [],
+                                    "properties": {},
+                                    "additionalProperties": false
+                                },
+                                "strict": true,
+                                "defer_loading": true
+                            }
+                        ]
+                    }
+                ]
+            }
+            """;
+
+        const string Output = """
+            {
+              "id": "resp_001",
+              "object": "response",
+              "created_at": 1741892091,
+              "status": "completed",
+              "model": "gpt-5.4-mini",
+              "output": [
+                {
+                  "type": "message",
+                  "id": "msg_001",
+                  "status": "completed",
+                  "role": "assistant",
+                  "content": [{"type": "output_text", "text": "Hello!", "annotations": []}]
+                }
+              ]
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-5.4-mini");
+
+        var getCustomer = AIFunctionFactory.Create(() => 42, "GetCustomer", "Gets a customer.");
+        var listOrders = AIFunctionFactory.Create(() => 42, "ListOrders", "Lists orders.");
+
+        var response = await client.GetResponseAsync("hello", new()
+        {
+            Tools =
+            [
+                new HostedToolSearchTool
+                {
+                    Namespace = "crm",
+                    NamespaceDescription = "first description wins",
+                    DeferredTools = ["GetCustomer"],
+                },
+                new HostedToolSearchTool
+                {
+                    Namespace = "crm",
+                    NamespaceDescription = "second description should be ignored",
+                    DeferredTools = ["ListOrders"],
+                },
+                getCustomer,
+                listOrders,
+            ],
+            AdditionalProperties = new() { ["strict"] = true },
+        });
+
+        Assert.NotNull(response);
+        Assert.Equal("Hello!", response.Text);
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -8510,4 +8510,116 @@ public class OpenAIResponseClientTests
         Assert.NotNull(response);
         Assert.Equal("Hello!", response.Text);
     }
+
+    [Fact]
+    public async Task ToolSearchTool_NamespaceDescription_FirstNonEmptyWins_NonStreaming()
+    {
+        // The first HostedToolSearchTool for "crm" omits NamespaceDescription; a later one
+        // supplies it. The supplied description should be used for the namespace wrapper.
+        const string Input = """
+            {
+                "model": "gpt-5.4-mini",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "hello"
+                            }
+                        ]
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "tool_search"
+                    },
+                    {
+                        "type": "namespace",
+                        "name": "crm",
+                        "description": "supplied by second tool",
+                        "tools": [
+                            {
+                                "type": "function",
+                                "name": "GetCustomer",
+                                "description": "Gets a customer.",
+                                "parameters": {
+                                    "type": "object",
+                                    "required": [],
+                                    "properties": {},
+                                    "additionalProperties": false
+                                },
+                                "strict": true,
+                                "defer_loading": true
+                            },
+                            {
+                                "type": "function",
+                                "name": "ListOrders",
+                                "description": "Lists orders.",
+                                "parameters": {
+                                    "type": "object",
+                                    "required": [],
+                                    "properties": {},
+                                    "additionalProperties": false
+                                },
+                                "strict": true,
+                                "defer_loading": true
+                            }
+                        ]
+                    }
+                ]
+            }
+            """;
+
+        const string Output = """
+            {
+              "id": "resp_001",
+              "object": "response",
+              "created_at": 1741892091,
+              "status": "completed",
+              "model": "gpt-5.4-mini",
+              "output": [
+                {
+                  "type": "message",
+                  "id": "msg_001",
+                  "status": "completed",
+                  "role": "assistant",
+                  "content": [{"type": "output_text", "text": "Hello!", "annotations": []}]
+                }
+              ]
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-5.4-mini");
+
+        var getCustomer = AIFunctionFactory.Create(() => 42, "GetCustomer", "Gets a customer.");
+        var listOrders = AIFunctionFactory.Create(() => 42, "ListOrders", "Lists orders.");
+
+        var response = await client.GetResponseAsync("hello", new()
+        {
+            Tools =
+            [
+                new HostedToolSearchTool
+                {
+                    Namespace = "crm",
+                    DeferredTools = ["GetCustomer"],
+                },
+                new HostedToolSearchTool
+                {
+                    Namespace = "crm",
+                    NamespaceDescription = "supplied by second tool",
+                    DeferredTools = ["ListOrders"],
+                },
+                getCustomer,
+                listOrders,
+            ],
+            AdditionalProperties = new() { ["strict"] = true },
+        });
+
+        Assert.NotNull(response);
+        Assert.Equal("Hello!", response.Text);
+    }
 }


### PR DESCRIPTION
* We were not sending a Namespace Description which is required by OpenAI.
* We support defining multiple namespaces by passing one HostedToolSearchTool for each one, this was causing that multiple tool_search tools were being sent on the wire, which was also being rejected by OpenAI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7500)