### PR TITLE
Update OpenTelemetry GenAI conventions to latest

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
@@ -79,6 +80,10 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     /// <remarks>This component does not own the instance and should not dispose it.</remarks>
     private readonly ActivitySource? _activitySource;
 
+    /// <summary>The <c>gen_ai.execute_tool.duration</c> histogram, or <see langword="null"/> if no <see cref="Meter"/> is available.</summary>
+    /// <remarks>This component does not own the underlying <see cref="Meter"/> and should not dispose it.</remarks>
+    private readonly Histogram<double>? _executeToolDurationHistogram;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="FunctionInvokingChatClient"/> class.
     /// </summary>
@@ -90,6 +95,11 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     {
         _logger = (ILogger?)loggerFactory?.CreateLogger<FunctionInvokingChatClient>() ?? NullLogger.Instance;
         _activitySource = innerClient.GetService<ActivitySource>();
+        if (innerClient.GetService<Meter>() is Meter meter)
+        {
+            _executeToolDurationHistogram = OtelMetricHelpers.CreateGenAIExecuteToolDurationHistogram(meter);
+        }
+
         FunctionInvocationServices = functionInvocationServices;
     }
 
@@ -101,7 +111,8 @@ public class FunctionInvokingChatClient : DelegatingChatClient
         invokeAgentActivity =>
             invokeAgentActivity is not null
                 ? invokeAgentActivity.GetCustomProperty(OpenTelemetryChatClient.SensitiveDataEnabledCustomKey) as string is OpenTelemetryChatClient.SensitiveDataEnabledTrueValue
-                : InnerClient.GetService<OpenTelemetryChatClient>()?.EnableSensitiveData is true);
+                : InnerClient.GetService<OpenTelemetryChatClient>()?.EnableSensitiveData is true,
+        _executeToolDurationHistogram);
 
     /// <summary>
     /// Gets or sets the <see cref="FunctionInvocationContext"/> for the current function invocation.

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
@@ -129,6 +129,7 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
     /// <inheritdoc/>
     public override object? GetService(Type serviceType, object? serviceKey = null) =>
         serviceType == typeof(ActivitySource) ? _activitySource :
+        serviceType == typeof(Meter) ? _meter :
         base.GetService(serviceType, serviceKey);
 
     /// <inheritdoc/>
@@ -326,6 +327,24 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
                     if (options.PresencePenalty is float presencePenalty)
                     {
                         _ = activity.AddTag(OpenTelemetryConsts.GenAI.Request.PresencePenalty, presencePenalty);
+                    }
+
+                    if (options.Reasoning?.Effort is ReasoningEffort reasoningEffort)
+                    {
+                        // The spec recommends emitting the exact string sent to the provider; the provider-agnostic
+                        // layer only has the abstract ReasoningEffort, so emit a normalized token for it. A provider
+                        // package can override with its exact wire value (e.g. OpenAI sends "xhigh" for ExtraHigh).
+                        string reasoningLevel = reasoningEffort switch
+                        {
+                            ReasoningEffort.None => "none",
+                            ReasoningEffort.Low => "low",
+                            ReasoningEffort.Medium => "medium",
+                            ReasoningEffort.High => "high",
+                            ReasoningEffort.ExtraHigh => "extra_high",
+                            _ => reasoningEffort.ToString().ToLowerInvariant(),
+                        };
+
+                        _ = activity.AddTag(OpenTelemetryConsts.GenAI.Request.ReasoningLevel, reasoningLevel);
                     }
 
                     if (options.Seed is long seed)

--- a/src/Libraries/Microsoft.Extensions.AI/Common/FunctionInvocationProcessor.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Common/FunctionInvocationProcessor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,6 +23,7 @@ internal sealed class FunctionInvocationProcessor
 {
     private readonly ILogger _logger;
     private readonly ActivitySource? _activitySource;
+    private readonly Histogram<double>? _executeToolDurationHistogram;
     private readonly Func<FunctionInvocationContext, CancellationToken, ValueTask<object?>> _invokeFunction;
     private readonly Func<Activity?, bool> _isSensitiveDataEnabled;
 
@@ -36,16 +38,19 @@ internal sealed class FunctionInvocationProcessor
     /// Receives the invoke agent activity (or null if not in agent context).
     /// Returns true if sensitive data should be logged/tagged, false otherwise.
     /// </param>
+    /// <param name="executeToolDurationHistogram">The optional <c>gen_ai.execute_tool.duration</c> histogram to record tool execution durations on.</param>
     public FunctionInvocationProcessor(
         ILogger logger,
         ActivitySource? activitySource,
         Func<FunctionInvocationContext, CancellationToken, ValueTask<object?>> invokeFunction,
-        Func<Activity?, bool>? isSensitiveDataEnabled = null)
+        Func<Activity?, bool>? isSensitiveDataEnabled = null,
+        Histogram<double>? executeToolDurationHistogram = null)
     {
         _logger = logger;
         _activitySource = activitySource;
         _invokeFunction = invokeFunction;
         _isSensitiveDataEnabled = isSensitiveDataEnabled ?? (_ => false);
+        _executeToolDurationHistogram = executeToolDurationHistogram;
     }
 
     /// <summary>
@@ -199,15 +204,18 @@ internal sealed class FunctionInvocationProcessor
         }
 
         object? result = null;
+        string? errorType = null;
         try
         {
             result = await _invokeFunction(context, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e)
         {
+            errorType = e.GetType().FullName;
+
             if (activity is not null)
             {
-                _ = activity.SetTag(OpenTelemetryConsts.Error.Type, e.GetType().FullName)
+                _ = activity.SetTag(OpenTelemetryConsts.Error.Type, errorType)
                             .SetStatus(ActivityStatusCode.Error, e.Message);
             }
 
@@ -224,6 +232,19 @@ internal sealed class FunctionInvocationProcessor
         }
         finally
         {
+            if (_executeToolDurationHistogram is { Enabled: true } executeToolDurationHistogram)
+            {
+                TagList tags = default;
+                tags.Add(OpenTelemetryConsts.GenAI.Tool.Name, context.Function.Name);
+                tags.Add(OpenTelemetryConsts.GenAI.Tool.Type, OpenTelemetryConsts.ToolTypeFunction);
+                if (errorType is not null)
+                {
+                    tags.Add(OpenTelemetryConsts.Error.Type, errorType);
+                }
+
+                executeToolDurationHistogram.Record(FunctionInvocationHelpers.GetElapsedTime(startingTimestamp).TotalSeconds, tags);
+            }
+
             bool loggedResult = false;
             if (enableSensitiveData || traceLoggingEnabled)
             {

--- a/src/Libraries/Microsoft.Extensions.AI/Common/OtelMetricHelpers.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Common/OtelMetricHelpers.cs
@@ -23,4 +23,12 @@ internal static class OtelMetricHelpers
             OpenTelemetryConsts.SecondsUnit,
             OpenTelemetryConsts.GenAI.Client.OperationDuration.Description,
             advice: new() { HistogramBucketBoundaries = OpenTelemetryConsts.GenAI.Client.OperationDuration.ExplicitBucketBoundaries });
+
+    /// <summary>Creates the standard <c>gen_ai.execute_tool.duration</c> histogram on <paramref name="meter"/>.</summary>
+    public static Histogram<double> CreateGenAIExecuteToolDurationHistogram(Meter meter) =>
+        meter.CreateHistogram<double>(
+            OpenTelemetryConsts.GenAI.ExecuteTool.Duration.Name,
+            OpenTelemetryConsts.SecondsUnit,
+            OpenTelemetryConsts.GenAI.ExecuteTool.Duration.Description,
+            advice: new() { HistogramBucketBoundaries = OpenTelemetryConsts.GenAI.ExecuteTool.Duration.ExplicitBucketBoundaries });
 }

--- a/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryConsts.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryConsts.cs
@@ -126,6 +126,7 @@ internal static class OpenTelemetryConsts
             public const string Model = "gen_ai.request.model";
             public const string MaxTokens = "gen_ai.request.max_tokens";
             public const string PresencePenalty = "gen_ai.request.presence_penalty";
+            public const string ReasoningLevel = "gen_ai.request.reasoning.level";
             public const string Seed = "gen_ai.request.seed";
             public const string StopSequences = "gen_ai.request.stop_sequences";
             public const string Stream = "gen_ai.request.stream";
@@ -160,6 +161,16 @@ internal static class OpenTelemetryConsts
                 public const string Id = "gen_ai.tool.call.id";
                 public const string Arguments = "gen_ai.tool.call.arguments";
                 public const string Result = "gen_ai.tool.call.result";
+            }
+        }
+
+        public static class ExecuteTool
+        {
+            public static class Duration
+            {
+                public const string Description = "Measures the duration of a tool execution.";
+                public const string Name = "gen_ai.execute_tool.duration";
+                public static readonly double[] ExplicitBucketBoundaries = [0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92];
             }
         }
 

--- a/src/Libraries/Microsoft.Extensions.AI/Realtime/FunctionInvokingRealtimeClientSession.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Realtime/FunctionInvokingRealtimeClientSession.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -67,6 +68,10 @@ internal sealed class FunctionInvokingRealtimeClientSession : IRealtimeClientSes
     /// <remarks>This component does not own the instance and should not dispose it.</remarks>
     private readonly ActivitySource? _activitySource;
 
+    /// <summary>The <c>gen_ai.execute_tool.duration</c> histogram, or <see langword="null"/> if no <see cref="Meter"/> is available.</summary>
+    /// <remarks>This component does not own the underlying <see cref="Meter"/> and should not dispose it.</remarks>
+    private readonly Histogram<double>? _executeToolDurationHistogram;
+
     /// <summary>The inner session to delegate to.</summary>
     private readonly IRealtimeClientSession _innerSession;
 
@@ -86,6 +91,11 @@ internal sealed class FunctionInvokingRealtimeClientSession : IRealtimeClientSes
         _client = Throw.IfNull(client);
         _logger = (ILogger?)loggerFactory?.CreateLogger<FunctionInvokingRealtimeClientSession>() ?? NullLogger.Instance;
         _activitySource = innerSession.GetService<ActivitySource>();
+        if (innerSession.GetService<Meter>() is Meter meter)
+        {
+            _executeToolDurationHistogram = OtelMetricHelpers.CreateGenAIExecuteToolDurationHistogram(meter);
+        }
+
         FunctionInvocationServices = functionInvocationServices;
     }
 
@@ -93,7 +103,8 @@ internal sealed class FunctionInvokingRealtimeClientSession : IRealtimeClientSes
     private FunctionInvocationProcessor Processor => field ??= new FunctionInvocationProcessor(
         _logger,
         _activitySource,
-        InvokeFunctionAsync);
+        InvokeFunctionAsync,
+        executeToolDurationHistogram: _executeToolDurationHistogram);
 
     /// <summary>
     /// Gets or sets the <see cref="FunctionInvocationContext"/> for the current function invocation.

--- a/src/Libraries/Microsoft.Extensions.AI/Realtime/OpenTelemetryRealtimeClientSession.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Realtime/OpenTelemetryRealtimeClientSession.cs
@@ -168,6 +168,7 @@ internal sealed partial class OpenTelemetryRealtimeClientSession : IRealtimeClie
 
         return
             serviceType == typeof(ActivitySource) ? _activitySource :
+            serviceType == typeof(Meter) ? _meter :
             serviceKey is null && serviceType.IsInstanceOfType(this) ? this :
             _innerSession.GetService(serviceType, serviceKey);
     }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using OpenTelemetry.Trace;
@@ -1162,6 +1163,39 @@ public class FunctionInvokingChatClientTests
                 Assert.Empty(activities);
             }
         }
+    }
+
+    [Fact]
+    public async Task ExecuteToolDurationMetricRecorded()
+    {
+        string sourceName = Guid.NewGuid().ToString();
+
+        List<ChatMessage> plan =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1", new Dictionary<string, object?> { ["arg1"] = "value1" })]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
+            new ChatMessage(ChatRole.Assistant, "world"),
+        ];
+
+        ChatOptions options = new()
+        {
+            Tools = [AIFunctionFactory.Create(() => "Result 1", "Func1")]
+        };
+
+        Func<ChatClientBuilder, ChatClientBuilder> configure = b => b.Use(c =>
+            new FunctionInvokingChatClient(new OpenTelemetryChatClient(c, sourceName: sourceName)));
+
+        using var executeToolDurationCollector = new MetricCollector<double>(null, sourceName, "gen_ai.execute_tool.duration");
+
+        await InvokeAndAssertAsync(options, plan, configurePipeline: configure);
+
+        var measurement = Assert.Single(executeToolDurationCollector.GetMeasurementSnapshot());
+        Assert.True(measurement.Value >= 0);
+        Assert.True(measurement.ContainsTags(
+            new KeyValuePair<string, object?>("gen_ai.tool.name", "Func1"),
+            new KeyValuePair<string, object?>("gen_ai.tool.type", "function")));
+        Assert.False(measurement.Tags.ContainsKey("error.type"));
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
@@ -130,6 +130,7 @@ public class OpenTelemetryChatClientTests
             ResponseFormat = ChatResponseFormat.Json,
             Temperature = 6.0f,
             Seed = 42,
+            Reasoning = new() { Effort = ReasoningEffort.High },
             StopSequences = ["hello", "world"],
             AdditionalProperties = new()
             {
@@ -178,6 +179,7 @@ public class OpenTelemetryChatClientTests
         Assert.Equal(5.0f, activity.GetTagItem("gen_ai.request.presence_penalty"));
         Assert.Equal(6.0f, activity.GetTagItem("gen_ai.request.temperature"));
         Assert.Equal(7, activity.GetTagItem("gen_ai.request.top_k"));
+        Assert.Equal("high", activity.GetTagItem("gen_ai.request.reasoning.level"));
         Assert.Equal(123, activity.GetTagItem("gen_ai.request.max_tokens"));
         Assert.Equal("""["hello", "world"]""", activity.GetTagItem("gen_ai.request.stop_sequences"));
         Assert.Equal(enableSensitiveData ? "value1" : null, activity.GetTagItem("service_tier"));


### PR DESCRIPTION
> **Draft** pending the first release of
> [open-telemetry/semantic-conventions-genai](https://github.com/open-telemetry/semantic-conventions-genai).
> Both conventions are **Development** stability and **unreleased**. Merge once they ship in a tagged release.

## What this PR implements

| Area | Convention | Upstream | Compensating change |
|---|---|---|---|
| `gen-ai` | `gen_ai.request.reasoning.level` | [semantic-conventions-genai#258](https://github.com/open-telemetry/semantic-conventions-genai/pull/258) | Emit on chat spans from `ChatOptions.Reasoning.Effort` in `OpenTelemetryChatClient` (normalized lowercase token; exact provider wire string may differ, e.g. OpenAI `xhigh`). |
| `gen-ai/agent` | `gen_ai.execute_tool.duration` | [#201](https://github.com/open-telemetry/semantic-conventions-genai/pull/201) + [#322](https://github.com/open-telemetry/semantic-conventions-genai/pull/322) | New histogram recorded in `FunctionInvocationProcessor` (`gen_ai.tool.name`, `gen_ai.tool.type`, `error.type`). `Meter` shared via `GetService(typeof(Meter))` on the chat + realtime OTel clients. |

Validation: build clean (net8.0/net9.0/net10.0, 0 warnings); 677 AI + 103 realtime tests pass. No public API surface change (constants/helpers `internal`); doc-comment version reference left at `v1.41` (GenAI repo has no release to bump to yet).

## Upstream scan tracking

Legend: 🔴 implemented here · ✅ already aligned · 🟡 watch/deferred · 🟢 not applicable (no client / docs-only)

### Merged upstream changes (Unreleased) -- applicability to dotnet/extensions

| Upstream PR | Area | Change | Applicability | Status |
|---|---|---|:---:|---|
| [#258](https://github.com/open-telemetry/semantic-conventions-genai/pull/258) | gen-ai | `gen_ai.request.reasoning.level` | 🔴 | Implemented |
| [#201](https://github.com/open-telemetry/semantic-conventions-genai/pull/201) | gen-ai/agent | `execute_tool.duration` + `invoke_agent.duration` | 🔴 | execute_tool.duration implemented; invoke_agent.duration N/A (no invoke_agent span) |
| [#322](https://github.com/open-telemetry/semantic-conventions-genai/pull/322) | gen-ai/agent | align invoke_agent.internal/execute_tool attrs+metrics | 🔴 | Informs execute_tool.duration tag set (implemented) |
| [#217](https://github.com/open-telemetry/semantic-conventions-genai/pull/217) | gen-ai | `top_k` double->int, split `retrieval.top_k` | ✅ | `ChatOptions.TopK` already `int?` |
| [#257](https://github.com/open-telemetry/semantic-conventions-genai/pull/257) | gen-ai | limit `system_instructions` to text parts | ✅ | Emits Instructions as a single text part |
| [#219](https://github.com/open-telemetry/semantic-conventions-genai/pull/219) | gen-ai | `conversation.id` no fallback UUIDs | ✅ | Uses real conversation id only |
| [#142](https://github.com/open-telemetry/semantic-conventions-genai/pull/142) | gen-ai | `document` modality in message schema | 🟡 | Watch (additive message serialization) |
| [#162](https://github.com/open-telemetry/semantic-conventions-genai/pull/162) | gen-ai | `conversation.compacted` + `CompactionPart` | 🟡 | Deferred (no compaction API) |
| [#179](https://github.com/open-telemetry/semantic-conventions-genai/pull/179) | gen-ai | `prompt.version` / `prompt.variable` | 🟡 | Deferred (no prompt-template API) |
| [#211](https://github.com/open-telemetry/semantic-conventions-genai/pull/211) | gen-ai | billed vs consumed token counts | 🟡 | Watch (clarification) |
| [#214](https://github.com/open-telemetry/semantic-conventions-genai/pull/214) | gen-ai | `provider.name` cond-required on operation.duration | 🟡 | Watch (we always set provider.name) |
| [#212](https://github.com/open-telemetry/semantic-conventions-genai/pull/212) | gen-ai | generalize `provider.name` description | 🟢 | Docs-only |
| [#216](https://github.com/open-telemetry/semantic-conventions-genai/pull/216) | gen-ai | span covers duration incl. retries | 🟢 | Docs-only |
| [#99](https://github.com/open-telemetry/semantic-conventions-genai/pull/99) | gen-ai | add `moonshot_ai` provider value | 🟢 | provider.name is passthrough |
| [#126](https://github.com/open-telemetry/semantic-conventions-genai/pull/126) | gen-ai/agent | `workflow.duration` metric | 🟢 | No invoke_workflow span emitted here |
| [#97](https://github.com/open-telemetry/semantic-conventions-genai/pull/97) | gen-ai/agent | `plan` operation | 🟢 | No plan/agent span |
| [#107](https://github.com/open-telemetry/semantic-conventions-genai/pull/107) | gen-ai/agent | `agent.name` sampling-relevant | 🟢 | No agent spans |
| [#242](https://github.com/open-telemetry/semantic-conventions-genai/pull/242) | gen-ai/agent | limit `agent.id` to stable ids | 🟢 | `agent.id` not emitted |
| [#289](https://github.com/open-telemetry/semantic-conventions-genai/pull/289) | gen-ai/agent | remove `provider.name` from internal agent spans | 🟢 | No internal agent span |
| [#321](https://github.com/open-telemetry/semantic-conventions-genai/pull/321) | gen-ai/agent | invoke_agent.duration in-proc clarification | 🟢 | No invoke_agent span |
| [#140](https://github.com/open-telemetry/semantic-conventions-genai/pull/140) | gen-ai | memory operation spans/attrs | 🟢 | No memory instrumentation |
| [#136](https://github.com/open-telemetry/semantic-conventions-genai/pull/136) | mcp | tool.call.arguments/result opt-in | 🟢 | No MCP instrumentation |
| [#220](https://github.com/open-telemetry/semantic-conventions-genai/pull/220) | mcp | context propagation (SEP-414) | 🟢 | No MCP instrumentation |
| [#330](https://github.com/open-telemetry/semantic-conventions-genai/pull/330) | tooling | complex-attr JSON serialization templates | 🟢 | Upstream authoring only |

### In-flight upstream changes (open PRs) -- applicability if merged

Filter: open PRs proposing convention changes (excludes currently-open pure dependency/CI/chore PRs: #112, #290, #328, #340; since the prior scan, chore #342 merged and #282 closed unmerged).

| Upstream PR | Area | Change | Applicability | Status |
|---|---|---|:---:|---|
| [#98](https://github.com/open-telemetry/semantic-conventions-genai/pull/98) | gen-ai/agent | model A2A handoff as `execute_tool` span | 🟡 | Watch (we own execute_tool) |
| [#215](https://github.com/open-telemetry/semantic-conventions-genai/pull/215) | gen-ai | clarify `client.operation.duration` scope | 🟡 | Watch (we emit it) |
| [#197](https://github.com/open-telemetry/semantic-conventions-genai/pull/197) | gen-ai | modality/cache/phase token-usage breakdowns | 🟡 | Watch (token usage attrs) |
| [#96](https://github.com/open-telemetry/semantic-conventions-genai/pull/96) | gen-ai | `token.cache` / `token.reasoning` metric attrs | 🟡 | Watch (token usage) |
| [#144](https://github.com/open-telemetry/semantic-conventions-genai/pull/144) | gen-ai | input-messages BlobPart optional + stripped_reason | 🟡 | Watch (message content) |
| [#143](https://github.com/open-telemetry/semantic-conventions-genai/pull/143) | gen-ai | `byte_size` on multimodal content parts | 🟡 | Watch (message content) |
| [#341](https://github.com/open-telemetry/semantic-conventions-genai/pull/341) | gen-ai/agent | rename `workflow.duration` -> `invoke_workflow.duration` | 🟢 | N/A (not emitted here) |
| [#164](https://github.com/open-telemetry/semantic-conventions-genai/pull/164) | gen-ai | `server.inter_token_latency` metric | 🟢 | N/A (server-side) |
| #336, #350, #270, #267, #252, #250, #238, #291, #202, #165, #351, #325 | gen-ai/agent | agent entity / identity / finish_reason / invocation / server / authorization / threat / content-size + agentic reference scenarios | 🟢 | N/A (M.E.AI doesn't own agent/invoke_agent spans) |
| #185, #184 | gen-ai/eval | evaluation operation/span + response.id | 🟢 | N/A (no eval instrumentation) |
| #195, #188, #190, #262 | gen-ai | a2a protocol, workflow node, context-selection event, guardrail/security span | 🟢 | N/A (not instrumented here) |
| #283, #324 | anthropic/aws-bedrock | provider reference scenarios | 🟢 | N/A (other SDK repos) |

## Tracking state

<!-- otel-genai-tracking:begin -->
```yaml
Upstream-Repo: open-telemetry/semantic-conventions-genai
Upstream-Scan-Ref: e153ed94728993acd0ee6a958559032ca8b20afe  # since 377226a: only chore #342 (agents.md), no convention change
Upstream-Scan-Date: 2026-06-26T16:06:34Z
Upstream-Release: none            # Unreleased; Towncrier fragments under changelog.d/
Core-Semconv-Dependency: v1.42.0
DotnetExtensions-Implemented-Version: v1.41
```
<!-- otel-genai-tracking:end -->
