### PR TITLE
Remove duplicate 'WebAPI' classification from template

### DIFF
--- a/src/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates/templates/AIAgentWebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates/templates/AIAgentWebApi-CSharp/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "Common", "AI", "API", "Web", "Web API", "WebAPI", "Service" ],
+  "classifications": [ "Common", "AI", "API", "Web", "Web API", "Service" ],
   "identity": "Microsoft.Agents.AI.ProjectTemplates.AIAgentWebApi.CSharp",
   "name": "AI Agent Web API",
   "description": "A project template for creating an AI Agent Web API application.",


### PR DESCRIPTION
No other .NET template uses the "WebAPI" classification. All the Web API templates use "Web API" (with a space) instead.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7577)