### PR TITLE
Add HTTP request latency log enricher (experimental)

### DIFF
--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/HttpLatencyTelemetryExtensions.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/HttpLatencyTelemetryExtensions.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET8_0_OR_GREATER
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Diagnostics.Latency;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extensions for enriching incoming HTTP request logs with latency telemetry.
+/// </summary>
+[Experimental(diagnosticId: DiagnosticIds.Experiments.HttpLogging, UrlFormat = DiagnosticIds.UrlFormat)]
+public static class HttpLatencyTelemetryExtensions
+{
+    /// <summary>
+    /// Adds an enricher that appends latency information from the request's latency context to incoming HTTP request logs.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add to.</param>
+    /// <returns>The value of <paramref name="services"/>.</returns>
+    /// <exception cref="System.ArgumentNullException"><paramref name="services"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// The latency data this enricher reads is populated by the request latency telemetry services. Call
+    /// <c>AddRequestLatencyTelemetry</c> and <c>AddRequestCheckpoint</c>, and add the corresponding middleware to the
+    /// request pipeline, so that an <see cref="Microsoft.Extensions.Diagnostics.Latency.ILatencyContext"/> is available for each request.
+    /// </remarks>
+    [Experimental(diagnosticId: DiagnosticIds.Experiments.HttpLogging, UrlFormat = DiagnosticIds.UrlFormat)]
+    public static IServiceCollection AddHttpLatencyTelemetry(this IServiceCollection services)
+    {
+        _ = Throw.IfNull(services);
+        return services.AddHttpLogEnricher<HttpLatencyLogEnricher>();
+    }
+}
+#endif

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/Internal/HttpLatencyLogEnricher.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/Internal/HttpLatencyLogEnricher.cs
@@ -23,7 +23,7 @@ internal sealed class HttpLatencyLogEnricher : IHttpLogEnricher
 {
     internal const string DataVersion = "v1.0";
 
-    private readonly ObjectPool<StringBuilder> _builderPool = PoolFactory.CreateStringBuilderPool();
+    private static readonly ObjectPool<StringBuilder> _builderPool = PoolFactory.SharedStringBuilderPool;
 
     public void Enrich(IEnrichmentTagCollector collector, HttpContext httpContext)
     {
@@ -52,7 +52,7 @@ internal sealed class HttpLatencyLogEnricher : IHttpLogEnricher
     {
         if (request.Headers.TryGetValue(TelemetryConstants.ClientApplicationNameHeader, out var values))
         {
-            _ = stringBuilder.Append(values);
+            _ = stringBuilder.Append(values[0]);
         }
     }
 

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/Internal/HttpLatencyLogEnricher.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/Internal/HttpLatencyLogEnricher.cs
@@ -39,7 +39,7 @@ internal sealed class HttpLatencyLogEnricher : IHttpLogEnricher
                 AppendClientName(httpContext.Request, stringBuilder);
                 _ = stringBuilder.Append(',');
                 FormatLatencyData(stringBuilder, latencyContext.LatencyData);
-                collector.Add("latencyInfo", stringBuilder.ToString());
+                collector.Add("LatencyInfo", stringBuilder.ToString());
             }
             finally
             {

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/Internal/HttpLatencyLogEnricher.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/Internal/HttpLatencyLogEnricher.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET8_0_OR_GREATER
+
+using System;
+using System.Text;
+using Microsoft.AspNetCore.Diagnostics.Logging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Enrichment;
+using Microsoft.Extensions.Diagnostics.Latency;
+using Microsoft.Extensions.Http.Diagnostics;
+using Microsoft.Extensions.ObjectPool;
+using Microsoft.Shared.Pools;
+
+namespace Microsoft.AspNetCore.Diagnostics.Latency;
+
+/// <summary>
+/// Enriches incoming HTTP request logs with latency information captured in the request's <see cref="ILatencyContext"/>.
+/// </summary>
+internal sealed class HttpLatencyLogEnricher : IHttpLogEnricher
+{
+    internal const string DataVersion = "v1.0";
+
+    private readonly ObjectPool<StringBuilder> _builderPool = PoolFactory.CreateStringBuilderPool();
+
+    public void Enrich(IEnrichmentTagCollector collector, HttpContext httpContext)
+    {
+        var latencyContext = httpContext.RequestServices.GetService<ILatencyContext>();
+
+        if (latencyContext != null)
+        {
+            StringBuilder stringBuilder = _builderPool.Get();
+            try
+            {
+                _ = stringBuilder.Append(DataVersion);
+                _ = stringBuilder.Append(',');
+                AppendClientName(httpContext.Request, stringBuilder);
+                _ = stringBuilder.Append(',');
+                FormatLatencyData(stringBuilder, latencyContext.LatencyData);
+                collector.Add("latencyInfo", stringBuilder.ToString());
+            }
+            finally
+            {
+                _builderPool.Return(stringBuilder);
+            }
+        }
+    }
+
+    private static void AppendClientName(HttpRequest request, StringBuilder stringBuilder)
+    {
+        if (request.Headers.TryGetValue(TelemetryConstants.ClientApplicationNameHeader, out var values))
+        {
+            _ = stringBuilder.Append(values);
+        }
+    }
+
+    private static void FormatLatencyData(StringBuilder sb, LatencyData latencyData)
+    {
+        const int MillisecondsPerSecond = 1000;
+
+        // Append tags
+        AppendSpanEscapingSlash(sb, latencyData.Tags, a => a.Name);
+        _ = sb.Append(',');
+        AppendSpanEscapingSlash(sb, latencyData.Tags, a => a.Value);
+        _ = sb.Append(',');
+
+        // Append checkpoints
+        AppendSpanEscapingSlash(sb, latencyData.Checkpoints, a => a.Name);
+        _ = sb.Append(',');
+        AppendSpan(sb, latencyData.Checkpoints, a => (long)Math.Round(((double)a.Elapsed / a.Frequency) * MillisecondsPerSecond));
+        _ = sb.Append(',');
+
+        // Append measures
+        AppendSpanEscapingSlash(sb, latencyData.Measures, a => a.Name);
+        _ = sb.Append(',');
+        AppendSpan(sb, latencyData.Measures, a => a.Value);
+        _ = sb.Append(',');
+
+        // Append duration
+        _ = sb.Append((long)Math.Round(((double)latencyData.DurationTimestamp / latencyData.DurationTimestampFrequency) * MillisecondsPerSecond));
+    }
+
+    private static void AppendSpanEscapingSlash<TX>(StringBuilder sb, ReadOnlySpan<TX> span, Func<TX, string> select)
+    {
+        for (int i = 0; i < span.Length; i++)
+        {
+            var selectedValue = select(span[i]).AsSpan();
+            for (int s = 0; s < selectedValue.Length; s++)
+            {
+                _ = sb.Append(selectedValue[s] == '/' ? '_' : selectedValue[s]);
+            }
+
+            _ = sb.Append('/');
+        }
+    }
+
+    private static void AppendSpan<TX, TY>(StringBuilder sb, ReadOnlySpan<TX> span, Func<TX, TY> apply)
+    {
+        for (int i = 0; i < span.Length; i++)
+        {
+            _ = sb.Append(apply(span[i]));
+            _ = sb.Append('/');
+        }
+    }
+}
+#endif

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Microsoft.AspNetCore.Diagnostics.Middleware.json
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Microsoft.AspNetCore.Diagnostics.Middleware.json
@@ -2,6 +2,16 @@
   "Name": "Microsoft.AspNetCore.Diagnostics.Middleware, Version=10.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
   "Types": [
     {
+      "Type": "static class Microsoft.Extensions.DependencyInjection.HttpLatencyTelemetryExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.DependencyInjection.HttpLatencyTelemetryExtensions.AddHttpLatencyTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
       "Type": "static class Microsoft.Extensions.DependencyInjection.HttpLoggingServiceCollectionExtensions",
       "Stage": "Stable",
       "Methods": [

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/README.md
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/README.md
@@ -128,7 +128,6 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRequestLatencyTelemetry();
 builder.Services.AddRequestCheckpoint();
 builder.Services.AddHttpLatencyTelemetry();
-builder.Services.AddHttpLoggingRedaction();
 
 var app = builder.Build();
 

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/README.md
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/README.md
@@ -108,6 +108,35 @@ app.UseRequestCheckpoint();
 app.UseRequestLatencyTelemetry();
 ```
 
+#### Enriching HTTP Request Logs with Latency Data
+
+This enricher appends the latency data collected for an incoming request (checkpoints, tags, measures, and total duration) to that request's HTTP log. It reads the per-request latency context populated by `AddRequestLatencyTelemetry`, so register the latency telemetry services and middleware as shown above.
+
+This API is only available for ASP.NET Core 8+.
+
+The enricher can be registered using the following method:
+
+```csharp
+public static IServiceCollection AddHttpLatencyTelemetry(this IServiceCollection services)
+```
+
+For example:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRequestLatencyTelemetry();
+builder.Services.AddRequestCheckpoint();
+builder.Services.AddHttpLatencyTelemetry();
+builder.Services.AddHttpLoggingRedaction();
+
+var app = builder.Build();
+
+app.UseRequestCheckpoint();
+app.UseHttpLogging();
+app.UseRequestLatencyTelemetry();
+```
+
 ### HTTP Request Logs Enrichment and Redaction
 
 These components enable enriching and redacting ASP.NET Core's [HTTP request logs](https://learn.microsoft.com/aspnet/core/fundamentals/http-logging/).

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/HttpLatencyTelemetryExtensionsTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/HttpLatencyTelemetryExtensionsTests.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.AspNetCore.Diagnostics.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Diagnostics.Latency.Test;
+
+public class HttpLatencyTelemetryExtensionsTests
+{
+    [Fact]
+    public void AddHttpLatencyTelemetry_NullArguments_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            HttpLatencyTelemetryExtensions.AddHttpLatencyTelemetry(null!));
+    }
+
+    [Fact]
+    public void AddHttpLatencyTelemetry_RegistersEnricher()
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddHttpLatencyTelemetry()
+            .BuildServiceProvider();
+
+        var enricher = serviceProvider.GetRequiredService<IHttpLogEnricher>();
+
+        Assert.NotNull(enricher);
+        Assert.IsType<HttpLatencyLogEnricher>(enricher);
+    }
+}

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.Enrichment;
+using Microsoft.Extensions.Diagnostics.Latency;
+using Microsoft.Extensions.Http.Diagnostics;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Diagnostics.Latency.Test.Internal;
+
+public class HttpLatencyLogEnricherTests
+{
+    [Fact]
+    public void HttpLatencyLogEnricher_DoesNotEnrich_OnNullContext()
+    {
+        HttpContext? httpContext = null;
+        var headers = new HeaderDictionary
+        {
+        };
+
+        var request = new Mock<HttpRequest>();
+        request.Setup(a => a.Headers).Returns(headers);
+        var enricher = new HttpLatencyLogEnricher();
+        Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
+        Assert.Throws<NullReferenceException>(() => enricher.Enrich(mockEnrichmentPropertyBag.Object, httpContext!));
+        mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => true), It.Is<string>(s => true)), Times.Never);
+    }
+
+    [Fact]
+    public void HttpLatencyLogEnricher_DoesNotEnrich_WithoutLatencyContext()
+    {
+        var context = GetHttpContext(null!);
+        var headers = new HeaderDictionary
+        {
+        };
+
+        var request = new Mock<HttpRequest>();
+        request.Setup(a => a.Headers).Returns(headers);
+        var enricher = new HttpLatencyLogEnricher();
+        Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
+        enricher.Enrich(mockEnrichmentPropertyBag.Object, context);
+
+        mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => true), It.Is<string>(s => true)), Times.Never);
+    }
+
+    [Fact]
+    public void HttpLatencyLogEnricher_Enriches_OnRequestWithoutHeader()
+    {
+        var ld = new MockLatencyData();
+        var lc = new Mock<ILatencyContext>();
+        lc.Setup(a => a.LatencyData).Returns(ld.LatencyData);
+        var context = GetHttpContext(lc.Object);
+        var headers = new HeaderDictionary
+        {
+        };
+
+        var request = new Mock<HttpRequest>();
+        request.Setup(a => a.Headers).Returns(headers);
+        var enricher = new HttpLatencyLogEnricher();
+        Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
+        enricher.Enrich(mockEnrichmentPropertyBag.Object, context);
+
+        mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => s.Equals("latencyInfo", StringComparison.Ordinal)), It.Is<string>(s => s.Contains(ld.PerfPanelString)
+        && s.Contains(HttpLatencyLogEnricher.DataVersion))), Times.Once);
+    }
+
+    [Fact]
+    public void HttpLatencyLogEnricher_Enriches_OnResponseWithHeader()
+    {
+        var ld = new MockLatencyData();
+        var lc = new Mock<ILatencyContext>();
+        lc.Setup(a => a.LatencyData).Returns(ld.LatencyData);
+        var headerName = "TestClient";
+        var headers = new HeaderDictionary
+        {
+            { TelemetryConstants.ClientApplicationNameHeader, headerName }
+        };
+
+        var context = GetHttpContext(lc.Object, headers);
+        var enricher = new HttpLatencyLogEnricher();
+        Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
+        enricher.Enrich(mockEnrichmentPropertyBag.Object, context);
+
+        mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => s.Equals("latencyInfo", StringComparison.Ordinal)),
+            It.Is<string>(s => s.Contains(ld.PerfPanelString) && s.Contains(headerName))), Times.Once);
+    }
+
+    private class MockLatencyData
+    {
+        private readonly ArraySegment<Checkpoint> _checkpoints = new(new[]
+        {
+            new Checkpoint("ca", 1, 1000),
+            new Checkpoint("cb", 2, 1000),
+            new Checkpoint("c/c", 3, 1000)
+        });
+
+        private readonly ArraySegment<Measure> _measures = new(new[]
+        {
+            new Measure("m/a", 1),
+            new Measure("mb", 2),
+            new Measure("mc", 3),
+        });
+
+        private readonly ArraySegment<Tag> _tags = new(new[]
+        {
+            new Tag("t/a", "t1"),
+            new Tag("tb", "t/2"),
+            new Tag("tc", "t3")
+        });
+
+        public MockLatencyData()
+        {
+            const int MillisecondsPerSecond = 1000;
+
+            LatencyData = new LatencyData(_tags, _checkpoints, _measures, 20, 1000);
+
+            PerfPanelString = string.Format(CultureInfo.InvariantCulture, "{0}/,{1}/,{2}/,{3}/,{4}/,{5}/,{6}",
+                string.Join("/", _tags.Select(a => a.Name.Replace('/', '_'))),
+                string.Join("/", _tags.Select(a => a.Value.Replace('/', '_'))),
+                string.Join("/", _checkpoints.Select(a => a.Name.Replace('/', '_'))),
+                string.Join("/", _checkpoints.Select(a => (long)Math.Round(((double)a.Elapsed / a.Frequency) * MillisecondsPerSecond))),
+                string.Join("/", _measures.Select(a => a.Name.Replace('/', '_'))),
+                string.Join("/", _measures.Select(a => a.Value)),
+                (long)Math.Round(((double)LatencyData.DurationTimestamp / LatencyData.DurationTimestampFrequency) * MillisecondsPerSecond));
+        }
+
+        public string PerfPanelString { get; private set; }
+
+        public LatencyData LatencyData { get; private set; }
+    }
+
+    private static HttpContext GetHttpContext(ILatencyContext latencyContext, IHeaderDictionary? headers = null)
+    {
+        var httpContextMock = new DefaultHttpContext();
+
+        if (headers != null)
+        {
+            foreach (var header in headers)
+            {
+                httpContextMock.Request.Headers[header.Key] = header.Value;
+            }
+        }
+
+        var serviceProviderMock = new Mock<IServiceProvider>();
+        serviceProviderMock
+            .Setup(serviceProvider => serviceProvider.GetService(typeof(ILatencyContext)))
+            .Returns(latencyContext);
+        httpContextMock.RequestServices = serviceProviderMock.Object;
+        return httpContextMock;
+    }
+}

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
@@ -63,7 +63,7 @@ public class HttpLatencyLogEnricherTests
         Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
         enricher.Enrich(mockEnrichmentPropertyBag.Object, context);
 
-        mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => s.Equals("latencyInfo", StringComparison.Ordinal)), It.Is<string>(s => s.Contains(ld.SerializedLatencyData)
+        mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => s.Equals("LatencyInfo", StringComparison.Ordinal)), It.Is<string>(s => s.Contains(ld.SerializedLatencyData)
         && s.Contains(HttpLatencyLogEnricher.DataVersion))), Times.Once);
     }
 
@@ -84,7 +84,7 @@ public class HttpLatencyLogEnricherTests
         Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
         enricher.Enrich(mockEnrichmentPropertyBag.Object, context);
 
-        mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => s.Equals("latencyInfo", StringComparison.Ordinal)),
+        mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => s.Equals("LatencyInfo", StringComparison.Ordinal)),
             It.Is<string>(s => s.Contains(ld.SerializedLatencyData) && s.Contains(headerName))), Times.Once);
     }
 

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
@@ -17,12 +17,6 @@ public class HttpLatencyLogEnricherTests
     public void HttpLatencyLogEnricher_DoesNotEnrich_OnNullContext()
     {
         HttpContext? httpContext = null;
-        var headers = new HeaderDictionary
-        {
-        };
-
-        var request = new Mock<HttpRequest>();
-        request.Setup(a => a.Headers).Returns(headers);
         var enricher = new HttpLatencyLogEnricher();
         Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
         Assert.Throws<NullReferenceException>(() => enricher.Enrich(mockEnrichmentPropertyBag.Object, httpContext!));
@@ -33,12 +27,6 @@ public class HttpLatencyLogEnricherTests
     public void HttpLatencyLogEnricher_DoesNotEnrich_WithoutLatencyContext()
     {
         var context = GetHttpContext(null!);
-        var headers = new HeaderDictionary
-        {
-        };
-
-        var request = new Mock<HttpRequest>();
-        request.Setup(a => a.Headers).Returns(headers);
         var enricher = new HttpLatencyLogEnricher();
         Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
         enricher.Enrich(mockEnrichmentPropertyBag.Object, context);

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Globalization;
-using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Diagnostics.Enrichment;
 using Microsoft.Extensions.Diagnostics.Latency;

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
@@ -65,7 +65,7 @@ public class HttpLatencyLogEnricherTests
         Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
         enricher.Enrich(mockEnrichmentPropertyBag.Object, context);
 
-        mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => s.Equals("latencyInfo", StringComparison.Ordinal)), It.Is<string>(s => s.Contains(ld.PerfPanelString)
+        mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => s.Equals("latencyInfo", StringComparison.Ordinal)), It.Is<string>(s => s.Contains(ld.SerializedLatencyData)
         && s.Contains(HttpLatencyLogEnricher.DataVersion))), Times.Once);
     }
 
@@ -87,7 +87,7 @@ public class HttpLatencyLogEnricherTests
         enricher.Enrich(mockEnrichmentPropertyBag.Object, context);
 
         mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => s.Equals("latencyInfo", StringComparison.Ordinal)),
-            It.Is<string>(s => s.Contains(ld.PerfPanelString) && s.Contains(headerName))), Times.Once);
+            It.Is<string>(s => s.Contains(ld.SerializedLatencyData) && s.Contains(headerName))), Times.Once);
     }
 
     private class MockLatencyData
@@ -119,7 +119,7 @@ public class HttpLatencyLogEnricherTests
 
             LatencyData = new LatencyData(_tags, _checkpoints, _measures, 20, 1000);
 
-            PerfPanelString = string.Format(CultureInfo.InvariantCulture, "{0}/,{1}/,{2}/,{3}/,{4}/,{5}/,{6}",
+            SerializedLatencyData = string.Format(CultureInfo.InvariantCulture, "{0}/,{1}/,{2}/,{3}/,{4}/,{5}/,{6}",
                 string.Join("/", _tags.Select(a => a.Name.Replace('/', '_'))),
                 string.Join("/", _tags.Select(a => a.Value.Replace('/', '_'))),
                 string.Join("/", _checkpoints.Select(a => a.Name.Replace('/', '_'))),
@@ -129,7 +129,7 @@ public class HttpLatencyLogEnricherTests
                 (long)Math.Round(((double)LatencyData.DurationTimestamp / LatencyData.DurationTimestampFrequency) * MillisecondsPerSecond));
         }
 
-        public string PerfPanelString { get; private set; }
+        public string SerializedLatencyData { get; private set; }
 
         public LatencyData LatencyData { get; private set; }
     }

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/HttpLatencyLogEnricherTests.cs
@@ -90,50 +90,6 @@ public class HttpLatencyLogEnricherTests
             It.Is<string>(s => s.Contains(ld.SerializedLatencyData) && s.Contains(headerName))), Times.Once);
     }
 
-    private class MockLatencyData
-    {
-        private readonly ArraySegment<Checkpoint> _checkpoints = new(new[]
-        {
-            new Checkpoint("ca", 1, 1000),
-            new Checkpoint("cb", 2, 1000),
-            new Checkpoint("c/c", 3, 1000)
-        });
-
-        private readonly ArraySegment<Measure> _measures = new(new[]
-        {
-            new Measure("m/a", 1),
-            new Measure("mb", 2),
-            new Measure("mc", 3),
-        });
-
-        private readonly ArraySegment<Tag> _tags = new(new[]
-        {
-            new Tag("t/a", "t1"),
-            new Tag("tb", "t/2"),
-            new Tag("tc", "t3")
-        });
-
-        public MockLatencyData()
-        {
-            const int MillisecondsPerSecond = 1000;
-
-            LatencyData = new LatencyData(_tags, _checkpoints, _measures, 20, 1000);
-
-            SerializedLatencyData = string.Format(CultureInfo.InvariantCulture, "{0}/,{1}/,{2}/,{3}/,{4}/,{5}/,{6}",
-                string.Join("/", _tags.Select(a => a.Name.Replace('/', '_'))),
-                string.Join("/", _tags.Select(a => a.Value.Replace('/', '_'))),
-                string.Join("/", _checkpoints.Select(a => a.Name.Replace('/', '_'))),
-                string.Join("/", _checkpoints.Select(a => (long)Math.Round(((double)a.Elapsed / a.Frequency) * MillisecondsPerSecond))),
-                string.Join("/", _measures.Select(a => a.Name.Replace('/', '_'))),
-                string.Join("/", _measures.Select(a => a.Value)),
-                (long)Math.Round(((double)LatencyData.DurationTimestamp / LatencyData.DurationTimestampFrequency) * MillisecondsPerSecond));
-        }
-
-        public string SerializedLatencyData { get; private set; }
-
-        public LatencyData LatencyData { get; private set; }
-    }
-
     private static HttpContext GetHttpContext(ILatencyContext latencyContext, IHeaderDictionary? headers = null)
     {
         var httpContextMock = new DefaultHttpContext();

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/MockLatencyData.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/MockLatencyData.cs
@@ -47,7 +47,7 @@ internal class MockLatencyData
             (long)Math.Round(((double)LatencyData.DurationTimestamp / LatencyData.DurationTimestampFrequency) * MillisecondsPerSecond));
     }
 
-    public string SerializedLatencyData { get; private set; }
+    public string SerializedLatencyData { get; }
 
-    public LatencyData LatencyData { get; private set; }
+    public LatencyData LatencyData { get; }
 }

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/MockLatencyData.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/Internal/MockLatencyData.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Extensions.Diagnostics.Latency;
+
+namespace Microsoft.AspNetCore.Diagnostics.Latency.Test.Internal;
+
+internal class MockLatencyData
+{
+    private readonly ArraySegment<Checkpoint> _checkpoints = new(new[]
+    {
+        new Checkpoint("ca", 1, 1000),
+        new Checkpoint("cb", 2, 1000),
+        new Checkpoint("c/c", 3, 1000)
+    });
+
+    private readonly ArraySegment<Measure> _measures = new(new[]
+    {
+        new Measure("m/a", 1),
+        new Measure("mb", 2),
+        new Measure("mc", 3),
+    });
+
+    private readonly ArraySegment<Tag> _tags = new(new[]
+    {
+        new Tag("t/a", "t1"),
+        new Tag("tb", "t/2"),
+        new Tag("tc", "t3")
+    });
+
+    public MockLatencyData()
+    {
+        const int MillisecondsPerSecond = 1000;
+
+        LatencyData = new LatencyData(_tags, _checkpoints, _measures, 20, 1000);
+
+        SerializedLatencyData = string.Format(CultureInfo.InvariantCulture, "{0}/,{1}/,{2}/,{3}/,{4}/,{5}/,{6}",
+            string.Join("/", _tags.Select(a => a.Name.Replace('/', '_'))),
+            string.Join("/", _tags.Select(a => a.Value.Replace('/', '_'))),
+            string.Join("/", _checkpoints.Select(a => a.Name.Replace('/', '_'))),
+            string.Join("/", _checkpoints.Select(a => (long)Math.Round(((double)a.Elapsed / a.Frequency) * MillisecondsPerSecond))),
+            string.Join("/", _measures.Select(a => a.Name.Replace('/', '_'))),
+            string.Join("/", _measures.Select(a => a.Value)),
+            (long)Math.Round(((double)LatencyData.DurationTimestamp / LatencyData.DurationTimestampFrequency) * MillisecondsPerSecond));
+    }
+
+    public string SerializedLatencyData { get; private set; }
+
+    public LatencyData LatencyData { get; private set; }
+}


### PR DESCRIPTION
## Summary
Completes the open-sourcing of the incoming-request latency log enricher that was originally intended for public release but was orphaned. Migrates it from the R9 SDK into Microsoft.AspNetCore.Diagnostics.Middleware.

## Changes
- **Public API**: AddHttpLatencyTelemetry() extension method (registered via AddHttpLogEnricher<T>) in Microsoft.Extensions.DependencyInjection namespace.
- **Internal**: HttpLatencyLogEnricher reads ILatencyContext from request services and emits a latencyInfo tag with checkpoints, measures, tags, and total duration.
- **API status**: Marked [Experimental(EXTEXP0013)] on both class and method, consistent with precedent (sibling HttpClientLatencyLogEnricher).

## Design notes
- Tag-key casing: uses lowercase `latencyInfo`, while sibling client enricher uses uppercase `LatencyInfo`. This inconsistency should be addressed at API review.

## Precedent
Follows the pattern established by @rainsxng (#6783) and @mariamgerges (#7380) for other migration enrichers. Baseline JSON, attribute placement, test porting all consistent with that precedent.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7602)