### PR TITLE
Update Agent Framework to 1.13.0

### DIFF
--- a/eng/packages/ProjectTemplates.props
+++ b/eng/packages/ProjectTemplates.props
@@ -19,11 +19,11 @@
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.0.0-beta.444" />
     <PackageVersion Include="CommunityToolkit.Aspire.OllamaSharp" Version="13.0.0-beta.444" />
     <PackageVersion Include="MessagePack" Version="2.5.301" />
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.3.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.DevUI" Version="1.3.0-preview.260423.1" />
-    <PackageVersion Include="Microsoft.Agents.AI.Hosting" Version="1.3.0-preview.260423.1" />
-    <PackageVersion Include="Microsoft.Agents.AI.Hosting.OpenAI" Version="1.3.0-alpha.260423.1" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.13.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.DevUI" Version="1.13.0-preview.260703.1" />
+    <PackageVersion Include="Microsoft.Agents.AI.Hosting" Version="1.13.0-preview.260703.1" />
+    <PackageVersion Include="Microsoft.Agents.AI.Hosting.OpenAI" Version="1.13.0-alpha.260703.1" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.13.0" />
     <PackageVersion Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="$(MicrosoftMLTokenizersVersion)" />
     <PackageVersion Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="$(MicrosoftMLTokenizersVersion)" />
     <PackageVersion Include="CommunityToolkit.VectorData.AzureAISearch" Version="1.0.0-preview.3" />

--- a/src/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.csproj
+++ b/src/ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates/Microsoft.Agents.AI.ProjectTemplates.csproj
@@ -10,7 +10,7 @@
 
     <!-- Set the version info to align with Microsoft.Agents.AI packages -->
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>3</MinorVersion>
+    <MinorVersion>13</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
 


### PR DESCRIPTION
Bumps the Microsoft.Agents.AI packages pinned in `eng/packages/ProjectTemplates.props` to Agent Framework `1.13.0` (released 260703) and aligns the `Microsoft.Agents.AI.ProjectTemplates` package version to match.

## Package version changes

| Package | Old | New |
|---|---|---|
| `Microsoft.Agents.AI` | `1.3.0` | `1.13.0` |
| `Microsoft.Agents.AI.DevUI` | `1.3.0-preview.260423.1` | `1.13.0-preview.260703.1` |
| `Microsoft.Agents.AI.Hosting` | `1.3.0-preview.260423.1` | `1.13.0-preview.260703.1` |
| `Microsoft.Agents.AI.Hosting.OpenAI` | `1.3.0-alpha.260423.1` | `1.13.0-alpha.260703.1` |
| `Microsoft.Agents.AI.Workflows` | `1.3.0` | `1.13.0` |

Each package keeps its own stabilization tier (stable / `-preview` / `-alpha`).

## Template package version

`Microsoft.Agents.AI.ProjectTemplates`: `1.3.0-preview` -> `1.13.0-preview` (Major/Minor/Patch aligned to the release; prerelease label unchanged).

## Validation

The `aiagent-webapi` template was restored, built, and packed against 1.13.0, and its snapshot + execution tests pass. Agent Framework changes across the `1.3.0` -> `1.13.0` range were reviewed; the breaking changes in that span are not consumed by the `aiagent-webapi` template or the `Microsoft.Extensions.AI*` libraries, so no consumption updates were required. CI on this PR is authoritative.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7613)