### PR TITLE
Fix Grpc.Net.ClientFactory version range check - Fixes #7565

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/buildTransitive/Microsoft.Extensions.Http.Resilience.targets
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/buildTransitive/Microsoft.Extensions.Http.Resilience.targets
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <_GrpcNetClientFactory>Grpc.Net.ClientFactory</_GrpcNetClientFactory>
     <_CompatibleGrpcNetClientFactoryVersion>2.64.0</_CompatibleGrpcNetClientFactoryVersion>
+    <!-- Extract a System.Version-compatible lower bound. Examples: [2.63.0] -> 2.63.0, [2.64.0,3.0.0) -> 2.64.0, (,2.80.0] and [2.64.0-preview.1] -> empty. -->
+    <_GrpcNetClientFactoryComparableVersionPattern>^\s*[\[\(]?\s*(\d+(?:\.\d+){1,3})(?=\s*(?:[,)\]]|$))</_GrpcNetClientFactoryComparableVersionPattern>
     <_GrpcNetClientFactoryVersionIsIncorrect>Grpc.Net.ClientFactory 2.63.0 or earlier could cause issues when used together with Microsoft.Extensions.Http.Resilience. For more details, see https://learn.microsoft.com/dotnet/core/resilience/http-resilience#known-issues. Consider using Grpc.Net.ClientFactory $(_CompatibleGrpcNetClientFactoryVersion) or later. To suppress the warning set SuppressCheckGrpcNetClientFactoryVersion=true.</_GrpcNetClientFactoryVersionIsIncorrect>
   </PropertyGroup>
 
@@ -15,40 +17,47 @@
           Condition=" '$(SuppressCheckGrpcNetClientFactoryVersion)' != 'true' ">
     <ItemGroup>
       <!-- Find the package in the .csproj file. -->
-      <_GrpcNetClientFactoryPackageReference Include="@(PackageReference)" Condition=" '%(PackageReference.Identity)' == '$(_GrpcNetClientFactory)' " />
+      <_GrpcNetClientFactoryPackageReference Include="@(PackageReference)" Condition=" '%(PackageReference.Identity)' == '$(_GrpcNetClientFactory)' ">
+        <_ComparableVersion>$([System.Text.RegularExpressions.Regex]::Match('%(PackageReference.Version)', '$(_GrpcNetClientFactoryComparableVersionPattern)').Groups[1].Value)</_ComparableVersion>
+        <_ComparableVersionOverride>$([System.Text.RegularExpressions.Regex]::Match('%(PackageReference.VersionOverride)', '$(_GrpcNetClientFactoryComparableVersionPattern)').Groups[1].Value)</_ComparableVersionOverride>
+      </_GrpcNetClientFactoryPackageReference>
 
       <!-- Find the version of the package in the Central Package Source. The solution uses the Central Package Management. -->
-      <_GrpcNetClientFactoryPackageVersion Include="@(PackageVersion)" Condition=" '%(PackageVersion.Identity)' == '$(_GrpcNetClientFactory)' " />
+      <_GrpcNetClientFactoryPackageVersion Include="@(PackageVersion)" Condition=" '%(PackageVersion.Identity)' == '$(_GrpcNetClientFactory)' ">
+        <_ComparableVersion>$([System.Text.RegularExpressions.Regex]::Match('%(PackageVersion.Version)', '$(_GrpcNetClientFactoryComparableVersionPattern)').Groups[1].Value)</_ComparableVersion>
+      </_GrpcNetClientFactoryPackageVersion>
       
       <!-- The package is added to the project as a transitive dependency. -->
-      <_GrpcNetClientFactoryTransitiveDependency Include="@(ReferencePath)" Condition=" '%(ReferencePath.NuGetPackageId)' == '$(_GrpcNetClientFactory)' " />
+      <_GrpcNetClientFactoryTransitiveDependency Include="@(ReferencePath)" Condition=" '%(ReferencePath.NuGetPackageId)' == '$(_GrpcNetClientFactory)' ">
+        <_ComparableVersion>$([System.Text.RegularExpressions.Regex]::Match('%(ReferencePath.NuGetPackageVersion)', '$(_GrpcNetClientFactoryComparableVersionPattern)').Groups[1].Value)</_ComparableVersion>
+      </_GrpcNetClientFactoryTransitiveDependency>
     </ItemGroup>
 
     <!-- The version of the package is included in the .csproj file. -->
     <Warning Condition=" @(_GrpcNetClientFactoryPackageReference->Count()) &gt; 0
-                         AND '%(_GrpcNetClientFactoryPackageReference.Version)' != ''
-                         AND $([MSBuild]::VersionLessThan('%(_GrpcNetClientFactoryPackageReference.Version)', '$(_CompatibleGrpcNetClientFactoryVersion)')) "
+                         AND '%(_GrpcNetClientFactoryPackageReference._ComparableVersion)' != ''
+                         AND $([MSBuild]::VersionLessThan('%(_GrpcNetClientFactoryPackageReference._ComparableVersion)', '$(_CompatibleGrpcNetClientFactoryVersion)')) "
              Text="$(_GrpcNetClientFactoryVersionIsIncorrect)" />
 
     <!-- The solution uses the Central Package Management and the version of the package is overridden in the .csproj file using the VersionOverride property. -->
     <Warning Condition=" '$(ManagePackageVersionsCentrally)' == 'true'
                          AND @(_GrpcNetClientFactoryPackageReference->Count()) &gt; 0
-                         AND '%(_GrpcNetClientFactoryPackageReference.VersionOverride)' != ''
-                         AND $([MSBuild]::VersionLessThan('%(_GrpcNetClientFactoryPackageReference.VersionOverride)', '$(_CompatibleGrpcNetClientFactoryVersion)')) "
+                         AND '%(_GrpcNetClientFactoryPackageReference._ComparableVersionOverride)' != ''
+                         AND $([MSBuild]::VersionLessThan('%(_GrpcNetClientFactoryPackageReference._ComparableVersionOverride)', '$(_CompatibleGrpcNetClientFactoryVersion)')) "
              Text="$(_GrpcNetClientFactoryVersionIsIncorrect)" />
 
     <!-- The solution uses the Central Package Management and the version of the package is included in the Central Package Source. -->
     <Warning Condition=" '$(ManagePackageVersionsCentrally)' == 'true'
                          AND @(_GrpcNetClientFactoryPackageReference->Count()) &gt; 0
-                         AND '%(_GrpcNetClientFactoryPackageVersion.Version)' != ''
-                         AND $([MSBuild]::VersionLessThan('%(_GrpcNetClientFactoryPackageVersion.Version)', '$(_CompatibleGrpcNetClientFactoryVersion)')) "
+                         AND '%(_GrpcNetClientFactoryPackageVersion._ComparableVersion)' != ''
+                         AND $([MSBuild]::VersionLessThan('%(_GrpcNetClientFactoryPackageVersion._ComparableVersion)', '$(_CompatibleGrpcNetClientFactoryVersion)')) "
              Text="$(_GrpcNetClientFactoryVersionIsIncorrect)" />
 
     <!-- This condition handles a case when the package is added to the project as a transitive dependency. -->
     <Warning Condition=" @(_GrpcNetClientFactoryPackageReference->Count()) == 0
                          AND @(_GrpcNetClientFactoryTransitiveDependency->Count()) &gt; 0
-                         AND '%(_GrpcNetClientFactoryTransitiveDependency.NuGetPackageVersion)' != ''
-                         AND $([MSBuild]::VersionLessThan('%(_GrpcNetClientFactoryTransitiveDependency.NuGetPackageVersion)', '$(_CompatibleGrpcNetClientFactoryVersion)')) "
+                         AND '%(_GrpcNetClientFactoryTransitiveDependency._ComparableVersion)' != ''
+                         AND $([MSBuild]::VersionLessThan('%(_GrpcNetClientFactoryTransitiveDependency._ComparableVersion)', '$(_CompatibleGrpcNetClientFactoryVersion)')) "
              Text="$(_GrpcNetClientFactoryVersionIsIncorrect)" />
   </Target>
 </Project>

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/BuildTransitive/GrpcNetClientFactoryVersionTargetTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/BuildTransitive/GrpcNetClientFactoryVersionTargetTests.cs
@@ -1,0 +1,458 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security;
+#if NETFRAMEWORK
+using System.Text;
+#endif
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.Extensions.Http.Resilience.Test.BuildTransitive;
+
+public class GrpcNetClientFactoryVersionTargetTests
+{
+    private const string WarningMessage = "Grpc.Net.ClientFactory 2.63.0 or earlier could cause issues";
+
+    public static TheoryData<string, string> CompatibleVersionSources => new()
+    {
+        {
+            "PackageReference.Version",
+            """
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" Version="[2.80.0]" />
+            </ItemGroup>
+            """
+        },
+        {
+            "PackageReference.VersionOverride",
+            """
+            <PropertyGroup>
+              <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" VersionOverride="[2.80.0]" />
+            </ItemGroup>
+            """
+        },
+        {
+            "PackageVersion.Version",
+            """
+            <PropertyGroup>
+              <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" />
+              <PackageVersion Include="Grpc.Net.ClientFactory" Version="[2.80.0]" />
+            </ItemGroup>
+            """
+        },
+        {
+            "ReferencePath.NuGetPackageVersion",
+            """
+            <ItemGroup>
+              <ReferencePath Include="Grpc.Net.ClientFactory.dll" NuGetPackageId="Grpc.Net.ClientFactory" NuGetPackageVersion="[2.80.0]" />
+            </ItemGroup>
+            """
+        },
+        {
+            "PackageReference.Version.Unpinned",
+            """
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" Version="2.80.0" />
+            </ItemGroup>
+            """
+        },
+        {
+            "PackageReference.VersionOverride.Unpinned",
+            """
+            <PropertyGroup>
+              <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" VersionOverride="2.80.0" />
+            </ItemGroup>
+            """
+        },
+        {
+            "PackageVersion.Version.Unpinned",
+            """
+            <PropertyGroup>
+              <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" />
+              <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.80.0" />
+            </ItemGroup>
+            """
+        },
+        {
+            "ReferencePath.NuGetPackageVersion.Unpinned",
+            """
+            <ItemGroup>
+              <ReferencePath Include="Grpc.Net.ClientFactory.dll" NuGetPackageId="Grpc.Net.ClientFactory" NuGetPackageVersion="2.80.0" />
+            </ItemGroup>
+            """
+        },
+    };
+
+    public static TheoryData<string, string> IncompatibleVersionSources => new()
+    {
+        {
+            "PackageReference.Version",
+            """
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" Version="[2.63.0]" />
+            </ItemGroup>
+            """
+        },
+        {
+            "PackageReference.VersionOverride",
+            """
+            <PropertyGroup>
+              <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" VersionOverride="[2.63.0]" />
+            </ItemGroup>
+            """
+        },
+        {
+            "PackageVersion.Version",
+            """
+            <PropertyGroup>
+              <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" />
+              <PackageVersion Include="Grpc.Net.ClientFactory" Version="[2.63.0]" />
+            </ItemGroup>
+            """
+        },
+        {
+            "ReferencePath.NuGetPackageVersion",
+            """
+            <ItemGroup>
+              <ReferencePath Include="Grpc.Net.ClientFactory.dll" NuGetPackageId="Grpc.Net.ClientFactory" NuGetPackageVersion="[2.63.0]" />
+            </ItemGroup>
+            """
+        },
+        {
+            "PackageReference.Version.Unpinned",
+            """
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" Version="2.63.0" />
+            </ItemGroup>
+            """
+        },
+        {
+            "PackageReference.VersionOverride.Unpinned",
+            """
+            <PropertyGroup>
+              <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" VersionOverride="2.63.0" />
+            </ItemGroup>
+            """
+        },
+        {
+            "PackageVersion.Version.Unpinned",
+            """
+            <PropertyGroup>
+              <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" />
+              <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.63.0" />
+            </ItemGroup>
+            """
+        },
+        {
+            "ReferencePath.NuGetPackageVersion.Unpinned",
+            """
+            <ItemGroup>
+              <ReferencePath Include="Grpc.Net.ClientFactory.dll" NuGetPackageId="Grpc.Net.ClientFactory" NuGetPackageVersion="2.63.0" />
+            </ItemGroup>
+            """
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(CompatibleVersionSources))]
+    public async Task CheckGrpcNetClientFactoryVersion_CompatibleVersion_DoesNotWarnOrFail(
+        string scenario,
+        string projectItems)
+    {
+        var result = await RunTargetAsync(projectItems);
+
+        result.ExitCode.Should().Be(0, result.ToString());
+        result.Output.Should().NotContain("MSB4184", scenario);
+        result.Output.Should().NotContain(WarningMessage, scenario);
+    }
+
+    [Theory]
+    [MemberData(nameof(IncompatibleVersionSources))]
+    public async Task CheckGrpcNetClientFactoryVersion_IncompatibleVersion_Warns(
+        string scenario,
+        string projectItems)
+    {
+        var result = await RunTargetAsync(projectItems);
+
+        result.ExitCode.Should().Be(0, result.ToString());
+        result.Output.Should().NotContain("MSB4184", scenario);
+        result.Output.Should().Contain(WarningMessage, scenario);
+    }
+
+    [Theory]
+    [InlineData("(,2.80.0]")]
+    [InlineData("[2.64.0-preview.1]")]
+    public async Task CheckGrpcNetClientFactoryVersion_VersionWithoutComparableSystemVersion_DoesNotFail(string version)
+    {
+        var result = await RunTargetAsync($"""
+            <ItemGroup>
+              <PackageReference Include="Grpc.Net.ClientFactory" Version="{version}" />
+            </ItemGroup>
+            """);
+
+        result.ExitCode.Should().Be(0, result.ToString());
+        result.Output.Should().NotContain("MSB4184");
+        result.Output.Should().NotContain(WarningMessage);
+    }
+
+    private static async Task<CommandResult> RunTargetAsync(string projectItems)
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"GrpcNetClientFactoryTargetTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+
+        try
+        {
+            var projectPath = Path.Combine(tempDirectory, "test.proj");
+            var project = $"""
+                <Project>
+                  <Import Project="{EscapeXml(GetTargetPath())}" />
+                {projectItems}
+                </Project>
+                """;
+
+            File.WriteAllText(projectPath, project);
+
+            return await RunDotNetAsync(tempDirectory, "msbuild", projectPath, "-nologo", "-v:minimal", "-t:_CheckGrpcNetClientFactoryVersion").ConfigureAwait(false);
+        }
+        finally
+        {
+            DeleteDirectoryBestEffort(tempDirectory);
+        }
+    }
+
+    private static void DeleteDirectoryBestEffort(string directory)
+    {
+        for (var retry = 0; retry < 3; retry++)
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+                return;
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup should not mask the test failure.
+                DelayBeforeCleanupRetry(retry);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Best-effort cleanup should not mask the test failure.
+                DelayBeforeCleanupRetry(retry);
+            }
+        }
+    }
+
+    private static void DelayBeforeCleanupRetry(int retry)
+    {
+        System.Threading.Thread.Sleep(TimeSpan.FromMilliseconds(50 * (retry + 1)));
+    }
+
+    private static async Task<CommandResult> RunDotNetAsync(string workingDirectory, params string[] arguments)
+    {
+        var processStartInfo = new ProcessStartInfo(GetDotNetPath())
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+#if NETFRAMEWORK
+            Arguments = CreateArguments(arguments),
+#endif
+        };
+
+#if !NETFRAMEWORK
+        foreach (var argument in arguments)
+        {
+            processStartInfo.ArgumentList.Add(argument);
+        }
+#endif
+
+        using var process = Process.Start(processStartInfo) ?? throw new InvalidOperationException("Failed to start dotnet.");
+
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = process.StandardError.ReadToEndAsync();
+
+        if (!process.WaitForExit((int)TimeSpan.FromSeconds(30).TotalMilliseconds))
+        {
+            KillProcess(process);
+            process.WaitForExit();
+            await ObserveOutputTasksAsync(standardOutputTask, standardErrorTask).ConfigureAwait(false);
+            throw new TimeoutException("Timed out while running dotnet msbuild.");
+        }
+
+        var standardOutput = await standardOutputTask.ConfigureAwait(false);
+        var standardError = await standardErrorTask.ConfigureAwait(false);
+
+        return new CommandResult(process.ExitCode, standardOutput, standardError);
+    }
+
+    private static void KillProcess(Process process)
+    {
+        try
+        {
+#if NETFRAMEWORK
+            process.Kill();
+#else
+            process.Kill(entireProcessTree: true);
+#endif
+        }
+        catch (InvalidOperationException exception)
+        {
+            _ = exception;
+        }
+    }
+
+    private static async Task ObserveOutputTasksAsync(Task<string> standardOutputTask, Task<string> standardErrorTask)
+    {
+        try
+        {
+#pragma warning disable VSTHRD003 // Output reader tasks are intentionally observed after the process exits.
+            await Task.WhenAll(standardOutputTask, standardErrorTask).ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+        }
+        catch (IOException exception)
+        {
+            _ = exception;
+        }
+        catch (ObjectDisposedException exception)
+        {
+            _ = exception;
+        }
+    }
+
+#if NETFRAMEWORK
+    private static string CreateArguments(params string[] arguments)
+    {
+        return string.Join(" ", Array.ConvertAll(arguments, QuoteArgument));
+    }
+
+    private static string QuoteArgument(string argument)
+    {
+        var quoted = new StringBuilder();
+        quoted.Append('"');
+
+        var backslashCount = 0;
+        foreach (var character in argument)
+        {
+            if (character == '\\')
+            {
+                backslashCount++;
+            }
+            else if (character == '"')
+            {
+                quoted.Append('\\', (backslashCount * 2) + 1);
+                quoted.Append('"');
+                backslashCount = 0;
+            }
+            else
+            {
+                quoted.Append('\\', backslashCount);
+                quoted.Append(character);
+                backslashCount = 0;
+            }
+        }
+
+        quoted.Append('\\', backslashCount * 2);
+        quoted.Append('"');
+
+        return quoted.ToString();
+    }
+#endif
+
+    private static string GetTargetPath()
+    {
+        var repoRoot = GetRepoRoot();
+        return Path.Combine(
+            repoRoot,
+            "src",
+            "Libraries",
+            "Microsoft.Extensions.Http.Resilience",
+            "buildTransitive",
+            "Microsoft.Extensions.Http.Resilience.targets");
+    }
+
+    private static string GetDotNetPath()
+    {
+        var dotnetFileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+        var repoDotnetPath = Path.Combine(GetRepoRoot(), ".dotnet", dotnetFileName);
+
+        return File.Exists(repoDotnetPath) ? repoDotnetPath : dotnetFileName;
+    }
+
+    private static string GetRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            var targetPath = Path.Combine(
+                directory.FullName,
+                "src",
+                "Libraries",
+                "Microsoft.Extensions.Http.Resilience",
+                "buildTransitive",
+                "Microsoft.Extensions.Http.Resilience.targets");
+
+            if (File.Exists(targetPath))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Failed to locate the repository root.");
+    }
+
+    private static string EscapeXml(string value)
+    {
+        return SecurityElement.Escape(value) ?? string.Empty;
+    }
+
+    private sealed record CommandResult(int ExitCode, string StandardOutput, string StandardError)
+    {
+        public string Output => StandardOutput + StandardError;
+
+        public override string ToString()
+        {
+            return $"""
+                Exit code: {ExitCode}
+                Standard output:
+                {StandardOutput}
+                Standard error:
+                {StandardError}
+                """;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7565
 
 ## Summary
 
 - Normalize `Grpc.Net.ClientFactory` NuGet version metadata before calling `VersionLessThan` in the `Microsoft.Extensions.Http.Resilience` buildTransitive target.
 - Handle bracket-pinned versions such as `[2.80.0]` without failing the build with `MSB4184`.
 - Add regression coverage for all version sources checked by the target:
   - `PackageReference.Version`
   - `PackageReference.VersionOverride`
   - `PackageVersion.Version`
   - `ReferencePath.NuGetPackageVersion`
 
 ## Validation
 
 - `./restore.sh`
 - `./.dotnet/dotnet test test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Microsoft.Extensions.Http.Resilience.Tests.csproj --filter GrpcNetClientFactoryVersionTargetTests --no-restore -v:minimal`
 - `./build.sh --vs Polly,Resilience`
 - `./build.sh --build --test`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7566)