### PR TITLE
Add ToolApprovalRequestContent.RequiresConfirmation

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
+using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
@@ -31,6 +33,27 @@ public sealed class ToolApprovalRequestContent : InputRequestContent
     /// Gets the tool call that requires approval before execution.
     /// </summary>
     public ToolCallContent ToolCall { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this approval request was added by the invoker
+    /// of the tool call rather than because the underlying tool itself was declared as requiring approval.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Defaults to <see langword="false"/>, indicating that the underlying tool itself required
+    /// approval (for example, the targeted function was an <see cref="ApprovalRequiredAIFunction"/>).
+    /// </para>
+    /// <para>
+    /// Some invokers convert every concurrent function call in a response into a
+    /// <see cref="ToolApprovalRequestContent"/> whenever any one of them targets an
+    /// <see cref="ApprovalRequiredAIFunction"/>, so that approvals and rejections stay coherent
+    /// across the batch. When set to <see langword="true"/>, this property indicates that the
+    /// request was added for that reason and the underlying tool did not itself require approval;
+    /// consumers may use this to, for example, auto-approve such requests.
+    /// </para>
+    /// </remarks>
+    [Experimental(DiagnosticIds.Experiments.AIFunctionApprovals, UrlFormat = DiagnosticIds.UrlFormat)]
+    public bool IsInvokerRequested { get; set; }
 
     /// <summary>
     /// Creates a <see cref="ToolApprovalResponseContent"/> indicating whether the tool call is approved or rejected.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
@@ -33,25 +33,14 @@ public sealed class ToolApprovalRequestContent : InputRequestContent
     public ToolCallContent ToolCall { get; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether this approval request needs a confirmation
-    /// from the consumer before the underlying tool call is invoked.
+    /// Gets or sets a value indicating whether the underlying tool call must be confirmed
+    /// before it is invoked.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// Defaults to <see langword="true"/>, indicating that the underlying tool genuinely
-    /// requires approval (for example, the targeted function is an <see cref="ApprovalRequiredAIFunction"/>)
-    /// and the consumer must obtain a confirmation (for instance, a user prompt, a policy decision,
-    /// or a governance gate) before the call is invoked.
-    /// </para>
-    /// <para>
-    /// Some invokers convert every concurrent function call in a response into a
-    /// <see cref="ToolApprovalRequestContent"/> whenever any one of them targets an
-    /// <see cref="ApprovalRequiredAIFunction"/>, so that approvals and rejections stay coherent
-    /// across the response. When set to <see langword="false"/>, this property indicates that
-    /// the underlying tool did not itself require approval and that the request exists only to
-    /// satisfy that constraint; consumers may auto-approve such requests without seeking a
-    /// confirmation.
-    /// </para>
+    /// Defaults to <see langword="true"/>. When <see langword="true"/>, the underlying tool
+    /// requires a confirmation (such as a user prompt, a policy decision, or any other approver)
+    /// before it can be invoked. When <see langword="false"/>, the underlying tool does not
+    /// require a confirmation and the consumer may proceed without prompting.
     /// </remarks>
     public bool RequiresConfirmation { get; set; } = true;
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
+using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
@@ -44,6 +46,7 @@ public sealed class ToolApprovalRequestContent : InputRequestContent
     /// <see cref="ToolApprovalResponseContent"/> still has to be supplied so the originating
     /// tool call can be invoked.
     /// </remarks>
+    [Experimental(DiagnosticIds.Experiments.AIApprovalsInvocationRequired, UrlFormat = DiagnosticIds.UrlFormat)]
     public bool RequiresConfirmation { get; set; } = true;
 
     /// <summary>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
@@ -35,25 +35,28 @@ public sealed class ToolApprovalRequestContent : InputRequestContent
     public ToolCallContent ToolCall { get; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether this approval request was added by the invoker
-    /// of the tool call rather than because the underlying tool itself was declared as requiring approval.
+    /// Gets or sets a value indicating whether this approval request needs a confirmation
+    /// from the consumer before the underlying tool call is invoked.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Defaults to <see langword="false"/>, indicating that the underlying tool itself required
-    /// approval (for example, the targeted function was an <see cref="ApprovalRequiredAIFunction"/>).
+    /// Defaults to <see langword="true"/>, indicating that the underlying tool genuinely
+    /// requires approval (for example, the targeted function is an <see cref="ApprovalRequiredAIFunction"/>)
+    /// and the consumer must obtain a confirmation (for instance, a user prompt, a policy decision,
+    /// or a governance gate) before the call is invoked.
     /// </para>
     /// <para>
     /// Some invokers convert every concurrent function call in a response into a
     /// <see cref="ToolApprovalRequestContent"/> whenever any one of them targets an
     /// <see cref="ApprovalRequiredAIFunction"/>, so that approvals and rejections stay coherent
-    /// across the batch. When set to <see langword="true"/>, this property indicates that the
-    /// request was added for that reason and the underlying tool did not itself require approval;
-    /// consumers may use this to, for example, auto-approve such requests.
+    /// across the response. When set to <see langword="false"/>, this property indicates that
+    /// the underlying tool did not itself require approval and that the request exists only to
+    /// satisfy that constraint; consumers may auto-approve such requests without seeking a
+    /// confirmation.
     /// </para>
     /// </remarks>
     [Experimental(DiagnosticIds.Experiments.AIFunctionApprovals, UrlFormat = DiagnosticIds.UrlFormat)]
-    public bool IsInvokerRequested { get; set; }
+    public bool RequiresConfirmation { get; set; } = true;
 
     /// <summary>
     /// Creates a <see cref="ToolApprovalResponseContent"/> indicating whether the tool call is approved or rejected.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
@@ -40,7 +40,9 @@ public sealed class ToolApprovalRequestContent : InputRequestContent
     /// Defaults to <see langword="true"/>. When <see langword="true"/>, the underlying tool
     /// requires a confirmation (such as a user prompt, a policy decision, or any other approver)
     /// before it can be invoked. When <see langword="false"/>, the underlying tool does not
-    /// require a confirmation and the consumer may proceed without prompting.
+    /// require a confirmation and the consumer may proceed without prompting; a corresponding
+    /// <see cref="ToolApprovalResponseContent"/> still has to be supplied so the originating
+    /// tool call can be invoked.
     /// </remarks>
     public bool RequiresConfirmation { get; set; } = true;
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
@@ -55,7 +53,6 @@ public sealed class ToolApprovalRequestContent : InputRequestContent
     /// confirmation.
     /// </para>
     /// </remarks>
-    [Experimental(DiagnosticIds.Experiments.AIFunctionApprovals, UrlFormat = DiagnosticIds.UrlFormat)]
     public bool RequiresConfirmation { get; set; } = true;
 
     /// <summary>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -4605,7 +4605,7 @@
       ],
       "Properties": [
         {
-          "Member": "bool Microsoft.Extensions.AI.ToolApprovalRequestContent.IsInvokerRequested { get; set; }",
+          "Member": "bool Microsoft.Extensions.AI.ToolApprovalRequestContent.RequiresConfirmation { get; set; }",
           "Stage": "Experimental"
         },
         {

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -4606,7 +4606,7 @@
       "Properties": [
         {
           "Member": "bool Microsoft.Extensions.AI.ToolApprovalRequestContent.RequiresConfirmation { get; set; }",
-          "Stage": "Experimental"
+          "Stage": "Stable"
         },
         {
           "Member": "Microsoft.Extensions.AI.ToolCallContent Microsoft.Extensions.AI.ToolApprovalRequestContent.ToolCall { get; }",

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -4606,7 +4606,7 @@
       "Properties": [
         {
           "Member": "bool Microsoft.Extensions.AI.ToolApprovalRequestContent.RequiresConfirmation { get; set; }",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "Microsoft.Extensions.AI.ToolCallContent Microsoft.Extensions.AI.ToolApprovalRequestContent.ToolCall { get; }",

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -1,5 +1,5 @@
 {
-  "Name": "Microsoft.Extensions.AI.Abstractions, Version=10.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Name": "Microsoft.Extensions.AI.Abstractions, Version=10.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
   "Types": [
     {
       "Type": "sealed class Microsoft.Extensions.AI.AdditionalPropertiesDictionary : Microsoft.Extensions.AI.AdditionalPropertiesDictionary<object?>",
@@ -4604,6 +4604,10 @@
         }
       ],
       "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.AI.ToolApprovalRequestContent.IsInvokerRequested { get; set; }",
+          "Stage": "Experimental"
+        },
         {
           "Member": "Microsoft.Extensions.AI.ToolCallContent Microsoft.Extensions.AI.ToolApprovalRequestContent.ToolCall { get; }",
           "Stage": "Stable"

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Microsoft.Extensions.AI.Evaluation.Reporting.Azure.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Microsoft.Extensions.AI.Evaluation.Reporting.Azure.csproj
@@ -12,6 +12,7 @@
     <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
     <MinCodeCoverage>n/a</MinCodeCoverage>
     <MinMutationScore>n/a</MinMutationScore>
+    <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Microsoft.Extensions.AI.Evaluation.Reporting.Azure.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Microsoft.Extensions.AI.Evaluation.Reporting.Azure.csproj
@@ -12,7 +12,6 @@
     <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
     <MinCodeCoverage>n/a</MinCodeCoverage>
     <MinMutationScore>n/a</MinMutationScore>
-    <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Microsoft.Extensions.AI.Evaluation.Reporting.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Microsoft.Extensions.AI.Evaluation.Reporting.csproj
@@ -19,6 +19,7 @@
     <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
     <MinCodeCoverage>n/a</MinCodeCoverage>
     <MinMutationScore>n/a</MinMutationScore>
+    <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Microsoft.Extensions.AI.Evaluation.Reporting.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Microsoft.Extensions.AI.Evaluation.Reporting.csproj
@@ -19,7 +19,6 @@
     <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
     <MinCodeCoverage>n/a</MinCodeCoverage>
     <MinMutationScore>n/a</MinMutationScore>
-    <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -613,7 +613,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                     for (; lastYieldedUpdateIndex < updates.Count; lastYieldedUpdateIndex++)
                     {
                         var updateToYield = updates[lastYieldedUpdateIndex];
-                        if (TryReplaceFunctionCallsWithApprovalRequests(updateToYield.Contents, out var updatedContents, options?.Tools, AdditionalTools))
+                        if (TryReplaceFunctionCallsWithApprovalRequests(updateToYield.Contents, approvalRequiredFunctions, out var updatedContents))
                         {
                             updateToYield.Contents = updatedContents;
                         }
@@ -1620,8 +1620,8 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     /// <returns>true if any <see cref="FunctionCallContent"/> was replaced, false otherwise.</returns>
     private static bool TryReplaceFunctionCallsWithApprovalRequests(
         IList<AIContent> content,
-        out List<AIContent>? updatedContent,
-        params ReadOnlySpan<IList<AITool>?> toolLists)
+        AITool[] approvalRequiredFunctions,
+        out List<AIContent>? updatedContent)
     {
         updatedContent = null;
 
@@ -1632,10 +1632,20 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                 if (content[i] is FunctionCallContent fcc && !fcc.InformationalOnly)
                 {
                     updatedContent ??= [.. content]; // Clone the list if we haven't already
-                    bool requiredByFunction = FindTool(fcc.Name, toolLists)?.GetService<ApprovalRequiredAIFunction>() is not null;
+
+                    bool requiresConfirmation = false;
+                    for (int j = 0; j < approvalRequiredFunctions.Length; j++)
+                    {
+                        if (string.Equals(approvalRequiredFunctions[j].Name, fcc.Name, StringComparison.Ordinal))
+                        {
+                            requiresConfirmation = true;
+                            break;
+                        }
+                    }
+
                     updatedContent[i] = new ToolApprovalRequestContent(ComposeApprovalRequestId(fcc.CallId), fcc)
                     {
-                        RequiresConfirmation = requiredByFunction,
+                        RequiresConfirmation = requiresConfirmation,
                     };
                 }
             }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -355,7 +355,13 @@ public class FunctionInvokingChatClient : DelegatingChatClient
             anyToolsRequireApproval = AnyToolsRequireApproval(options?.Tools, AdditionalTools);
             if (anyToolsRequireApproval)
             {
-                response.Messages = ReplaceFunctionCallsWithApprovalRequests(response.Messages, options?.Tools, AdditionalTools);
+                var approvalRequiredFunctions =
+                    (options?.Tools ?? Enumerable.Empty<AITool>())
+                    .Concat(AdditionalTools ?? Enumerable.Empty<AITool>())
+                    .Where(t => t.GetService<ApprovalRequiredAIFunction>() is not null)
+                    .ToArray();
+
+                response.Messages = ReplaceFunctionCallsWithApprovalRequests(response.Messages, approvalRequiredFunctions);
             }
 
             // Any function call work to do? If yes, ensure we're tracking that work in functionCallContents.
@@ -1660,7 +1666,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     /// </summary>
     private IList<ChatMessage> ReplaceFunctionCallsWithApprovalRequests(
         IList<ChatMessage> messages,
-        params ReadOnlySpan<IList<AITool>?> toolLists)
+        AITool[] approvalRequiredFunctions)
     {
         var outputMessages = messages;
 
@@ -1668,7 +1674,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
         List<(int MessageIndex, int ContentIndex, bool RequiresConfirmation)>? allFunctionCallContentIndices = null;
 
         // Build a list of the indices of all FunctionCallContent items.
-        // Also check if any of them require approval.
+        // Also check whether each call's target name matches an approval-required function.
         for (int i = 0; i < messages.Count; i++)
         {
             var content = messages[i].Contents;
@@ -1676,10 +1682,19 @@ public class FunctionInvokingChatClient : DelegatingChatClient
             {
                 if (content[j] is FunctionCallContent functionCall && !functionCall.InformationalOnly)
                 {
-                    bool requiredByFunction = FindTool(functionCall.Name, toolLists)?.GetService<ApprovalRequiredAIFunction>() is not null;
-                    (allFunctionCallContentIndices ??= []).Add((i, j, requiredByFunction));
+                    bool requiresConfirmation = false;
+                    for (int k = 0; k < approvalRequiredFunctions.Length; k++)
+                    {
+                        if (string.Equals(approvalRequiredFunctions[k].Name, functionCall.Name, StringComparison.Ordinal))
+                        {
+                            requiresConfirmation = true;
+                            break;
+                        }
+                    }
 
-                    anyApprovalRequired |= requiredByFunction;
+                    (allFunctionCallContentIndices ??= []).Add((i, j, requiresConfirmation));
+
+                    anyApprovalRequired |= requiresConfirmation;
                 }
             }
         }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -613,7 +613,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                     for (; lastYieldedUpdateIndex < updates.Count; lastYieldedUpdateIndex++)
                     {
                         var updateToYield = updates[lastYieldedUpdateIndex];
-                        if (TryReplaceFunctionCallsWithApprovalRequests(updateToYield.Contents, out var updatedContents))
+                        if (TryReplaceFunctionCallsWithApprovalRequests(updateToYield.Contents, out var updatedContents, options?.Tools, AdditionalTools))
                         {
                             updateToYield.Contents = updatedContents;
                         }
@@ -1618,7 +1618,10 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     /// Replaces all <see cref="FunctionCallContent"/> with <see cref="ToolApprovalRequestContent"/> and ouputs a new list if any of them were replaced.
     /// </summary>
     /// <returns>true if any <see cref="FunctionCallContent"/> was replaced, false otherwise.</returns>
-    private static bool TryReplaceFunctionCallsWithApprovalRequests(IList<AIContent> content, out List<AIContent>? updatedContent)
+    private static bool TryReplaceFunctionCallsWithApprovalRequests(
+        IList<AIContent> content,
+        out List<AIContent>? updatedContent,
+        params ReadOnlySpan<IList<AITool>?> toolLists)
     {
         updatedContent = null;
 
@@ -1629,7 +1632,11 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                 if (content[i] is FunctionCallContent fcc && !fcc.InformationalOnly)
                 {
                     updatedContent ??= [.. content]; // Clone the list if we haven't already
-                    updatedContent[i] = new ToolApprovalRequestContent(ComposeApprovalRequestId(fcc.CallId), fcc);
+                    bool requiredByFunction = FindTool(fcc.Name, toolLists)?.GetService<ApprovalRequiredAIFunction>() is not null;
+                    updatedContent[i] = new ToolApprovalRequestContent(ComposeApprovalRequestId(fcc.CallId), fcc)
+                    {
+                        IsInvokerRequested = !requiredByFunction,
+                    };
                 }
             }
         }
@@ -1648,7 +1655,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
         var outputMessages = messages;
 
         bool anyApprovalRequired = false;
-        List<(int, int)>? allFunctionCallContentIndices = null;
+        List<(int MessageIndex, int ContentIndex, bool IsInvokerRequested)>? allFunctionCallContentIndices = null;
 
         // Build a list of the indices of all FunctionCallContent items.
         // Also check if any of them require approval.
@@ -1659,9 +1666,10 @@ public class FunctionInvokingChatClient : DelegatingChatClient
             {
                 if (content[j] is FunctionCallContent functionCall && !functionCall.InformationalOnly)
                 {
-                    (allFunctionCallContentIndices ??= []).Add((i, j));
+                    bool requiredByFunction = FindTool(functionCall.Name, toolLists)?.GetService<ApprovalRequiredAIFunction>() is not null;
+                    (allFunctionCallContentIndices ??= []).Add((i, j, !requiredByFunction));
 
-                    anyApprovalRequired |= FindTool(functionCall.Name, toolLists)?.GetService<ApprovalRequiredAIFunction>() is not null;
+                    anyApprovalRequired |= requiredByFunction;
                 }
             }
         }
@@ -1676,7 +1684,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
             outputMessages = [.. messages];
             int lastMessageIndex = -1;
 
-            foreach (var (messageIndex, contentIndex) in allFunctionCallContentIndices!)
+            foreach (var (messageIndex, contentIndex, isInvokerRequested) in allFunctionCallContentIndices!)
             {
                 // Clone the message if we didn't already clone it in a previous iteration.
                 var message = lastMessageIndex != messageIndex ? outputMessages[messageIndex].Clone() : outputMessages[messageIndex];
@@ -1684,7 +1692,10 @@ public class FunctionInvokingChatClient : DelegatingChatClient
 
                 var functionCall = (FunctionCallContent)message.Contents[contentIndex];
                 LogFunctionRequiresApproval(functionCall.Name);
-                message.Contents[contentIndex] = new ToolApprovalRequestContent(ComposeApprovalRequestId(functionCall.CallId), functionCall);
+                message.Contents[contentIndex] = new ToolApprovalRequestContent(ComposeApprovalRequestId(functionCall.CallId), functionCall)
+                {
+                    IsInvokerRequested = isInvokerRequested,
+                };
                 outputMessages[messageIndex] = message;
 
                 lastMessageIndex = messageIndex;

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -1635,7 +1635,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                     bool requiredByFunction = FindTool(fcc.Name, toolLists)?.GetService<ApprovalRequiredAIFunction>() is not null;
                     updatedContent[i] = new ToolApprovalRequestContent(ComposeApprovalRequestId(fcc.CallId), fcc)
                     {
-                        IsInvokerRequested = !requiredByFunction,
+                        RequiresConfirmation = requiredByFunction,
                     };
                 }
             }
@@ -1655,7 +1655,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
         var outputMessages = messages;
 
         bool anyApprovalRequired = false;
-        List<(int MessageIndex, int ContentIndex, bool IsInvokerRequested)>? allFunctionCallContentIndices = null;
+        List<(int MessageIndex, int ContentIndex, bool RequiresConfirmation)>? allFunctionCallContentIndices = null;
 
         // Build a list of the indices of all FunctionCallContent items.
         // Also check if any of them require approval.
@@ -1667,7 +1667,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                 if (content[j] is FunctionCallContent functionCall && !functionCall.InformationalOnly)
                 {
                     bool requiredByFunction = FindTool(functionCall.Name, toolLists)?.GetService<ApprovalRequiredAIFunction>() is not null;
-                    (allFunctionCallContentIndices ??= []).Add((i, j, !requiredByFunction));
+                    (allFunctionCallContentIndices ??= []).Add((i, j, requiredByFunction));
 
                     anyApprovalRequired |= requiredByFunction;
                 }
@@ -1684,7 +1684,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
             outputMessages = [.. messages];
             int lastMessageIndex = -1;
 
-            foreach (var (messageIndex, contentIndex, isInvokerRequested) in allFunctionCallContentIndices!)
+            foreach (var (messageIndex, contentIndex, requiresConfirmation) in allFunctionCallContentIndices!)
             {
                 // Clone the message if we didn't already clone it in a previous iteration.
                 var message = lastMessageIndex != messageIndex ? outputMessages[messageIndex].Clone() : outputMessages[messageIndex];
@@ -1694,7 +1694,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                 LogFunctionRequiresApproval(functionCall.Name);
                 message.Contents[contentIndex] = new ToolApprovalRequestContent(ComposeApprovalRequestId(functionCall.CallId), functionCall)
                 {
-                    IsInvokerRequested = isInvokerRequested,
+                    RequiresConfirmation = requiresConfirmation,
                 };
                 outputMessages[messageIndex] = message;
 

--- a/src/Shared/DiagnosticIds/DiagnosticIds.cs
+++ b/src/Shared/DiagnosticIds/DiagnosticIds.cs
@@ -53,6 +53,7 @@ internal static class DiagnosticIds
         internal const string AITextToSpeech = AIExperiments;
         internal const string AIMcpServers = AIExperiments;
         internal const string AIFunctionApprovals = AIExperiments;
+        internal const string AIApprovalsInvocationRequired = AIExperiments;
 
         internal const string AIChatReduction = AIExperiments;
         internal const string AIToolSearch = AIExperiments;

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/AssertExtensions.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/AssertExtensions.cs
@@ -50,6 +50,7 @@ internal static class AssertExtensions
                 {
                     var actualApprovalRequest = (ToolApprovalRequestContent)chatItem;
                     Assert.Equal(expectedApprovalRequest.RequestId, actualApprovalRequest.RequestId);
+                    Assert.Equal(expectedApprovalRequest.IsInvokerRequested, actualApprovalRequest.IsInvokerRequested);
                     Assert.Equal(expectedApprovalRequest.ToolCall.CallId, actualApprovalRequest.ToolCall.CallId);
                     Assert.Equal(expectedApprovalRequest.ToolCall.GetType(), actualApprovalRequest.ToolCall.GetType());
                     AssertToolCallNameAndArguments(expectedApprovalRequest.ToolCall, actualApprovalRequest.ToolCall);

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/AssertExtensions.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/AssertExtensions.cs
@@ -50,7 +50,7 @@ internal static class AssertExtensions
                 {
                     var actualApprovalRequest = (ToolApprovalRequestContent)chatItem;
                     Assert.Equal(expectedApprovalRequest.RequestId, actualApprovalRequest.RequestId);
-                    Assert.Equal(expectedApprovalRequest.IsInvokerRequested, actualApprovalRequest.IsInvokerRequested);
+                    Assert.Equal(expectedApprovalRequest.RequiresConfirmation, actualApprovalRequest.RequiresConfirmation);
                     Assert.Equal(expectedApprovalRequest.ToolCall.CallId, actualApprovalRequest.ToolCall.CallId);
                     Assert.Equal(expectedApprovalRequest.ToolCall.GetType(), actualApprovalRequest.ToolCall.GetType());
                     AssertToolCallNameAndArguments(expectedApprovalRequest.ToolCall, actualApprovalRequest.ToolCall);

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/ToolApprovalRequestContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/ToolApprovalRequestContentTests.cs
@@ -130,4 +130,28 @@ public class ToolApprovalRequestContentTests
         Assert.NotNull(approvalRequest.AdditionalProperties);
         Assert.Equal("val", approvalRequest.AdditionalProperties["key"]?.ToString());
     }
+
+    [Fact]
+    public void IsInvokerRequested_DefaultsToFalse()
+    {
+        var content = new ToolApprovalRequestContent("req-1", new FunctionCallContent("call1", "Func"));
+        Assert.False(content.IsInvokerRequested);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void IsInvokerRequested_RoundtripsThroughJson(bool value)
+    {
+        var content = new ToolApprovalRequestContent("req-1", new FunctionCallContent("call1", "Func"))
+        {
+            IsInvokerRequested = value,
+        };
+
+        string json = JsonSerializer.Serialize(content, AIJsonUtilities.DefaultOptions);
+        var deserialized = JsonSerializer.Deserialize<ToolApprovalRequestContent>(json, AIJsonUtilities.DefaultOptions);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal(value, deserialized!.IsInvokerRequested);
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/ToolApprovalRequestContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/ToolApprovalRequestContentTests.cs
@@ -132,26 +132,26 @@ public class ToolApprovalRequestContentTests
     }
 
     [Fact]
-    public void IsInvokerRequested_DefaultsToFalse()
+    public void RequiresConfirmation_DefaultsToTrue()
     {
         var content = new ToolApprovalRequestContent("req-1", new FunctionCallContent("call1", "Func"));
-        Assert.False(content.IsInvokerRequested);
+        Assert.True(content.RequiresConfirmation);
     }
 
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public void IsInvokerRequested_RoundtripsThroughJson(bool value)
+    public void RequiresConfirmation_RoundtripsThroughJson(bool value)
     {
         var content = new ToolApprovalRequestContent("req-1", new FunctionCallContent("call1", "Func"))
         {
-            IsInvokerRequested = value,
+            RequiresConfirmation = value,
         };
 
         string json = JsonSerializer.Serialize(content, AIJsonUtilities.DefaultOptions);
         var deserialized = JsonSerializer.Deserialize<ToolApprovalRequestContent>(json, AIJsonUtilities.DefaultOptions);
 
         Assert.NotNull(deserialized);
-        Assert.Equal(value, deserialized!.IsInvokerRequested);
+        Assert.Equal(value, deserialized!.RequiresConfirmation);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
@@ -84,7 +84,7 @@ public class FunctionInvokingChatClientApprovalsTests
                 new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1")),
                 new ToolApprovalRequestContent("ficc_callId2", new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
                 {
-                    IsInvokerRequested = true,
+                    RequiresConfirmation = false,
                 }
             ])
         ];
@@ -124,19 +124,19 @@ public class FunctionInvokingChatClientApprovalsTests
             new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1"), new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } })]),
         ];
 
-        // When additionalToolsRequireApproval is true: Func1 (additional tools) requires approval and Func2 (options.Tools) is collateral.
-        // When false: Func2 (options.Tools) requires approval and Func1 (additional tools) is collateral.
+        // When additionalToolsRequireApproval is true: Func1 (additional tools) requires approval and Func2 (options.Tools) does not.
+        // When false: Func2 (options.Tools) requires approval and Func1 (additional tools) does not.
         List<ChatMessage> expectedOutput =
         [
             new ChatMessage(ChatRole.Assistant,
             [
                 new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1"))
                 {
-                    IsInvokerRequested = !additionalToolsRequireApproval,
+                    RequiresConfirmation = additionalToolsRequireApproval,
                 },
                 new ToolApprovalRequestContent("ficc_callId2", new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
                 {
-                    IsInvokerRequested = additionalToolsRequireApproval,
+                    RequiresConfirmation = !additionalToolsRequireApproval,
                 }
             ])
         ];
@@ -149,10 +149,10 @@ public class FunctionInvokingChatClientApprovalsTests
     private sealed class PassThroughDelegatingAIFunction(AIFunction inner) : DelegatingAIFunction(inner);
 
     [Fact]
-    public async Task IsInvokerRequested_IsFalseForApprovalRequiredFunctionNestedInDelegatingWrapperAsync()
+    public async Task RequiresConfirmation_IsTrueForApprovalRequiredFunctionNestedInDelegatingWrapperAsync()
     {
         // Wrap the ApprovalRequiredAIFunction in another DelegatingAIFunction (e.g. a telemetry decorator).
-        // FICC must still classify the call as "function-required approval" (IsInvokerRequested = false)
+        // FICC must still classify the call as approval-required (RequiresConfirmation = true, the default)
         // by walking the delegation chain via GetService<ApprovalRequiredAIFunction>().
         AITool[] tools =
         [
@@ -184,7 +184,7 @@ public class FunctionInvokingChatClientApprovalsTests
                 new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1")),
                 new ToolApprovalRequestContent("ficc_callId2", new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
                 {
-                    IsInvokerRequested = true,
+                    RequiresConfirmation = false,
                 }
             ])
         ];
@@ -195,12 +195,12 @@ public class FunctionInvokingChatClientApprovalsTests
     }
 
     [Fact]
-    public async Task IsInvokerRequested_IsTrueForFunctionCallWithNoMatchingToolWhenPeerRequiresApprovalAsync()
+    public async Task RequiresConfirmation_IsFalseForFunctionCallWithNoMatchingToolWhenPeerRequiresApprovalAsync()
     {
         // The downstream client emits an FCC referencing a tool name that is not in the tools list.
-        // Because a peer call (Func1) requires approval, FICC still wraps the unknown call as collateral.
+        // Because a peer call (Func1) requires approval, FICC still wraps the unknown call.
         // Since no matching tool is found (and therefore no ApprovalRequiredAIFunction is detected),
-        // the resulting approval request must carry IsInvokerRequested = true.
+        // the resulting approval request must carry RequiresConfirmation = false.
         var options = new ChatOptions
         {
             Tools =
@@ -229,7 +229,7 @@ public class FunctionInvokingChatClientApprovalsTests
                 new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1")),
                 new ToolApprovalRequestContent("ficc_callId2", new FunctionCallContent("callId2", "Unknown"))
                 {
-                    IsInvokerRequested = true,
+                    RequiresConfirmation = false,
                 }
             ])
         ];
@@ -1841,7 +1841,7 @@ public class FunctionInvokingChatClientApprovalsTests
         ToolApprovalRequestContent tarc =>
             new ToolApprovalRequestContent(tarc.RequestId, (ToolCallContent)CloneFcc(tarc.ToolCall))
             {
-                IsInvokerRequested = tarc.IsInvokerRequested,
+                RequiresConfirmation = tarc.RequiresConfirmation,
             },
         ToolApprovalResponseContent tarc =>
             new ToolApprovalResponseContent(tarc.RequestId, tarc.Approved, (ToolCallContent)CloneFcc(tarc.ToolCall))

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
@@ -83,6 +83,9 @@ public class FunctionInvokingChatClientApprovalsTests
             [
                 new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1")),
                 new ToolApprovalRequestContent("ficc_callId2", new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
+                {
+                    IsInvokerRequested = true,
+                }
             ])
         ];
 
@@ -121,18 +124,119 @@ public class FunctionInvokingChatClientApprovalsTests
             new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1"), new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } })]),
         ];
 
+        // When additionalToolsRequireApproval is true: Func1 (additional tools) requires approval and Func2 (options.Tools) is collateral.
+        // When false: Func2 (options.Tools) requires approval and Func1 (additional tools) is collateral.
         List<ChatMessage> expectedOutput =
         [
             new ChatMessage(ChatRole.Assistant,
             [
-                new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1")),
+                new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1"))
+                {
+                    IsInvokerRequested = !additionalToolsRequireApproval,
+                },
                 new ToolApprovalRequestContent("ficc_callId2", new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
+                {
+                    IsInvokerRequested = additionalToolsRequireApproval,
+                }
             ])
         ];
 
         await InvokeAndAssertAsync(options, input, downstreamClientOutput, expectedOutput, additionalTools: additionalTools);
 
         await InvokeAndAssertStreamingAsync(options, input, downstreamClientOutput, expectedOutput, additionalTools: additionalTools);
+    }
+
+    private sealed class PassThroughDelegatingAIFunction(AIFunction inner) : DelegatingAIFunction(inner);
+
+    [Fact]
+    public async Task IsInvokerRequested_IsFalseForApprovalRequiredFunctionNestedInDelegatingWrapperAsync()
+    {
+        // Wrap the ApprovalRequiredAIFunction in another DelegatingAIFunction (e.g. a telemetry decorator).
+        // FICC must still classify the call as "function-required approval" (IsInvokerRequested = false)
+        // by walking the delegation chain via GetService<ApprovalRequiredAIFunction>().
+        AITool[] tools =
+        [
+            new PassThroughDelegatingAIFunction(
+                new ApprovalRequiredAIFunction(
+                    AIFunctionFactory.Create(() => "Result 1", "Func1"))),
+            AIFunctionFactory.Create((int i) => $"Result 2: {i}", "Func2"),
+        ];
+
+        var options = new ChatOptions { Tools = tools };
+
+        List<ChatMessage> input =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+        ];
+
+        List<ChatMessage> downstreamClientOutput =
+        [
+            new ChatMessage(ChatRole.Assistant, [
+                new FunctionCallContent("callId1", "Func1"),
+                new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } })
+            ]),
+        ];
+
+        List<ChatMessage> expectedOutput =
+        [
+            new ChatMessage(ChatRole.Assistant,
+            [
+                new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1")),
+                new ToolApprovalRequestContent("ficc_callId2", new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
+                {
+                    IsInvokerRequested = true,
+                }
+            ])
+        ];
+
+        await InvokeAndAssertAsync(options, input, downstreamClientOutput, expectedOutput);
+
+        await InvokeAndAssertStreamingAsync(options, input, downstreamClientOutput, expectedOutput);
+    }
+
+    [Fact]
+    public async Task IsInvokerRequested_IsTrueForFunctionCallWithNoMatchingToolWhenPeerRequiresApprovalAsync()
+    {
+        // The downstream client emits an FCC referencing a tool name that is not in the tools list.
+        // Because a peer call (Func1) requires approval, FICC still wraps the unknown call as collateral.
+        // Since no matching tool is found (and therefore no ApprovalRequiredAIFunction is detected),
+        // the resulting approval request must carry IsInvokerRequested = true.
+        var options = new ChatOptions
+        {
+            Tools =
+            [
+                new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => "Result 1", "Func1")),
+            ]
+        };
+
+        List<ChatMessage> input =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+        ];
+
+        List<ChatMessage> downstreamClientOutput =
+        [
+            new ChatMessage(ChatRole.Assistant, [
+                new FunctionCallContent("callId1", "Func1"),
+                new FunctionCallContent("callId2", "Unknown"),
+            ]),
+        ];
+
+        List<ChatMessage> expectedOutput =
+        [
+            new ChatMessage(ChatRole.Assistant,
+            [
+                new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1")),
+                new ToolApprovalRequestContent("ficc_callId2", new FunctionCallContent("callId2", "Unknown"))
+                {
+                    IsInvokerRequested = true,
+                }
+            ])
+        ];
+
+        await InvokeAndAssertAsync(options, input, downstreamClientOutput, expectedOutput);
+
+        await InvokeAndAssertStreamingAsync(options, input, downstreamClientOutput, expectedOutput);
     }
 
     [Fact]
@@ -1735,7 +1839,10 @@ public class FunctionInvokingChatClientApprovalsTests
             InformationalOnly = fcc.InformationalOnly
         },
         ToolApprovalRequestContent tarc =>
-            new ToolApprovalRequestContent(tarc.RequestId, (ToolCallContent)CloneFcc(tarc.ToolCall)),
+            new ToolApprovalRequestContent(tarc.RequestId, (ToolCallContent)CloneFcc(tarc.ToolCall))
+            {
+                IsInvokerRequested = tarc.IsInvokerRequested,
+            },
         ToolApprovalResponseContent tarc =>
             new ToolApprovalResponseContent(tarc.RequestId, tarc.Approved, (ToolCallContent)CloneFcc(tarc.ToolCall))
             {


### PR DESCRIPTION
Resolves #7550.

Adds `ToolApprovalRequestContent.RequiresConfirmation` so consumers can distinguish approval requests where the underlying function genuinely needs approval (`RequiresConfirmation = true`, the default) from requests that `FunctionInvokingChatClient` added as a no-op because a peer call in the same response requires approval (`RequiresConfirmation = false`).

See #7550 for the full proposal (summary, motivation, goals, non-goals, detailed design). The name is still being iterated on in #7550; the property name in this PR may change to the agreed-upon name before merge.

## Changes

- **`Microsoft.Extensions.AI.Abstractions`** — new `bool ToolApprovalRequestContent.RequiresConfirmation { get; set; } = true;`, serialized like `FunctionCallContent.InformationalOnly`. Default `true` means any non-FICC producer that constructs a `ToolApprovalRequestContent` because the underlying tool genuinely requires approval is correct without code changes.
- **`FunctionInvokingChatClient`** — both wrap sites now set the flag per call.
  - Non-streaming `ReplaceFunctionCallsWithApprovalRequests` uses `FindTool` + `GetService<ApprovalRequiredAIFunction>()` per FCC; the lookup is captured in the existing index list so the wrap site sets `RequiresConfirmation` without a second pass.
  - Streaming `TryReplaceFunctionCallsWithApprovalRequests` now takes the pre-computed `approvalRequiredFunctions` array (already computed at the caller for batch buffering) and matches by name, avoiding a second `FindTool` + `GetService` scan per FCC.
- **API baseline** — `Microsoft.Extensions.AI.Abstractions.json` updated.

## Tests

- `AssertExtensions.EqualMessageLists` and the test-local `CloneFcc` propagate and assert the new flag.
- Two existing FICC mixed-batch approval tests assert per-call polarity.
- Two new FICC tests: (a) approval-required function nested inside another `DelegatingAIFunction`; (b) FCC whose name doesn't match any tool when a peer requires approval.
- Two new unit tests on `ToolApprovalRequestContent`: default value, JSON round-trip.

40 approval tests, 161 FICC tests, and 21 `ToolApprovalRequestContent` unit tests pass on net9.0.
