### PR TITLE
Fix up docs with Copilot (M.E.ServiceDiscovery)

### DIFF
--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Abstractions/IServiceEndpointBuilder.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Abstractions/IServiceEndpointBuilder.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Primitives;
 namespace Microsoft.Extensions.ServiceDiscovery;
 
 /// <summary>
-/// Builder to create a <see cref="ServiceEndpointSource"/> instances.
+/// Represents a builder that creates <see cref="ServiceEndpointSource"/> instances.
 /// </summary>
 public interface IServiceEndpointBuilder
 {

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndpointProviderOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndpointProviderOptions.cs
@@ -29,7 +29,10 @@ public class DnsServiceEndpointProviderOptions
     public double RetryBackOffFactor { get; set; } = 2;
 
     /// <summary>
-    /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint. Defaults to <c>false</c>.
+    /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint.
     /// </summary>
+    /// <remarks>
+    /// The default delegate returns <see langword="false"/>.
+    /// </remarks>
     public Func<ServiceEndpoint, bool> ShouldApplyHostNameMetadata { get; set; } = _ => false;
 }

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndpointProviderOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndpointProviderOptions.cs
@@ -31,8 +31,8 @@ public class DnsServiceEndpointProviderOptions
     /// <summary>
     /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint.
     /// </summary>
-    /// <remarks>
+    /// <value>
     /// The default delegate returns <see langword="false"/>.
-    /// </remarks>
+    /// </value>
     public Func<ServiceEndpoint, bool> ShouldApplyHostNameMetadata { get; set; } = _ => false;
 }

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndpointProviderOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndpointProviderOptions.cs
@@ -42,7 +42,10 @@ public class DnsSrvServiceEndpointProviderOptions
     public Func<ServiceEndpointQuery, string>? ServiceDomainNameCallback { get; set; }
 
     /// <summary>
-    /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint. Defaults to <c>false</c>.
+    /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint.
     /// </summary>
+    /// <remarks>
+    /// The default delegate returns <see langword="false"/>.
+    /// </remarks>
     public Func<ServiceEndpoint, bool> ShouldApplyHostNameMetadata { get; set; } = _ => false;
 }

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndpointProviderOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndpointProviderOptions.cs
@@ -44,8 +44,8 @@ public class DnsSrvServiceEndpointProviderOptions
     /// <summary>
     /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint.
     /// </summary>
-    /// <remarks>
+    /// <value>
     /// The default delegate returns <see langword="false"/>.
-    /// </remarks>
+    /// </value>
     public Func<ServiceEndpoint, bool> ShouldApplyHostNameMetadata { get; set; } = _ => false;
 }

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ConfigurationServiceEndpointProviderOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ConfigurationServiceEndpointProviderOptions.cs
@@ -11,12 +11,18 @@ namespace Microsoft.Extensions.ServiceDiscovery;
 public sealed class ConfigurationServiceEndpointProviderOptions
 {
     /// <summary>
-    /// The name of the configuration section which contains service endpoints. Defaults to <c>"Services"</c>.
+    /// Gets or sets the name of the configuration section that contains service endpoints.
     /// </summary>
+    /// <value>
+    /// The default value is <c>"Services"</c>.
+    /// </value>
     public string SectionName { get; set; } = "Services";
 
     /// <summary>
-    /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint. Defaults to a delegate which returns <c>false</c>.
+    /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint.
     /// </summary>
+    /// <value>
+    /// The default delegate returns <see langword="false"/>.
+    /// </value>
     public Func<ServiceEndpoint, bool> ShouldApplyHostNameMetadata { get; set; } = _ => false;
 }

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery/Http/IServiceDiscoveryHttpMessageHandlerFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery/Http/IServiceDiscoveryHttpMessageHandlerFactory.cs
@@ -4,13 +4,13 @@
 namespace Microsoft.Extensions.ServiceDiscovery.Http;
 
 /// <summary>
-/// Factory which creates <see cref="HttpMessageHandler"/> instances which resolve endpoints using service discovery
+/// Represents a factory that creates <see cref="HttpMessageHandler"/> instances that resolve endpoints using service discovery
 /// before delegating to a provided handler.
 /// </summary>
 public interface IServiceDiscoveryHttpMessageHandlerFactory
 {
     /// <summary>
-    /// Creates an <see cref="HttpMessageHandler"/> instance which resolve endpoints using service discovery before
+    /// Creates an <see cref="HttpMessageHandler"/> instance that resolves endpoints using service discovery before
     /// delegating to a provided handler.
     /// </summary>
     /// <param name="handler">The handler to delegate to.</param>

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery/Internal/ServiceEndpointResolverResult.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery/Internal/ServiceEndpointResolverResult.cs
@@ -18,7 +18,7 @@ internal sealed class ServiceEndpointResolverResult(ServiceEndpointSource? endpo
     public Exception? Exception { get; } = exception;
 
     /// <summary>
-    /// Gets a value indicating whether resolution completed successfully.
+    /// Gets a value that indicates whether resolution completed successfully.
     /// </summary>
     [MemberNotNullWhen(true, nameof(EndpointSource))]
     public bool ResolvedSuccessfully => Exception is null;

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryOptions.cs
@@ -15,8 +15,7 @@ public sealed class ServiceDiscoveryOptions
     /// Gets or sets a value that indicates whether all URI schemes for URIs resolved by the service discovery system are allowed.
     /// </summary>
     /// <value>
-    /// <see langword="true"/> if all URI schemes are allowed; otherwise, <see langword="false"/>.
-    /// <see langword="false"/> if only the schemes specified in <see cref="AllowedSchemes"/> are allowed.
+    /// <see langword="true"/> to allow all URI schemes; <see langword="false"/> to allow only schemes specified in <see cref="AllowedSchemes"/>.
     /// </value>
     public bool AllowAllSchemes { get; set; } = true;
 

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryOptions.cs
@@ -12,10 +12,12 @@ namespace Microsoft.Extensions.ServiceDiscovery;
 public sealed class ServiceDiscoveryOptions
 {
     /// <summary>
-    /// Gets or sets a value indicating whether all URI schemes for URIs resolved by the service discovery system are allowed.
-    /// If this value is <see langword="true"/>, all URI schemes are allowed.
-    /// If this value is <see langword="false"/>, only the schemes specified in <see cref="AllowedSchemes"/> are allowed.
+    /// Gets or sets a value that indicates whether all URI schemes for URIs resolved by the service discovery system are allowed.
     /// </summary>
+    /// <value>
+    /// <see langword="true"/> if all URI schemes are allowed; otherwise, <see langword="false"/>.
+    /// <see langword="false"/> if only the schemes specified in <see cref="AllowedSchemes"/> are allowed.
+    /// </value>
     public bool AllowAllSchemes { get; set; } = true;
 
     /// <summary>


### PR DESCRIPTION
Fixes dotnet/dotnet-api-docs#12837.

- Separate out long summaries into remarks tag
- Use consistent wording for properties
- Methods start with present tense verb
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7598)