### PR TITLE
Fix ToolJson.AdditionalProperties to accept sub-schema objects

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIClientExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIClientExtensions.cs
@@ -315,6 +315,8 @@ public static class OpenAIClientExtensions
     /// <summary>Used to create the JSON payload for an OpenAI tool description.</summary>
     internal sealed class ToolJson
     {
+        private static readonly JsonElement _falseElement = JsonDocument.Parse("false").RootElement.Clone();
+
         [JsonPropertyName("type")]
         public string Type { get; set; } = "object";
 
@@ -325,7 +327,7 @@ public static class OpenAIClientExtensions
         public Dictionary<string, JsonElement> Properties { get; set; } = [];
 
         [JsonPropertyName("additionalProperties")]
-        public bool AdditionalProperties { get; set; }
+        public JsonElement AdditionalProperties { get; set; } = _falseElement;
 
         [JsonExtensionData]
         public Dictionary<string, JsonElement>? ExtensionData { get; set; }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIClientExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIClientExtensions.cs
@@ -315,7 +315,7 @@ public static class OpenAIClientExtensions
     /// <summary>Used to create the JSON payload for an OpenAI tool description.</summary>
     internal sealed class ToolJson
     {
-        private static readonly JsonElement _falseElement = JsonDocument.Parse("false").RootElement.Clone();
+        private static readonly JsonElement _falseElement = JsonElement.Parse("false"u8);
 
         [JsonPropertyName("type")]
         public string Type { get; set; } = "object";

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
@@ -497,6 +497,10 @@ public abstract class ChatClientIntegrationTests : IDisposable
                 createWithSchema("""
                     {"properties":{"commit_message":{"description":"Extra detail for merge commit","type":"string"},"commit_title":{"description":"Title for merge commit","type":"string"},"merge_method":{"description":"Merge method","enum":["merge","squash","rebase"],"type":"string"},"owner":{"description":"Repository owner","type":"string"},"pullNumber":{"description":"Pull request number","type":"number"},"repo":{"description":"Repository name","type":"string"}},"required":["owner","repo","pullNumber"],"type":"object"}
                     """),
+
+                createWithSchema("""
+                    {"type":"object","properties":{"labels":{"type":"object"}},"additionalProperties":{"type":"string"}}
+                    """),
             ],
         };
 

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
@@ -107,6 +107,35 @@ public class OpenAIConversionTests
     }
 
     [Fact]
+    public void AsOpenAIChatTool_ExplicitSchema_PreservesObjectAdditionalProperties()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "labels": { "type": "object" }
+                },
+                "additionalProperties": { "type": "string" }
+            }
+            """).RootElement;
+
+        var function = AIFunctionFactory.CreateDeclaration(
+            "set_labels",
+            "Stores labels and arbitrary string metadata.",
+            schema);
+
+        var tool = function.AsOpenAIChatTool();
+        Assert.NotNull(tool);
+        Assert.Equal("set_labels", tool.FunctionName);
+
+        using var parsedParams = JsonDocument.Parse(tool.FunctionParameters);
+        var root = parsedParams.RootElement;
+        Assert.True(root.TryGetProperty("additionalProperties", out var ap), "additionalProperties should be preserved");
+        Assert.Equal(JsonValueKind.Object, ap.ValueKind);
+        Assert.Equal("string", ap.GetProperty("type").GetString());
+    }
+
+    [Fact]
     public void AsOpenAIChatTool_PreservesExtraTopLevelPropertiesLikeDefs()
     {
         // Create a JSON schema with $defs (used for reference types)
@@ -166,6 +195,36 @@ public class OpenAIConversionTests
         var functionTool = Assert.IsType<FunctionTool>(tool);
         Assert.Equal("test_function", functionTool.FunctionName);
         Assert.Equal("A test function for conversion", functionTool.FunctionDescription);
+    }
+
+    [Fact]
+    public void AsOpenAIResponseTool_ExplicitSchema_PreservesObjectAdditionalProperties()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "labels": { "type": "object" }
+                },
+                "additionalProperties": { "type": "string" }
+            }
+            """).RootElement;
+
+        var function = AIFunctionFactory.CreateDeclaration(
+            "set_labels",
+            "Stores labels and arbitrary string metadata.",
+            schema);
+
+        var tool = function.AsOpenAIResponseTool();
+        Assert.NotNull(tool);
+        var functionTool = Assert.IsType<FunctionTool>(tool);
+        Assert.Equal("set_labels", functionTool.FunctionName);
+
+        using var parsedParams = JsonDocument.Parse(functionTool.FunctionParameters);
+        var root = parsedParams.RootElement;
+        Assert.True(root.TryGetProperty("additionalProperties", out var ap), "additionalProperties should be preserved");
+        Assert.Equal(JsonValueKind.Object, ap.ValueKind);
+        Assert.Equal("string", ap.GetProperty("type").GetString());
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -8633,4 +8633,216 @@ public class OpenAIResponseClientTests
         Assert.NotNull(response);
         Assert.Equal("Hello!", response.Text);
     }
+
+    [Fact]
+    public async Task Tool_SchemaWithObjectAdditionalProperties_FunctionCallArgumentsReceived()
+    {
+        const string Input = """
+            {
+                "model": "gpt-4o-mini",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "TagResource",
+                        "description": "Tags a resource with key-value labels.",
+                        "parameters": {
+                            "type": "object",
+                            "required": ["resource_name"],
+                            "properties": {
+                                "resource_name": {
+                                    "type": "string",
+                                    "description": "Name of the resource."
+                                }
+                            },
+                            "additionalProperties": {"type": "string"}
+                        },
+                        "strict": null
+                    }
+                ],
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "Tag my-server with env=production."}]
+                    }
+                ]
+            }
+            """;
+
+        const string Output = """
+            {
+              "id": "resp_tag_001",
+              "object": "response",
+              "created_at": 1741891428,
+              "status": "completed",
+              "model": "gpt-4o-mini-2024-07-18",
+              "output": [
+                {
+                  "type": "function_call",
+                  "id": "fc_tag_001",
+                  "call_id": "call_tag_abc",
+                  "name": "TagResource",
+                  "arguments": "{\"resource_name\":\"my-server\",\"env\":\"production\"}",
+                  "status": "completed"
+                }
+              ],
+              "parallel_tool_calls": true,
+              "previous_response_id": null,
+              "reasoning": {"effort": null, "summary": null},
+              "store": true,
+              "temperature": 1.0,
+              "text": {"format": {"type": "text"}},
+              "tool_choice": "auto",
+              "tools": [],
+              "top_p": 1.0,
+              "usage": {
+                "input_tokens": 30,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens": 20,
+                "output_tokens_details": {"reasoning_tokens": 0},
+                "total_tokens": 50
+              },
+              "user": null,
+              "metadata": {}
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-4o-mini");
+
+        const string ExplicitSchema = """
+            {
+                "type": "object",
+                "properties": {
+                    "resource_name": {
+                        "type": "string",
+                        "description": "Name of the resource."
+                    }
+                },
+                "required": ["resource_name"],
+                "additionalProperties": {"type": "string"}
+            }
+            """;
+
+        var tool = AIFunctionFactory.CreateDeclaration("TagResource", "Tags a resource with key-value labels.", JsonDocument.Parse(ExplicitSchema).RootElement);
+
+        var response = await client.GetResponseAsync(
+            "Tag my-server with env=production.",
+            new ChatOptions { Tools = [tool] });
+
+        Assert.NotNull(response);
+        var call = Assert.IsType<FunctionCallContent>(Assert.Single(response.Messages[0].Contents));
+        Assert.Equal("TagResource", call.Name);
+        Assert.NotNull(call.Arguments);
+        Assert.Equal("my-server", ((JsonElement)call.Arguments["resource_name"]!).GetString());
+        Assert.Equal("production", ((JsonElement)call.Arguments["env"]!).GetString());
+    }
+
+    [Fact]
+    public async Task Tool_SchemaWithObjectAdditionalProperties_Streaming_FunctionCallArgumentsReceived()
+    {
+        const string Input = """
+            {
+                "model": "gpt-4o-mini",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "TagResource",
+                        "description": "Tags a resource with key-value labels.",
+                        "parameters": {
+                            "type": "object",
+                            "required": ["resource_name"],
+                            "properties": {
+                                "resource_name": {
+                                    "type": "string",
+                                    "description": "Name of the resource."
+                                }
+                            },
+                            "additionalProperties": {"type": "string"}
+                        },
+                        "strict": null
+                    }
+                ],
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "Tag my-server with env=production."}]
+                    }
+                ],
+                "stream": true
+            }
+            """;
+
+        const string Output = """
+            event: response.created
+            data: {"type":"response.created","response":{"id":"resp_tag_002","object":"response","created_at":1741892091,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+            event: response.in_progress
+            data: {"type":"response.in_progress","response":{"id":"resp_tag_002","object":"response","created_at":1741892091,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+            event: response.output_item.added
+            data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_tag_002","call_id":"call_tag_def","name":"TagResource","arguments":"","status":"in_progress"}}
+
+            event: response.function_call_arguments.delta
+            data: {"type":"response.function_call_arguments.delta","item_id":"fc_tag_002","output_index":0,"delta":"{\"resource_name\":\"my-server\",\"env\":\"production\"}"}
+
+            event: response.function_call_arguments.done
+            data: {"type":"response.function_call_arguments.done","item_id":"fc_tag_002","output_index":0,"arguments":"{\"resource_name\":\"my-server\",\"env\":\"production\"}"}
+
+            event: response.output_item.done
+            data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_tag_002","call_id":"call_tag_def","name":"TagResource","arguments":"{\"resource_name\":\"my-server\",\"env\":\"production\"}","status":"completed"}}
+
+            event: response.completed
+            data: {"type":"response.completed","response":{"id":"resp_tag_002","object":"response","created_at":1741892091,"status":"completed","model":"gpt-4o-mini","output":[{"type":"function_call","id":"fc_tag_002","call_id":"call_tag_def","name":"TagResource","arguments":"{\"resource_name\":\"my-server\",\"env\":\"production\"}","status":"completed"}],"usage":{"input_tokens":30,"output_tokens":20,"total_tokens":50}}}
+
+            
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-4o-mini");
+
+        const string ExplicitSchema = """
+            {
+                "type": "object",
+                "properties": {
+                    "resource_name": {
+                        "type": "string",
+                        "description": "Name of the resource."
+                    }
+                },
+                "required": ["resource_name"],
+                "additionalProperties": {"type": "string"}
+            }
+            """;
+
+        var tool = AIFunctionFactory.CreateDeclaration("TagResource", "Tags a resource with key-value labels.", JsonDocument.Parse(ExplicitSchema).RootElement);
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (var update in client.GetStreamingResponseAsync(
+            "Tag my-server with env=production.",
+            new ChatOptions { Tools = [tool] }))
+        {
+            updates.Add(update);
+        }
+
+        var functionCallUpdate = updates.FirstOrDefault(u => u.Contents.OfType<FunctionCallContent>().Any());
+        Assert.NotNull(functionCallUpdate);
+        var call = functionCallUpdate.Contents.OfType<FunctionCallContent>().Single();
+        Assert.Equal("call_tag_def", call.CallId);
+        Assert.Equal("TagResource", call.Name);
+        Assert.NotNull(call.Arguments);
+        Assert.Equal("my-server", ((JsonElement)call.Arguments["resource_name"]!).GetString());
+        Assert.Equal("production", ((JsonElement)call.Arguments["env"]!).GetString());
+
+        var response = updates.ToChatResponse();
+        Assert.Equal("resp_tag_002", response.ResponseId);
+        var coalesced = response.Messages[0].Contents.OfType<FunctionCallContent>().Single();
+        Assert.Equal("TagResource", coalesced.Name);
+        Assert.NotNull(coalesced.Arguments);
+        Assert.Equal("my-server", ((JsonElement)coalesced.Arguments["resource_name"]!).GetString());
+        Assert.Equal("production", ((JsonElement)coalesced.Arguments["env"]!).GetString());
+    }
 }


### PR DESCRIPTION
Change AdditionalProperties from bool to JsonElement so that JSON Schema additionalProperties values like {"type":"string"} are preserved instead of throwing a JsonException during deserialization.

Fixes https://github.com/dotnet/extensions/issues/7540
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7546)