### PR TITLE
Set the Microsoft.McpServer template for the SDK to take precedence

### DIFF
--- a/src/ProjectTemplates/Microsoft.McpServer.ProjectTemplates/Microsoft.McpServer.ProjectTemplates.csproj
+++ b/src/ProjectTemplates/Microsoft.McpServer.ProjectTemplates/Microsoft.McpServer.ProjectTemplates.csproj
@@ -11,7 +11,7 @@
     <!-- Set the version info to align with ModelContextProtocol packages -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
 
     <Workstream>AI</Workstream>
     <!-- Template-only package (no Compile items or tests), so coverage/mutation thresholds are not applicable. -->

--- a/src/ProjectTemplates/Microsoft.McpServer.ProjectTemplates/templates/McpServer-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Microsoft.McpServer.ProjectTemplates/templates/McpServer-CSharp/.template.config/template.json
@@ -7,6 +7,8 @@
     "MCP"
   ],
   "identity": "Microsoft.McpServer.ProjectTemplates.McpServer.CSharp",
+  "groupIdentity": "Microsoft.McpServer",
+  "precedence": "1021",
   "name": "MCP Server App",
   "description": "A project template for creating a Model Context Protocol (MCP) server using C# and the ModelContextProtocol package.",
   "shortName": "mcpserver",


### PR DESCRIPTION
Chose _not_ to bump the MCP package references to the new 1.3.0 version since the changes are minimal and that would put this OOB version of the template a version ahead of the .NET 11 SDK version that will ship next week. This PR aligns the OOB project template package with the SDK-delivered one so with a precedence value lower than the `10000` and `11000` value ranges that come from the SDKs. That will have the highest version of the SDK that is installed take precedence when the user has the OOB installed along with the SDK.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7517)