### PR TITLE
Allow OpenTelemetry*Client.JsonSerializerOptions to control full OTel message formatting

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
@@ -93,8 +93,8 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
     /// <summary>Gets or sets JSON serialization options to use when formatting chat data into telemetry strings.</summary>
     /// <remarks>
     /// <para>
-    /// The default value uses <see cref="System.Text.Json.JsonNamingPolicy.SnakeCaseLower"/> property naming,
-    /// <see cref="System.Text.Json.JsonSerializerOptions.WriteIndented"/> set to <see langword="true"/>,
+    /// The default value uses <see cref="JsonNamingPolicy.SnakeCaseLower"/> property naming,
+    /// <see cref="JsonSerializerOptions.WriteIndented"/> set to <see langword="true"/>,
     /// and includes type metadata for all built-in OpenTelemetry message-part types.
     /// </para>
     /// <para>
@@ -103,16 +103,16 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
     /// client.JsonSerializerOptions = new JsonSerializerOptions(client.JsonSerializerOptions) { WriteIndented = false };
     /// </code>
     /// </para>
+    /// <para>
+    /// The value must produce OpenTelemetry-conformant message JSON: its <see cref="JsonSerializerOptions.PropertyNamingPolicy"/>
+    /// must be <see cref="JsonNamingPolicy.SnakeCaseLower"/> and the built-in OpenTelemetry type resolver must be first in its
+    /// <see cref="JsonSerializerOptions.TypeInfoResolverChain"/>. Copying the current options as shown above preserves both.
+    /// </para>
     /// </remarks>
     public JsonSerializerOptions JsonSerializerOptions
     {
         get => _jsonSerializerOptions;
-        set
-        {
-            _ = Throw.IfNull(value);
-            OtelMessageSerializer.ThrowIfMissingOtelResolver(value);
-            _jsonSerializerOptions = value;
-        }
+        set => _jsonSerializerOptions = Throw.IfNull(value);
     }
 
     /// <inheritdoc/>
@@ -150,11 +150,14 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
         base.GetService(serviceType, serviceKey);
 
     /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">
+    /// <see cref="JsonSerializerOptions"/> is not configured to produce OpenTelemetry-conformant message JSON.
+    /// </exception>
     public override async Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
     {
         _ = Throw.IfNull(messages);
-        _jsonSerializerOptions.MakeReadOnly();
+        OtelMessageSerializer.ValidateAndFreeze(_jsonSerializerOptions);
 
         using Activity? activity = CreateAndConfigureActivity(options);
         Stopwatch? stopwatch = _operationDurationHistogram.Enabled ? Stopwatch.StartNew() : null;
@@ -181,11 +184,14 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
     }
 
     /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">
+    /// <see cref="JsonSerializerOptions"/> is not configured to produce OpenTelemetry-conformant message JSON.
+    /// </exception>
     public override async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
         IEnumerable<ChatMessage> messages, ChatOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         _ = Throw.IfNull(messages);
-        _jsonSerializerOptions.MakeReadOnly();
+        OtelMessageSerializer.ValidateAndFreeze(_jsonSerializerOptions);
 
         using Activity? activity = CreateAndConfigureActivity(options, streaming: true);
         bool recordChunkHistograms = _timeToFirstChunkHistogram.Enabled || _timePerOutputChunkHistogram.Enabled;

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
@@ -87,14 +87,32 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
             advice: new() { HistogramBucketBoundaries = OpenTelemetryConsts.GenAI.Client.TimePerOutputChunk.ExplicitBucketBoundaries }
             );
 
-        _jsonSerializerOptions = AIJsonUtilities.DefaultOptions;
+        _jsonSerializerOptions = OtelMessageSerializer.DefaultOptions;
     }
 
     /// <summary>Gets or sets JSON serialization options to use when formatting chat data into telemetry strings.</summary>
+    /// <remarks>
+    /// <para>
+    /// The default value uses <see cref="System.Text.Json.JsonNamingPolicy.SnakeCaseLower"/> property naming,
+    /// <see cref="System.Text.Json.JsonSerializerOptions.WriteIndented"/> set to <see langword="true"/>,
+    /// and includes type metadata for all built-in OpenTelemetry message-part types.
+    /// </para>
+    /// <para>
+    /// To customize settings, it is recommended to copy the current options and override individual properties:
+    /// <code>
+    /// client.JsonSerializerOptions = new JsonSerializerOptions(client.JsonSerializerOptions) { WriteIndented = false };
+    /// </code>
+    /// </para>
+    /// </remarks>
     public JsonSerializerOptions JsonSerializerOptions
     {
         get => _jsonSerializerOptions;
-        set => _jsonSerializerOptions = Throw.IfNull(value);
+        set
+        {
+            _ = Throw.IfNull(value);
+            OtelMessageSerializer.ThrowIfMissingOtelResolver(value);
+            _jsonSerializerOptions = value;
+        }
     }
 
     /// <inheritdoc/>
@@ -527,12 +545,12 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
             {
                 _ = activity.AddTag(
                     OpenTelemetryConsts.GenAI.SystemInstructions,
-                    JsonSerializer.Serialize(new object[1] { new OtelGenericPart { Content = options!.Instructions } }, OtelMessageSerializer.DefaultOptions.GetTypeInfo(typeof(IList<object>))));
+                    JsonSerializer.Serialize(new object[1] { new OtelGenericPart { Content = options!.Instructions } }, _jsonSerializerOptions.GetTypeInfo(typeof(IList<object>))));
             }
 
             _ = activity.AddTag(
                 OpenTelemetryConsts.GenAI.Input.Messages,
-                OtelMessageSerializer.SerializeChatMessages(messages, customContentSerializerOptions: _jsonSerializerOptions));
+                OtelMessageSerializer.SerializeChatMessages(messages, options: _jsonSerializerOptions));
         }
     }
 
@@ -542,7 +560,7 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
         {
             _ = activity.AddTag(
                 OpenTelemetryConsts.GenAI.Output.Messages,
-                OtelMessageSerializer.SerializeChatMessages(response.Messages, response.FinishReason, customContentSerializerOptions: _jsonSerializerOptions));
+                OtelMessageSerializer.SerializeChatMessages(response.Messages, response.FinishReason, options: _jsonSerializerOptions));
         }
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI/Common/OtelMessageSerializer.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Common/OtelMessageSerializer.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Shared.Diagnostics;
 
 #pragma warning disable CA1307 // Specify StringComparison for clarity
 #pragma warning disable CA1308 // Normalize strings to uppercase
@@ -18,6 +19,19 @@ namespace Microsoft.Extensions.AI;
 internal static class OtelMessageSerializer
 {
     internal static readonly JsonSerializerOptions DefaultOptions = CreateDefaultOptions();
+
+    /// <summary>
+    /// Validates that the given options include the required OTel type resolver.
+    /// </summary>
+    internal static void ThrowIfMissingOtelResolver(JsonSerializerOptions options)
+    {
+        if (!options.TypeInfoResolverChain.Any(r => r is OtelContext))
+        {
+            Throw.ArgumentException(
+                nameof(options),
+                "The provided JsonSerializerOptions is missing the required OpenTelemetry type resolver.");
+        }
+    }
 
     private static readonly JsonElement _emptyObject =
         JsonSerializer.SerializeToElement(new object(), DefaultOptions.GetTypeInfo(typeof(object)));
@@ -36,8 +50,10 @@ internal static class OtelMessageSerializer
     }
 
     internal static string SerializeChatMessages(
-        IEnumerable<ChatMessage> messages, ChatFinishReason? chatFinishReason = null, JsonSerializerOptions? customContentSerializerOptions = null)
+        IEnumerable<ChatMessage> messages, ChatFinishReason? chatFinishReason = null, JsonSerializerOptions? options = null)
     {
+        options ??= DefaultOptions;
+
         List<object> output = [];
 
         string? finishReason =
@@ -225,12 +241,7 @@ internal static class OtelMessageSerializer
                         JsonElement element = _emptyObject;
                         try
                         {
-                            JsonTypeInfo? unknownContentTypeInfo =
-                                customContentSerializerOptions?.TryGetTypeInfo(content.GetType(), out JsonTypeInfo? ctsi) is true ? ctsi :
-                                DefaultOptions.TryGetTypeInfo(content.GetType(), out JsonTypeInfo? dtsi) ? dtsi :
-                                null;
-
-                            if (unknownContentTypeInfo is not null)
+                            if (options.TryGetTypeInfo(content.GetType(), out JsonTypeInfo? unknownContentTypeInfo))
                             {
                                 element = JsonSerializer.SerializeToElement(content, unknownContentTypeInfo);
                             }
@@ -252,7 +263,7 @@ internal static class OtelMessageSerializer
             output.Add(m);
         }
 
-        return JsonSerializer.Serialize(output, DefaultOptions.GetTypeInfo(typeof(IList<object>)));
+        return JsonSerializer.Serialize(output, options.GetTypeInfo(typeof(IList<object>)));
     }
 
     /// <summary>Derives the OTel <c>modality</c> classifier from a media type's top-level type.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI/Common/OtelMessageSerializer.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Common/OtelMessageSerializer.cs
@@ -21,16 +21,27 @@ internal static class OtelMessageSerializer
     internal static readonly JsonSerializerOptions DefaultOptions = CreateDefaultOptions();
 
     /// <summary>
-    /// Validates that the given options include the required OTel type resolver.
+    /// Validates that the given options would produce OpenTelemetry-conformant message JSON, then makes them
+    /// read-only so the validated state cannot be mutated afterwards.
     /// </summary>
-    internal static void ThrowIfMissingOtelResolver(JsonSerializerOptions options)
+    internal static void ValidateAndFreeze(JsonSerializerOptions options)
     {
-        if (!options.TypeInfoResolverChain.Any(r => r is OtelContext))
+        const string CopyHint = "Copy the existing JsonSerializerOptions (new JsonSerializerOptions(instance.JsonSerializerOptions)) and override only the properties you need.";
+
+        IList<IJsonTypeInfoResolver> chain = options.TypeInfoResolverChain;
+        if (chain.Count == 0 || chain[0] is not OtelContext)
         {
-            Throw.ArgumentException(
-                nameof(options),
-                "The provided JsonSerializerOptions is missing the required OpenTelemetry type resolver.");
+            Throw.InvalidOperationException(
+                "The configured JsonSerializerOptions must have the required OpenTelemetry type resolver first in its TypeInfoResolverChain. " + CopyHint);
         }
+
+        if (options.PropertyNamingPolicy != JsonNamingPolicy.SnakeCaseLower)
+        {
+            Throw.InvalidOperationException(
+                "The configured JsonSerializerOptions must use JsonNamingPolicy.SnakeCaseLower to produce OpenTelemetry-conformant property names. " + CopyHint);
+        }
+
+        options.MakeReadOnly();
     }
 
     private static readonly JsonElement _emptyObject =

--- a/src/Libraries/Microsoft.Extensions.AI/Realtime/OpenTelemetryRealtimeClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Realtime/OpenTelemetryRealtimeClient.cs
@@ -53,8 +53,8 @@ public sealed class OpenTelemetryRealtimeClient : DelegatingRealtimeClient
     /// <summary>Gets or sets JSON serialization options to use when formatting realtime data into telemetry strings.</summary>
     /// <remarks>
     /// <para>
-    /// The default value uses <see cref="System.Text.Json.JsonNamingPolicy.SnakeCaseLower"/> property naming,
-    /// <see cref="System.Text.Json.JsonSerializerOptions.WriteIndented"/> set to <see langword="true"/>,
+    /// The default value uses <see cref="JsonNamingPolicy.SnakeCaseLower"/> property naming,
+    /// <see cref="JsonSerializerOptions.WriteIndented"/> set to <see langword="true"/>,
     /// and includes type metadata for all built-in OpenTelemetry message-part types.
     /// </para>
     /// <para>
@@ -63,16 +63,16 @@ public sealed class OpenTelemetryRealtimeClient : DelegatingRealtimeClient
     /// client.JsonSerializerOptions = new JsonSerializerOptions(client.JsonSerializerOptions) { WriteIndented = false };
     /// </code>
     /// </para>
+    /// <para>
+    /// The value must produce OpenTelemetry-conformant message JSON: its <see cref="JsonSerializerOptions.PropertyNamingPolicy"/>
+    /// must be <see cref="JsonNamingPolicy.SnakeCaseLower"/> and the built-in OpenTelemetry type resolver must be first in its
+    /// <see cref="JsonSerializerOptions.TypeInfoResolverChain"/>. Copying the current options as shown above preserves both.
+    /// </para>
     /// </remarks>
     public JsonSerializerOptions JsonSerializerOptions
     {
         get => _jsonSerializerOptions;
-        set
-        {
-            _ = Throw.IfNull(value);
-            OtelMessageSerializer.ThrowIfMissingOtelResolver(value);
-            _jsonSerializerOptions = value;
-        }
+        set => _jsonSerializerOptions = Throw.IfNull(value);
     }
 
     /// <inheritdoc />

--- a/src/Libraries/Microsoft.Extensions.AI/Realtime/OpenTelemetryRealtimeClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Realtime/OpenTelemetryRealtimeClient.cs
@@ -36,7 +36,7 @@ public sealed class OpenTelemetryRealtimeClient : DelegatingRealtimeClient
     {
         _logger = logger;
         _sourceName = sourceName;
-        _jsonSerializerOptions = AIJsonUtilities.DefaultOptions;
+        _jsonSerializerOptions = OtelMessageSerializer.DefaultOptions;
     }
 
     /// <summary>
@@ -51,10 +51,28 @@ public sealed class OpenTelemetryRealtimeClient : DelegatingRealtimeClient
     public bool EnableSensitiveData { get; set; } = TelemetryHelpers.EnableSensitiveDataDefault;
 
     /// <summary>Gets or sets JSON serialization options to use when formatting realtime data into telemetry strings.</summary>
+    /// <remarks>
+    /// <para>
+    /// The default value uses <see cref="System.Text.Json.JsonNamingPolicy.SnakeCaseLower"/> property naming,
+    /// <see cref="System.Text.Json.JsonSerializerOptions.WriteIndented"/> set to <see langword="true"/>,
+    /// and includes type metadata for all built-in OpenTelemetry message-part types.
+    /// </para>
+    /// <para>
+    /// To customize settings, it is recommended to copy the current options and override individual properties:
+    /// <code>
+    /// client.JsonSerializerOptions = new JsonSerializerOptions(client.JsonSerializerOptions) { WriteIndented = false };
+    /// </code>
+    /// </para>
+    /// </remarks>
     public JsonSerializerOptions JsonSerializerOptions
     {
         get => _jsonSerializerOptions;
-        set => _jsonSerializerOptions = Throw.IfNull(value);
+        set
+        {
+            _ = Throw.IfNull(value);
+            OtelMessageSerializer.ThrowIfMissingOtelResolver(value);
+            _jsonSerializerOptions = value;
+        }
     }
 
     /// <inheritdoc />

--- a/src/Libraries/Microsoft.Extensions.AI/Realtime/OpenTelemetryRealtimeClientSession.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Realtime/OpenTelemetryRealtimeClientSession.cs
@@ -129,8 +129,8 @@ internal sealed partial class OpenTelemetryRealtimeClientSession : IRealtimeClie
     /// <summary>Gets or sets JSON serialization options to use when formatting realtime data into telemetry strings.</summary>
     /// <remarks>
     /// <para>
-    /// The default value uses <see cref="System.Text.Json.JsonNamingPolicy.SnakeCaseLower"/> property naming,
-    /// <see cref="System.Text.Json.JsonSerializerOptions.WriteIndented"/> set to <see langword="true"/>,
+    /// The default value uses <see cref="JsonNamingPolicy.SnakeCaseLower"/> property naming,
+    /// <see cref="JsonSerializerOptions.WriteIndented"/> set to <see langword="true"/>,
     /// and includes type metadata for all built-in OpenTelemetry message-part types.
     /// </para>
     /// <para>
@@ -139,16 +139,16 @@ internal sealed partial class OpenTelemetryRealtimeClientSession : IRealtimeClie
     /// session.JsonSerializerOptions = new JsonSerializerOptions(session.JsonSerializerOptions) { WriteIndented = false };
     /// </code>
     /// </para>
+    /// <para>
+    /// The value must produce OpenTelemetry-conformant message JSON: its <see cref="JsonSerializerOptions.PropertyNamingPolicy"/>
+    /// must be <see cref="JsonNamingPolicy.SnakeCaseLower"/> and the built-in OpenTelemetry type resolver must be first in its
+    /// <see cref="JsonSerializerOptions.TypeInfoResolverChain"/>. Copying the current options as shown above preserves both.
+    /// </para>
     /// </remarks>
     public JsonSerializerOptions JsonSerializerOptions
     {
         get => _jsonSerializerOptions;
-        set
-        {
-            _ = Throw.IfNull(value);
-            OtelMessageSerializer.ThrowIfMissingOtelResolver(value);
-            _jsonSerializerOptions = value;
-        }
+        set => _jsonSerializerOptions = Throw.IfNull(value);
     }
 
     /// <inheritdoc />
@@ -191,8 +191,13 @@ internal sealed partial class OpenTelemetryRealtimeClientSession : IRealtimeClie
     }
 
     /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">
+    /// <see cref="JsonSerializerOptions"/> is not configured to produce OpenTelemetry-conformant message JSON.
+    /// </exception>
     public async Task SendAsync(RealtimeClientMessage message, CancellationToken cancellationToken = default)
     {
+        OtelMessageSerializer.ValidateAndFreeze(_jsonSerializerOptions);
+
         if (EnableSensitiveData && _activitySource.HasListeners())
         {
             var otelMessage = ExtractClientOtelMessage(message);
@@ -211,10 +216,13 @@ internal sealed partial class OpenTelemetryRealtimeClientSession : IRealtimeClie
     }
 
     /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">
+    /// <see cref="JsonSerializerOptions"/> is not configured to produce OpenTelemetry-conformant message JSON.
+    /// </exception>
     public async IAsyncEnumerable<RealtimeServerMessage> GetStreamingResponseAsync(
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        _jsonSerializerOptions.MakeReadOnly();
+        OtelMessageSerializer.ValidateAndFreeze(_jsonSerializerOptions);
 
         RealtimeSessionOptions? options = Options;
         string? requestModelId = options?.Model ?? _defaultModelId;

--- a/src/Libraries/Microsoft.Extensions.AI/Realtime/OpenTelemetryRealtimeClientSession.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Realtime/OpenTelemetryRealtimeClientSession.cs
@@ -123,14 +123,32 @@ internal sealed partial class OpenTelemetryRealtimeClientSession : IRealtimeClie
         _tokenUsageHistogram = OtelMetricHelpers.CreateGenAITokenUsageHistogram(_meter);
         _operationDurationHistogram = OtelMetricHelpers.CreateGenAIOperationDurationHistogram(_meter);
 
-        _jsonSerializerOptions = AIJsonUtilities.DefaultOptions;
+        _jsonSerializerOptions = OtelMessageSerializer.DefaultOptions;
     }
 
     /// <summary>Gets or sets JSON serialization options to use when formatting realtime data into telemetry strings.</summary>
+    /// <remarks>
+    /// <para>
+    /// The default value uses <see cref="System.Text.Json.JsonNamingPolicy.SnakeCaseLower"/> property naming,
+    /// <see cref="System.Text.Json.JsonSerializerOptions.WriteIndented"/> set to <see langword="true"/>,
+    /// and includes type metadata for all built-in OpenTelemetry message-part types.
+    /// </para>
+    /// <para>
+    /// To customize settings, it is recommended to copy the current options and override individual properties:
+    /// <code>
+    /// session.JsonSerializerOptions = new JsonSerializerOptions(session.JsonSerializerOptions) { WriteIndented = false };
+    /// </code>
+    /// </para>
+    /// </remarks>
     public JsonSerializerOptions JsonSerializerOptions
     {
         get => _jsonSerializerOptions;
-        set => _jsonSerializerOptions = Throw.IfNull(value);
+        set
+        {
+            _ = Throw.IfNull(value);
+            OtelMessageSerializer.ThrowIfMissingOtelResolver(value);
+            _jsonSerializerOptions = value;
+        }
     }
 
     /// <inheritdoc />
@@ -311,7 +329,7 @@ internal sealed partial class OpenTelemetryRealtimeClientSession : IRealtimeClie
     }
 
     /// <summary>Adds output messages tag to the activity if there are messages to add.</summary>
-    private static void AddOutputMessagesTag(Activity? activity, List<RealtimeOtelMessage>? outputMessages)
+    private void AddOutputMessagesTag(Activity? activity, List<RealtimeOtelMessage>? outputMessages)
     {
         if (activity is { IsAllDataRequested: true } && outputMessages is { Count: > 0 })
         {
@@ -498,15 +516,15 @@ internal sealed partial class OpenTelemetryRealtimeClientSession : IRealtimeClie
     }
 
     /// <summary>Serializes a single message to OTel format (as an array with one element).</summary>
-    private static string SerializeMessage(RealtimeOtelMessage message)
+    private string SerializeMessage(RealtimeOtelMessage message)
     {
-        return JsonSerializer.Serialize(new[] { message }, OtelContext.Default.IEnumerableRealtimeOtelMessage);
+        return JsonSerializer.Serialize(new[] { message }, _jsonSerializerOptions.GetTypeInfo(typeof(IEnumerable<RealtimeOtelMessage>)));
     }
 
     /// <summary>Serializes content items to OTel format.</summary>
-    private static string SerializeMessages(IEnumerable<RealtimeOtelMessage> messages)
+    private string SerializeMessages(IEnumerable<RealtimeOtelMessage> messages)
     {
-        return JsonSerializer.Serialize(messages, OtelContext.Default.IEnumerableRealtimeOtelMessage);
+        return JsonSerializer.Serialize(messages, _jsonSerializerOptions.GetTypeInfo(typeof(IEnumerable<RealtimeOtelMessage>)));
     }
 
     /// <summary>Extracts content from an AIContent list and converts to OTel format.</summary>
@@ -622,17 +640,7 @@ internal sealed partial class OpenTelemetryRealtimeClientSession : IRealtimeClie
                     JsonElement element = default;
                     try
                     {
-                        JsonTypeInfo? unknownContentTypeInfo = null;
-                        if (_jsonSerializerOptions?.TryGetTypeInfo(content.GetType(), out JsonTypeInfo? ctsi) ?? false)
-                        {
-                            unknownContentTypeInfo = ctsi;
-                        }
-                        else if (AIJsonUtilities.DefaultOptions.TryGetTypeInfo(content.GetType(), out JsonTypeInfo? dtsi))
-                        {
-                            unknownContentTypeInfo = dtsi;
-                        }
-
-                        if (unknownContentTypeInfo is not null)
+                        if (_jsonSerializerOptions.TryGetTypeInfo(content.GetType(), out JsonTypeInfo? unknownContentTypeInfo))
                         {
                             element = JsonSerializer.SerializeToElement(content, unknownContentTypeInfo);
                         }
@@ -716,7 +724,7 @@ internal sealed partial class OpenTelemetryRealtimeClientSession : IRealtimeClie
                         {
                             _ = activity.AddTag(
                                 OpenTelemetryConsts.GenAI.SystemInstructions,
-                                JsonSerializer.Serialize(new object[1] { new OtelGenericPart { Content = options.Instructions } }, OtelContext.Default.IListObject));
+                                JsonSerializer.Serialize(new object[1] { new OtelGenericPart { Content = options.Instructions } }, _jsonSerializerOptions.GetTypeInfo(typeof(IList<object>))));
                         }
 
                     }
@@ -725,7 +733,7 @@ internal sealed partial class OpenTelemetryRealtimeClientSession : IRealtimeClie
                     {
                         _ = activity.AddTag(
                             OpenTelemetryConsts.GenAI.Tool.Definitions,
-                            JsonSerializer.Serialize(options.Tools.Select(t => OtelFunction.Create(t, includeOptionalProperties: EnableSensitiveData)), OtelContext.Default.IEnumerableOtelFunction));
+                            JsonSerializer.Serialize(options.Tools.Select(t => OtelFunction.Create(t, includeOptionalProperties: EnableSensitiveData)), _jsonSerializerOptions.GetTypeInfo(typeof(IEnumerable<OtelFunction>))));
                     }
                 }
             }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
@@ -1021,26 +1021,100 @@ public class OpenTelemetryChatClientTests
     }
 
     [Fact]
-    public void JsonSerializerOptions_MissingOtelResolver_Throws()
+    public async Task JsonSerializerOptions_NonSnakeCaseLowerNamingPolicy_ThrowsOnUse()
     {
-        using var innerClient = new TestChatClient();
-        using var chatClient = innerClient
-            .AsBuilder()
-            .UseOpenTelemetry(configure: instance =>
-            {
-                // Blank options — no OTel resolver
-                var ex = Assert.Throws<ArgumentException>(() =>
-                    instance.JsonSerializerOptions = new JsonSerializerOptions());
-                Assert.Contains("OpenTelemetry type resolver", ex.Message);
+        await RunTest(null);
+        await RunTest(JsonNamingPolicy.CamelCase);
 
-                // Options with a reflection resolver but no OTel resolver
-                var optsWithReflection = new JsonSerializerOptions();
-                optsWithReflection.TypeInfoResolverChain.Add(JsonSerializerOptions.Default.TypeInfoResolver!);
-                ex = Assert.Throws<ArgumentException>(() =>
-                    instance.JsonSerializerOptions = optsWithReflection);
-                Assert.Contains("OpenTelemetry type resolver", ex.Message);
-            })
-            .Build();
+        static async Task RunTest(JsonNamingPolicy? policy)
+        {
+            using var innerClient = new TestChatClient
+            {
+                GetResponseAsyncCallback = (messages, options, cancellationToken) =>
+                    Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "hi"))),
+            };
+            using var chatClient = new OpenTelemetryChatClient(innerClient);
+
+            // Copy the conformant default (so the OTel resolver stays first) and change only the naming
+            // policy. This isolates the naming-policy check: any value other than SnakeCaseLower must throw.
+            chatClient.JsonSerializerOptions =
+                new JsonSerializerOptions(chatClient.JsonSerializerOptions) { PropertyNamingPolicy = policy };
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => chatClient.GetResponseAsync([new(ChatRole.User, "hello")]));
+
+            Assert.Contains("new JsonSerializerOptions(", ex.Message);
+        }
+    }
+
+    [Fact]
+    public async Task JsonSerializerOptions_DefaultOptionsNotCopied_ThrowsOnUse()
+    {
+        using var innerClient = new TestChatClient
+        {
+            GetResponseAsyncCallback = (messages, options, cancellationToken) =>
+                Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "hi"))),
+        };
+        using var chatClient = new OpenTelemetryChatClient(innerClient);
+
+        // Starting from a blank JsonSerializerOptions (instead of copying the client's existing
+        // options) omits the required OpenTelemetry type resolver, so the first request throws.
+        chatClient.JsonSerializerOptions = new JsonSerializerOptions();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => chatClient.GetResponseAsync([new(ChatRole.User, "hello")]));
+
+        Assert.Contains("new JsonSerializerOptions(", ex.Message);
+    }
+
+    [Fact]
+    public async Task JsonSerializerOptions_OtelResolverNotFirst_ThrowsOnUse()
+    {
+        using var innerClient = new TestChatClient
+        {
+            GetResponseAsyncCallback = (messages, options, cancellationToken) =>
+                Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "hi"))),
+        };
+        using var chatClient = new OpenTelemetryChatClient(innerClient);
+
+        // Capture the OTel resolver from the conformant default before overwriting the options.
+        var otelResolver = chatClient.JsonSerializerOptions.TypeInfoResolverChain[0];
+
+        // OTel resolver present, snake_case set, but shadowed by an earlier reflection-based resolver.
+        // The first resolver in the chain wins, so reflection would serialize a non-conformant shape.
+        var opts = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+        opts.TypeInfoResolverChain.Add(JsonSerializerOptions.Default.TypeInfoResolver!);
+        opts.TypeInfoResolverChain.Add(otelResolver);
+        chatClient.JsonSerializerOptions = opts;
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => chatClient.GetResponseAsync([new(ChatRole.User, "hello")]));
+        Assert.Contains("new JsonSerializerOptions(", ex.Message);
+    }
+
+    [Fact]
+    public async Task JsonSerializerOptions_ConformantValue_IsFrozenOnFirstUse()
+    {
+        using var innerClient = new TestChatClient
+        {
+            GetResponseAsyncCallback = (messages, options, cancellationToken) =>
+                Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "hi"))),
+        };
+        using var chatClient = new OpenTelemetryChatClient(innerClient);
+
+        // A mutable, conformant copy of the default options.
+        var opts = new JsonSerializerOptions(chatClient.JsonSerializerOptions) { WriteIndented = false };
+        chatClient.JsonSerializerOptions = opts;
+
+        // Assignment alone does not freeze; the options stay mutable until first use.
+        Assert.False(opts.IsReadOnly);
+
+        _ = await chatClient.GetResponseAsync([new(ChatRole.User, "hello")]);
+
+        // First use freezes the value so its validated state cannot be mutated afterwards.
+        Assert.True(opts.IsReadOnly);
+        Assert.Same(opts, chatClient.JsonSerializerOptions);
+        Assert.Throws<InvalidOperationException>(() => opts.PropertyNamingPolicy = null);
     }
 
     [Theory]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -105,7 +106,7 @@ public class OpenTelemetryChatClientTests
             .UseOpenTelemetry(null, sourceName, configure: instance =>
             {
                 instance.EnableSensitiveData = enableSensitiveData;
-                instance.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;
+                AddTestJsonResolver(instance);
             })
             .Build();
 
@@ -433,7 +434,7 @@ public class OpenTelemetryChatClientTests
             .UseOpenTelemetry(null, sourceName, configure: instance =>
             {
                 instance.EnableSensitiveData = true;
-                instance.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;
+                AddTestJsonResolver(instance);
             })
             .Build();
 
@@ -594,7 +595,7 @@ public class OpenTelemetryChatClientTests
             .UseOpenTelemetry(null, sourceName, configure: instance =>
             {
                 instance.EnableSensitiveData = true;
-                instance.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;
+                AddTestJsonResolver(instance);
             })
             .Build();
 
@@ -696,7 +697,7 @@ public class OpenTelemetryChatClientTests
             .UseOpenTelemetry(null, sourceName, configure: instance =>
             {
                 instance.EnableSensitiveData = true;
-                instance.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;
+                AddTestJsonResolver(instance);
             })
             .Build();
 
@@ -829,7 +830,7 @@ public class OpenTelemetryChatClientTests
             .UseOpenTelemetry(null, sourceName, configure: instance =>
             {
                 instance.EnableSensitiveData = true;
-                instance.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;
+                AddTestJsonResolver(instance);
             })
             .Build();
 
@@ -998,6 +999,106 @@ public class OpenTelemetryChatClientTests
     private sealed class NonSerializableAIContent : AIContent;
 
     private static string ReplaceWhitespace(string? input) => Regex.Replace(input ?? "", @"\s+", " ").Trim();
+
+    /// <summary>
+    /// Configures the <see cref="OpenTelemetryChatClient"/> with options that chain the
+    /// <see cref="TestJsonSerializerContext"/> resolver after the default OTel resolvers.
+    /// </summary>
+    private static void AddTestJsonResolver(OpenTelemetryChatClient instance)
+    {
+        var opts = new JsonSerializerOptions(instance.JsonSerializerOptions);
+        opts.TypeInfoResolverChain.Add(TestJsonSerializerContext.Default);
+        instance.JsonSerializerOptions = opts;
+    }
+
+    [Fact]
+    public void JsonSerializerOptions_DefaultIsImmutable()
+    {
+        using var innerClient = new TestChatClient();
+        using var chatClient = new OpenTelemetryChatClient(innerClient);
+        Assert.True(chatClient.JsonSerializerOptions.IsReadOnly);
+        Assert.Throws<InvalidOperationException>(() => chatClient.JsonSerializerOptions.WriteIndented = true);
+    }
+
+    [Fact]
+    public void JsonSerializerOptions_MissingOtelResolver_Throws()
+    {
+        using var innerClient = new TestChatClient();
+        using var chatClient = innerClient
+            .AsBuilder()
+            .UseOpenTelemetry(configure: instance =>
+            {
+                // Blank options — no OTel resolver
+                var ex = Assert.Throws<ArgumentException>(() =>
+                    instance.JsonSerializerOptions = new JsonSerializerOptions());
+                Assert.Contains("OpenTelemetry type resolver", ex.Message);
+
+                // Options with a reflection resolver but no OTel resolver
+                var optsWithReflection = new JsonSerializerOptions();
+                optsWithReflection.TypeInfoResolverChain.Add(JsonSerializerOptions.Default.TypeInfoResolver!);
+                ex = Assert.Throws<ArgumentException>(() =>
+                    instance.JsonSerializerOptions = optsWithReflection);
+                Assert.Contains("OpenTelemetry type resolver", ex.Message);
+            })
+            .Build();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task JsonSerializerOptions_WriteIndented_IsHonored(bool writeIndented)
+    {
+        var sourceName = Guid.NewGuid().ToString();
+        var activities = new List<Activity>();
+        using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .AddInMemoryExporter(activities)
+            .Build();
+
+        using var innerClient = new TestChatClient
+        {
+            GetResponseAsyncCallback = async (messages, options, cancellationToken) =>
+            {
+                await Task.Yield();
+                return new ChatResponse(new ChatMessage(ChatRole.Assistant, "Hi!"))
+                {
+                    FinishReason = ChatFinishReason.Stop,
+                };
+            },
+            GetServiceCallback = (serviceType, serviceKey) =>
+                serviceType == typeof(ChatClientMetadata) ? new ChatClientMetadata("testprovider", new Uri("http://localhost"), "model") :
+                null,
+        };
+
+        using var chatClient = innerClient
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: sourceName, configure: instance =>
+            {
+                instance.EnableSensitiveData = true;
+                instance.JsonSerializerOptions = new JsonSerializerOptions(instance.JsonSerializerOptions) { WriteIndented = writeIndented };
+            })
+            .Build();
+
+        await chatClient.GetResponseAsync("Hello!");
+
+        var activity = Assert.Single(activities);
+        var inputMessages = Assert.IsType<string>(activity.GetTagItem("gen_ai.input.messages"));
+        var outputMessages = Assert.IsType<string>(activity.GetTagItem("gen_ai.output.messages"));
+
+        if (writeIndented)
+        {
+            Assert.Contains("\n", inputMessages);
+            Assert.Contains("\n", outputMessages);
+        }
+        else
+        {
+            Assert.DoesNotContain("\n", inputMessages);
+            Assert.DoesNotContain("\n", outputMessages);
+
+            // Verify compact JSON still uses snake_case (not camelCase "finishReason")
+            Assert.Contains("\"finish_reason\":", outputMessages);
+        }
+    }
 
     [Theory]
     [InlineData(false)]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Realtime/OpenTelemetryRealtimeClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Realtime/OpenTelemetryRealtimeClientTests.cs
@@ -586,23 +586,92 @@ public class OpenTelemetryRealtimeClientTests
     }
 
     [Fact]
-    public async Task JsonSerializerOptions_MissingOtelResolver_Throws()
+    public async Task JsonSerializerOptions_DefaultOptionsNotCopied_ThrowsOnUse()
     {
         await using var innerSession = new TestRealtimeClientSession();
         using var innerClient = new TestRealtimeClient(innerSession);
         using var client = new OpenTelemetryRealtimeClient(innerClient);
 
-        // Blank options — no OTel resolver
-        var ex = Assert.Throws<ArgumentException>(() =>
-            client.JsonSerializerOptions = new JsonSerializerOptions());
-        Assert.Contains("OpenTelemetry type resolver", ex.Message);
+        // Starting from a blank JsonSerializerOptions (instead of copying the client's existing
+        // options) omits the required OpenTelemetry type resolver, so the first send throws.
+        client.JsonSerializerOptions = new JsonSerializerOptions();
 
-        // Options with a reflection resolver but no OTel resolver
-        var optsWithReflection = new JsonSerializerOptions();
-        optsWithReflection.TypeInfoResolverChain.Add(JsonSerializerOptions.Default.TypeInfoResolver!);
-        ex = Assert.Throws<ArgumentException>(() =>
-            client.JsonSerializerOptions = optsWithReflection);
-        Assert.Contains("OpenTelemetry type resolver", ex.Message);
+        await using var session = await client.CreateSessionAsync();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            session.SendAsync(new CreateResponseRealtimeClientMessage()));
+
+        Assert.Contains("new JsonSerializerOptions(", ex.Message);
+    }
+
+    [Fact]
+    public async Task JsonSerializerOptions_OtelResolverNotFirst_ThrowsOnUse()
+    {
+        await using var innerSession = new TestRealtimeClientSession();
+        using var innerClient = new TestRealtimeClient(innerSession);
+        using var client = new OpenTelemetryRealtimeClient(innerClient);
+
+        // Capture the OTel resolver from the conformant default before overwriting the options.
+        var otelResolver = client.JsonSerializerOptions.TypeInfoResolverChain[0];
+
+        // OTel resolver present, snake_case set, but shadowed by an earlier reflection-based resolver.
+        // The first resolver in the chain wins, so reflection would serialize a non-conformant shape.
+        var opts = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+        opts.TypeInfoResolverChain.Add(JsonSerializerOptions.Default.TypeInfoResolver!);
+        opts.TypeInfoResolverChain.Add(otelResolver);
+        client.JsonSerializerOptions = opts;
+
+        await using var session = await client.CreateSessionAsync();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            session.SendAsync(new CreateResponseRealtimeClientMessage()));
+
+        Assert.Contains("new JsonSerializerOptions(", ex.Message);
+    }
+
+    [Fact]
+    public async Task JsonSerializerOptions_NonSnakeCaseLowerNamingPolicy_ThrowsOnUse()
+    {
+        await RunTest(null);
+        await RunTest(JsonNamingPolicy.CamelCase);
+
+        static async Task RunTest(JsonNamingPolicy? policy)
+        {
+            await using var innerSession = new TestRealtimeClientSession();
+            using var innerClient = new TestRealtimeClient(innerSession);
+            using var client = new OpenTelemetryRealtimeClient(innerClient);
+
+            // Copy the conformant default (so the OTel resolver stays first) and change only the naming
+            // policy. This isolates the naming-policy check: any value other than SnakeCaseLower must throw.
+            client.JsonSerializerOptions =
+                new JsonSerializerOptions(client.JsonSerializerOptions) { PropertyNamingPolicy = policy };
+
+            await using var session = await client.CreateSessionAsync();
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                session.SendAsync(new CreateResponseRealtimeClientMessage()));
+
+            Assert.Contains("new JsonSerializerOptions(", ex.Message);
+        }
+    }
+
+    [Fact]
+    public async Task JsonSerializerOptions_ConformantValue_IsFrozenOnFirstUse()
+    {
+        await using var innerSession = new TestRealtimeClientSession();
+        using var innerClient = new TestRealtimeClient(innerSession);
+        using var client = new OpenTelemetryRealtimeClient(innerClient);
+
+        // A mutable, conformant copy of the default options.
+        var opts = new JsonSerializerOptions(client.JsonSerializerOptions) { WriteIndented = false };
+        client.JsonSerializerOptions = opts;
+
+        // Assignment alone does not freeze; the options stay mutable until first use.
+        Assert.False(opts.IsReadOnly);
+
+        await using var session = await client.CreateSessionAsync();
+        await session.SendAsync(new CreateResponseRealtimeClientMessage());
+
+        // First use freezes the value so its validated state cannot be mutated afterwards.
+        Assert.True(opts.IsReadOnly);
+        Assert.Throws<InvalidOperationException>(() => opts.PropertyNamingPolicy = null);
     }
 
     [Theory]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Realtime/OpenTelemetryRealtimeClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Realtime/OpenTelemetryRealtimeClientTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,7 +81,9 @@ public class OpenTelemetryRealtimeClientTests
         using var innerClient = new TestRealtimeClient(innerSession);
         using var client = new OpenTelemetryRealtimeClient(innerClient, sourceName: sourceName);
         client.EnableSensitiveData = enableSensitiveData;
-        client.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;
+        var opts = new JsonSerializerOptions(client.JsonSerializerOptions);
+        opts.TypeInfoResolverChain.Add(TestJsonSerializerContext.Default);
+        client.JsonSerializerOptions = opts;
         await using var session = await client.CreateSessionAsync();
 
         await foreach (var msg in GetClientMessagesAsync())
@@ -570,6 +573,111 @@ public class OpenTelemetryRealtimeClientTests
         _ = cancellationToken;
 
         yield return new ResponseCreatedRealtimeServerMessage(RealtimeServerMessageType.ResponseDone);
+    }
+
+    [Fact]
+    public async Task JsonSerializerOptions_DefaultIsImmutable()
+    {
+        await using var innerSession = new TestRealtimeClientSession();
+        using var innerClient = new TestRealtimeClient(innerSession);
+        using var client = new OpenTelemetryRealtimeClient(innerClient);
+        Assert.True(client.JsonSerializerOptions.IsReadOnly);
+        Assert.Throws<InvalidOperationException>(() => client.JsonSerializerOptions.WriteIndented = true);
+    }
+
+    [Fact]
+    public async Task JsonSerializerOptions_MissingOtelResolver_Throws()
+    {
+        await using var innerSession = new TestRealtimeClientSession();
+        using var innerClient = new TestRealtimeClient(innerSession);
+        using var client = new OpenTelemetryRealtimeClient(innerClient);
+
+        // Blank options — no OTel resolver
+        var ex = Assert.Throws<ArgumentException>(() =>
+            client.JsonSerializerOptions = new JsonSerializerOptions());
+        Assert.Contains("OpenTelemetry type resolver", ex.Message);
+
+        // Options with a reflection resolver but no OTel resolver
+        var optsWithReflection = new JsonSerializerOptions();
+        optsWithReflection.TypeInfoResolverChain.Add(JsonSerializerOptions.Default.TypeInfoResolver!);
+        ex = Assert.Throws<ArgumentException>(() =>
+            client.JsonSerializerOptions = optsWithReflection);
+        Assert.Contains("OpenTelemetry type resolver", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task JsonSerializerOptions_WriteIndented_IsHonored(bool writeIndented)
+    {
+        var sourceName = Guid.NewGuid().ToString();
+        var activities = new List<Activity>();
+        using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .AddInMemoryExporter(activities)
+            .Build();
+
+        await using var innerSession = new TestRealtimeClientSession
+        {
+            Options = new RealtimeSessionOptions
+            {
+                Model = "test-model",
+                SessionKind = RealtimeSessionKind.Conversation,
+            },
+            GetServiceCallback = (serviceType, serviceKey) =>
+                serviceType == typeof(ChatClientMetadata) ? new ChatClientMetadata("testprovider", new Uri("http://localhost"), "model") :
+                null,
+            GetStreamingResponseAsyncCallback = (cancellationToken) => CallbackAsync(cancellationToken),
+        };
+
+        static async IAsyncEnumerable<RealtimeServerMessage> CallbackAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            _ = cancellationToken;
+            yield return new OutputTextAudioRealtimeServerMessage(RealtimeServerMessageType.OutputTextDone) { OutputIndex = 0, Text = "Hi!" };
+            yield return new ResponseCreatedRealtimeServerMessage(RealtimeServerMessageType.ResponseDone)
+            {
+                ResponseId = "resp_1",
+                Status = "completed",
+            };
+        }
+
+        using var innerClient = new TestRealtimeClient(innerSession);
+        using var client = new OpenTelemetryRealtimeClient(innerClient, sourceName: sourceName);
+        client.EnableSensitiveData = true;
+        client.JsonSerializerOptions = new JsonSerializerOptions(client.JsonSerializerOptions) { WriteIndented = writeIndented };
+        await using var session = await client.CreateSessionAsync();
+
+        await foreach (var msg in GetClientMessagesAsync())
+        {
+            await session.SendAsync(msg);
+        }
+
+        await foreach (var response in session.GetStreamingResponseAsync())
+        {
+            // Consume responses
+        }
+
+        // Find activities with input or output messages
+        var inputActivity = activities.FirstOrDefault(a => a.GetTagItem("gen_ai.input.messages") is not null);
+        var outputActivity = activities.FirstOrDefault(a => a.GetTagItem("gen_ai.output.messages") is not null);
+
+        Assert.NotNull(inputActivity);
+        Assert.NotNull(outputActivity);
+
+        var inputMessages = (string)inputActivity.GetTagItem("gen_ai.input.messages")!;
+        var outputMessages = (string)outputActivity.GetTagItem("gen_ai.output.messages")!;
+
+        if (writeIndented)
+        {
+            Assert.Contains("\n", inputMessages);
+            Assert.Contains("\n", outputMessages);
+        }
+        else
+        {
+            Assert.DoesNotContain("\n", inputMessages);
+            Assert.DoesNotContain("\n", outputMessages);
+        }
     }
 
 #pragma warning disable IDE0060 // Remove unused parameter


### PR DESCRIPTION
OpenTelemetry clients hardcode serialization options for `gen_ai.input.messages` and `gen_ai.output.messages`, ignoring the user-supplied JsonSerializerOptions.

This PR changes the default JsonSerializerOptions on OpenTelemetryChatClient and OpenTelemetryRealtimeClient/Session from AIJsonUtilities.DefaultOptions to OtelMessageSerializer.DefaultOptions (the previously hardcoded). The provided options now control the entire serialization pipeline, including the final JSON output, not just unknown content type resolution.

Users could now customize formatting (e.g. compact JSON) by copying the default options and overriding the desired properties:
```cs
  client.JsonSerializerOptions = new JsonSerializerOptions(client.JsonSerializerOptions) { WriteIndented = false };
```

### Breaking change

Before this fix, the setter on JsonSerializerOptions accepted any valid options object silently, even ones missing the OTel resolver. Those options were only used for a narrow fallback (unknown AIContent subtype resolution), so the missing resolver was harmless; the final serialization always used the hardcoded DefaultOptions.

After this fix, the setter throws ArgumentException if the supplied options don't contain the OtelContext resolver in their TypeInfoResolverChain.

---
If acceptable, 
fixes https://github.com/dotnet/extensions/issues/7514.