### PR TITLE
Fix flaky StampedeTests and harden related test waits

### DIFF
--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/RedisTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/RedisTests.cs
@@ -81,9 +81,17 @@ public class RedisTests : DistributedCacheTests, IClassFixture<RedisFixture>
 
         Assert.Equal(1, count);
 
-        await Task.Delay(500); // the L2 write continues in the background; give it a chance
+        // the L2 write continues in the background; poll up to 50 times (5 seconds total) until the key surfaces a TTL
+        TimeSpan? ttl = null;
+        for (var i = 0; i < 50 && ttl is null; i++)
+        {
+            ttl = await redis.GetDatabase().KeyTimeToLiveAsync(key);
+            if (ttl is null)
+            {
+                await Task.Delay(100);
+            }
+        }
 
-        var ttl = await redis.GetDatabase().KeyTimeToLiveAsync(key);
         Log.WriteLine($"ttl: {ttl}");
         Assert.NotNull(ttl);
     }

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/StampedeTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/StampedeTests.cs
@@ -215,12 +215,15 @@ public class StampedeTests : IClassFixture<TestEventListener>
             cancel.Cancel();
         }
 
-        await Task.Delay(500); // cancellation happens on a worker; need to allow a moment
+        // allow the shared underlying task time to enter its semaphore wait
+        await Task.Delay(500);
+
         for (var i = 0; i < callerCount; i++)
         {
             var result = results[i];
 
-            // should have already cancelled, even though underlying task hasn't finished yet
+            // cancellation happens on a worker; wait up to 5 seconds total for the caller's task to observe its cancel
+            await WaitForCompletionAsync(result, 5_000);
             Assert.Equal(TaskStatus.Canceled, result.Status);
             var ex = Assert.Throws<OperationCanceledException>(() => result.GetAwaiter().GetResult());
             Assert.Equal(cancels[i].Token, ex.CancellationToken); // each gets the correct blame
@@ -296,14 +299,17 @@ public class StampedeTests : IClassFixture<TestEventListener>
             }
         }
 
-        await Task.Delay(500); // cancellation happens on a worker; need to allow a moment
+        // allow the shared underlying task time to enter its semaphore wait
+        await Task.Delay(500);
+
         for (var i = 0; i < callerCount; i++)
         {
             if (i != remaining)
             {
                 var result = results[i];
 
-                // should have already cancelled, even though underlying task hasn't finished yet
+                // cancellation happens on a worker; wait up to 5 seconds total for the caller's task to observe its cancel
+                await WaitForCompletionAsync(result, 5_000);
                 Assert.Equal(TaskStatus.Canceled, result.Status);
                 var ex = Assert.Throws<OperationCanceledException>(() => result.GetAwaiter().GetResult());
                 Assert.Equal(cancels[i].Token, ex.CancellationToken); // each gets the correct blame
@@ -491,4 +497,23 @@ public class StampedeTests : IClassFixture<TestEventListener>
     }
 
     private static string Me([CallerMemberName] string caller = "") => caller;
+
+    private static async Task WaitForCompletionAsync(
+        Task task,
+        int timeoutMs,
+        [CallerArgumentExpression(nameof(task))] string? expression = null)
+    {
+        if (task.IsCompleted)
+        {
+            return;
+        }
+
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+        var completed = await Task.WhenAny(task, Task.Delay(timeoutMs));
+#pragma warning restore VSTHRD003
+        if (completed != task)
+        {
+            throw new TimeoutException($"Task '{expression}' did not complete within {timeoutMs}ms");
+        }
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.Hosting.Testing.Tests/FakeHostTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Hosting.Testing.Tests/FakeHostTests.cs
@@ -33,9 +33,24 @@ public class FakeHostTests
             })
             .StartAsync();
 
-        await Task.Delay(100); // Give some time for the host to shut down
+        // poll up to 50 times (5 seconds total) until the host has shut down and its service provider has been disposed
+        ObjectDisposedException? captured = null;
+        for (var i = 0; i < 50; i++)
+        {
+            try
+            {
+                host.Services.GetService<IHost>();
+            }
+            catch (ObjectDisposedException ex)
+            {
+                captured = ex;
+                break;
+            }
 
-        Assert.Throws<ObjectDisposedException>(() => host.Services.GetService<IHost>());
+            await Task.Delay(100);
+        }
+
+        Assert.NotNull(captured);
     }
 
     [Fact]
@@ -50,7 +65,12 @@ public class FakeHostTests
         var sut = new FakeHost(hostMock.Object, new FakeHostOptions { StartUpTimeout = TimeSpan.Zero });
 #pragma warning restore CA2000
         await sut.StartAsync();
-        await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+        // poll up to 50 times (5 seconds total) until the inner IHost.StartAsync invocation has been recorded
+        for (var i = 0; i < 50 && hostMock.Invocations.Count == 0; i++)
+        {
+            await Task.Delay(100);
+        }
 
         hostMock.VerifyAll();
     }


### PR DESCRIPTION
Fixes #6836

`StampedeTests.MultipleCallsShareExecution_MostCancel` (and its sibling `_EveryoneCancels`) asserted `result.Status == TaskStatus.Canceled` after a fixed `Task.Delay(500)`. On loaded CI agents, the HybridCache stampede coordinator hadn't always transitioned every caller task to `Canceled` within that window, producing intermittent failures.

This PR replaces that pure-delay assertion with a bounded poll on the caller's task and opportunistically applies the same hardening to two other tests that used fixed delays before asserting on background-thread state.

### StampedeTests (the actual flake fix)

- Adds a private static `WaitForCompletionAsync(Task, int timeoutMs, [CallerArgumentExpression] string?)` helper modeled on `AssertAwaitingTaskCompleted` in `FakeLogCollectorTests.LogEnumeration.cs`. The `timeoutMs` has no default; the 5-second budget is passed explicitly at each call site.
- Both `MultipleCallsShareExecution_EveryoneCancels` and `_MostCancel` now `await WaitForCompletionAsync(result, 5_000)` before asserting `TaskStatus.Canceled`.
- The original 500ms `Task.Delay` warmup is **retained** with an updated comment explaining its actual purpose: letting the shared underlying lambda enter its `semaphore.WaitAsync(...)` before the main thread completes the handshake. A first attempt that removed it entirely failed 25/25 on net462 at `Assert.Equal(1, executeCount)` because the test reuses a single `SemaphoreSlim` for handshakes in both directions and `SemaphoreSlim` does not guarantee FIFO ordering.

Stress-verified locally: 25/25 pass on net8/9/10/462 for both methods after the fix.

### Opportunistic improvements to related "pure delay before assert" tests

- **`RedisTests`**: replaced `await Task.Delay(500)` before reading `KeyTimeToLiveAsync` with a bounded poll (50 attempts of 100ms = 5 seconds total) on the TTL becoming non-null. The test is `IClassFixture<RedisFixture>` and skipped without a Redis instance, so it is not in default CI -- this is purely defense-in-depth for the codebase's reusable wait pattern.
- **`FakeHostTests`**:
  - `Host_ShutsDownAfterTimeout`: replaced a fixed delay with a try/catch poll (50 x 100ms = 5 seconds total) capturing `ObjectDisposedException`, then asserting it surfaced.
  - `StartAsync_NoTokenProvided_UsesDefaultTimeout`: replaced a fixed delay with a poll on `hostMock.Invocations.Count` (50 x 100ms = 5 seconds total) before `hostMock.VerifyAll()`.

Stress-verified locally: 25/25 pass on net8/9/10/462 for both `FakeHostTests` methods.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/new/jeffhandley:jeffhandley/ci-unstable-test)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7572)