### PR TITLE
Upgrade OpenAI package from 2.10.0 to 2.11.0

### DIFF
--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.Extensions.VectorData.Abstractions" Version="$(MicrosoftExtensionsVectorDataAbstractionsVersion)" />
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="$(MicrosoftMLTokenizersVersion)" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.2.0" />
-    <PackageVersion Include="OpenAI" Version="2.10.0" />
+    <PackageVersion Include="OpenAI" Version="2.11.0" />
     <PackageVersion Include="Polly" Version="8.4.2" />
     <PackageVersion Include="Polly.Core" Version="8.4.2" />
     <PackageVersion Include="Polly.Extensions" Version="8.4.2" />

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIHostedFileClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIHostedFileClient.cs
@@ -120,7 +120,7 @@ internal sealed class OpenAIHostedFileClient : IHostedFileClient
             var requestOptions = options?.RawRepresentationFactory?.Invoke(this) as RequestOptions ?? new();
             requestOptions.CancellationToken = cancellationToken;
 
-            var result = await GetContainerClient().CreateContainerFileAsync(
+            var result = await GetContainerClient().UploadContainerFileAsync(
                 containerId,
                 binaryContent,
                 multipart.Headers.ContentType!.ToString(),

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -775,7 +775,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                             "image/png" => ImageGenerationToolOutputFileFormat.Png,
                             "image/jpeg" => ImageGenerationToolOutputFileFormat.Jpeg,
                             "image/webp" => ImageGenerationToolOutputFileFormat.Webp,
-                            _ => null,
+                            _ => (ImageGenerationToolOutputFileFormat?)null,
                         } :
                         null,
                     PartialImageCount = igo?.StreamingCount,


### PR DESCRIPTION
- Bump OpenAI version to 2.11.0 in central package management.
- Ran integration tests to validate ingestion.
- Walked through the [changelog](https://github.com/openai/openai-dotnet/blob/OpenAI_2.11.0/CHANGELOG.md) and reacted to some breaking changes.  There're additions that we could use to build new abstractions that can be evaluated in the future.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7544)

Fixes https://github.com/dotnet/extensions/issues/7509.