### PR TITLE
Fix FICC tool_calls/tool ordering with approvals and service-managed chat history

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -870,6 +870,16 @@ public class FunctionInvokingChatClient : DelegatingChatClient
             c is ToolApprovalRequestContent { ToolCall: FunctionCallContent { InformationalOnly: false } }
             or ToolApprovalResponseContent { ToolCall: FunctionCallContent { InformationalOnly: false } });
 
+    /// <summary>
+    /// Determines whether <paramref name="message"/> contains any content that is neither an approval request nor an
+    /// approval response, i.e. genuine caller content (such as text) rather than approval machinery. Such content is
+    /// what causes the reconstructed tool-call/result block to be inserted before the approval message rather than
+    /// appended after it. Preserved approval content (for example MCP or informational-only approvals that survive
+    /// extraction) is intentionally not treated as this kind of content, so it stays ahead of the reconstructed block.
+    /// </summary>
+    private static bool MessageHasNonApprovalContent(ChatMessage message) =>
+        message.Contents.Any(static c => c is not (ToolApprovalRequestContent or ToolApprovalResponseContent));
+
     /// <summary>Copies any <see cref="FunctionCallContent"/> from <paramref name="messages"/> to <paramref name="functionCalls"/>.</summary>
     private static bool CopyFunctionCalls(
         IList<ChatMessage> messages, [NotNullWhen(true)] ref List<FunctionCallContent>? functionCalls)
@@ -1320,22 +1330,36 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     private (List<ChatMessage>? preDownstreamCallHistory, List<ApprovalResultWithRequestMessage>? approvals, int approvedResultInsertIndex) ProcessFunctionApprovalResponses(
         List<ChatMessage> originalMessages, bool hasConversationId, string? toolMessageId, string? functionCallContentFallbackMessageId)
     {
-        // Determine how many trailing caller-supplied messages sit after the approval exchange before extraction
-        // removes it. Messages after the last message carrying approval content are trailing messages that must
-        // remain after the reconstructed tool-call/result block; everything else stays before it. This keeps the
-        // reconstructed tool-call and tool result adjacent and ahead of the trailing messages, which is required
-        // in service-managed mode where the assistant tool-call is held by the service and is not re-sent. When
-        // there are no trailing messages this reduces to appending at the end of the list.
+        // Determine where the reconstructed tool-call/tool-result block is inserted into the outgoing list.
+        //
+        // The block is anchored just before the last message that carries approval content. Everything from that
+        // message onwards - its residual content that survives extraction (if the approval response shared a message
+        // with other content), plus every message after it - ends up after the block; everything before it stays
+        // before. This keeps a reconstructed tool result adjacent to the assistant tool-call it belongs to (whether
+        // that tool-call is reconstructed by us in client-managed mode, or held by the service in service-managed
+        // mode) and ahead of any trailing or residual caller-supplied content.
+        //
+        // The count is computed before extraction. Any message positioned after lastApprovalIndex carries no
+        // extracted approval content - lastApprovalIndex is the last one that does - so extraction never removes
+        // those messages. The last approval message itself survives only when it has other, non-approval, content.
+        // That makes the trailing count stable across extraction, so the resulting insert index is always in range.
+        //
+        // Known limitation: content interleaved between multiple approval responses, or placed before an approval
+        // response, remains before the block (only the last approval position is used as the anchor). In
+        // service-managed mode - where the service holds every prior tool-call ahead of all new messages - such
+        // interleaved/leading content can therefore break tool_calls->tool adjacency. Interleaving other content
+        // among, or before, approval responses is not a supported usage pattern.
         int lastApprovalIndex = originalMessages.FindLastIndex(MessageHasApprovalContent);
-        int trailingMessageCount = lastApprovalIndex >= 0 ? originalMessages.Count - 1 - lastApprovalIndex : 0;
+        int trailingMessageCount = lastApprovalIndex >= 0
+            ? (originalMessages.Count - 1 - lastApprovalIndex) + (MessageHasNonApprovalContent(originalMessages[lastApprovalIndex]) ? 1 : 0)
+            : 0;
 
         // Extract any approval responses where we need to execute or reject the function calls.
         // The original messages are also modified to remove all approval requests and responses.
         var notInvokedResponses = ExtractAndRemoveApprovalRequestsAndResponses(originalMessages);
 
-        // The reconstructed function call/result messages are inserted just before the trailing caller-supplied
-        // messages. Those trailing messages contain no approval content and so are never removed by extraction,
-        // which means they remain at the tail and this index is always valid.
+        // Insert just before the last approval message's surviving content (see above). When there are no trailing
+        // or residual messages this reduces to appending at the end of the list.
         int insertIndex = originalMessages.Count - trailingMessageCount;
 
         // Wrap the function call content in message(s).

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -304,11 +304,12 @@ public class FunctionInvokingChatClient : DelegatingChatClient
             // for any AIFunctions that were actually ApprovalRequiredAIFunctions. If the incoming chat messages include responses to those
             // approval requests, we need to process them now. This entails removing these manufactured approval requests from the chat message
             // list and replacing them with the appropriate FunctionCallContents and FunctionResultContents that would have been generated if
-            // the inner client had returned them directly.
-            (responseMessages, var notInvokedApprovals) = ProcessFunctionApprovalResponses(
+            // the inner client had returned them directly. The reconstructed messages are inserted at the approval anchor so they stay adjacent
+            // to the assistant tool-call and ahead of any trailing caller-supplied messages.
+            (responseMessages, var notInvokedApprovals, int approvedResultInsertIndex) = ProcessFunctionApprovalResponses(
                 originalMessages, !string.IsNullOrWhiteSpace(options?.ConversationId), toolMessageId: null, functionCallContentFallbackMessageId: null);
             (IList<ChatMessage>? invokedApprovedFunctionApprovalResponses, bool shouldTerminate, consecutiveErrorCount) =
-                await InvokeApprovedFunctionApprovalResponsesAsync(notInvokedApprovals, originalMessages, options, consecutiveErrorCount, isStreaming: false, cancellationToken);
+                await InvokeApprovedFunctionApprovalResponsesAsync(notInvokedApprovals, originalMessages, options, consecutiveErrorCount, isStreaming: false, approvedResultInsertIndex, cancellationToken);
 
             if (invokedApprovedFunctionApprovalResponses is not null)
             {
@@ -474,8 +475,9 @@ public class FunctionInvokingChatClient : DelegatingChatClient
             // for any AIFunctions that were actually ApprovalRequiredAIFunctions. If the incoming chat messages include responses to those
             // approval requests, we need to process them now. This entails removing these manufactured approval requests from the chat message
             // list and replacing them with the appropriate FunctionCallContents and FunctionResultContents that would have been generated if
-            // the inner client had returned them directly.
-            var (preDownstreamCallHistory, notInvokedApprovals) = ProcessFunctionApprovalResponses(
+            // the inner client had returned them directly. The reconstructed messages are inserted at the approval anchor so they stay adjacent
+            // to the assistant tool-call and ahead of any trailing caller-supplied messages.
+            var (preDownstreamCallHistory, notInvokedApprovals, approvedResultInsertIndex) = ProcessFunctionApprovalResponses(
                 originalMessages, !string.IsNullOrWhiteSpace(options?.ConversationId), toolMessageId, functionCallContentFallbackMessageId);
             if (preDownstreamCallHistory is not null)
             {
@@ -491,7 +493,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
 
             // Invoke approved approval responses, which generates some additional FRC wrapped in ChatMessage.
             (IList<ChatMessage>? invokedApprovedFunctionApprovalResponses, bool shouldTerminate, consecutiveErrorCount) =
-                await InvokeApprovedFunctionApprovalResponsesAsync(notInvokedApprovals, originalMessages, options, consecutiveErrorCount, isStreaming: true, cancellationToken);
+                await InvokeApprovedFunctionApprovalResponsesAsync(notInvokedApprovals, originalMessages, options, consecutiveErrorCount, isStreaming: true, approvedResultInsertIndex, cancellationToken);
 
             if (invokedApprovedFunctionApprovalResponses is not null)
             {
@@ -504,11 +506,11 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                         Activity.Current = activity; // workaround for https://github.com/dotnet/runtime/issues/47802
                     }
                 }
+            }
 
-                if (shouldTerminate)
-                {
-                    yield break;
-                }
+            if (shouldTerminate)
+            {
+                yield break;
             }
         }
 
@@ -861,9 +863,12 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     /// instances with a <see cref="FunctionCallContent"/> tool call that the FICC needs to process.
     /// </summary>
     private static bool HasAnyApprovalContent(List<ChatMessage> messages) =>
-        messages.Exists(static m => m.Contents.Any(static c =>
+        messages.Exists(MessageHasApprovalContent);
+
+    private static bool MessageHasApprovalContent(ChatMessage message) =>
+        message.Contents.Any(static c =>
             c is ToolApprovalRequestContent { ToolCall: FunctionCallContent { InformationalOnly: false } }
-            or ToolApprovalResponseContent { ToolCall: FunctionCallContent { InformationalOnly: false } }));
+            or ToolApprovalResponseContent { ToolCall: FunctionCallContent { InformationalOnly: false } });
 
     /// <summary>Copies any <see cref="FunctionCallContent"/> from <paramref name="messages"/> to <paramref name="functionCalls"/>.</summary>
     private static bool CopyFunctionCalls(
@@ -1135,11 +1140,15 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     /// <param name="consecutiveErrorCount">The number of consecutive iterations, prior to this one, that were recorded as having function invocation errors.</param>
     /// <param name="isStreaming">Whether the function calls are being processed in a streaming context.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
+    /// <param name="insertIndex">
+    /// The index at which to insert the generated result messages into <paramref name="messages"/>. When
+    /// <see langword="null"/>, the results are appended to the end of the list.
+    /// </param>
     /// <returns>A value indicating how the caller should proceed.</returns>
     private async Task<(bool ShouldTerminate, int NewConsecutiveErrorCount, IList<ChatMessage> MessagesAdded)> ProcessFunctionCallsAsync(
         List<ChatMessage> messages, ChatOptions? options,
         List<FunctionCallContent> functionCallContents, int iteration, int consecutiveErrorCount,
-        bool isStreaming, CancellationToken cancellationToken)
+        bool isStreaming, CancellationToken cancellationToken, int? insertIndex = null)
     {
         // We must add a response for every tool call, regardless of whether we successfully executed it or not.
         // If we successfully execute it, we'll add the result. If we don't, we'll add an error.
@@ -1180,7 +1189,14 @@ public class FunctionInvokingChatClient : DelegatingChatClient
         IList<ChatMessage> addedMessages = CreateResponseMessages(results.ToArray());
         ThrowIfNoFunctionResultsAdded(addedMessages);
         UpdateConsecutiveErrorCountOrThrow(addedMessages, ref consecutiveErrorCount);
-        messages.AddRange(addedMessages);
+        if (insertIndex is int idx)
+        {
+            messages.InsertRange(idx, addedMessages);
+        }
+        else
+        {
+            messages.AddRange(addedMessages);
+        }
 
         return (shouldTerminate, consecutiveErrorCount, addedMessages);
     }
@@ -1301,12 +1317,26 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     /// 3. Generate failed <see cref="FunctionResultContent"/> for any rejected <see cref="ToolApprovalResponseContent"/>.
     /// 4. add all the new content items to <paramref name="originalMessages"/> and return them as the pre-invocation history.
     /// </summary>
-    private (List<ChatMessage>? preDownstreamCallHistory, List<ApprovalResultWithRequestMessage>? approvals) ProcessFunctionApprovalResponses(
+    private (List<ChatMessage>? preDownstreamCallHistory, List<ApprovalResultWithRequestMessage>? approvals, int approvedResultInsertIndex) ProcessFunctionApprovalResponses(
         List<ChatMessage> originalMessages, bool hasConversationId, string? toolMessageId, string? functionCallContentFallbackMessageId)
     {
+        // Determine how many trailing caller-supplied messages sit after the approval exchange before extraction
+        // removes it. Messages after the last message carrying approval content are trailing messages that must
+        // remain after the reconstructed tool-call/result block; everything else stays before it. This keeps the
+        // reconstructed tool-call and tool result adjacent and ahead of the trailing messages, which is required
+        // in service-managed mode where the assistant tool-call is held by the service and is not re-sent. When
+        // there are no trailing messages this reduces to appending at the end of the list.
+        int lastApprovalIndex = originalMessages.FindLastIndex(MessageHasApprovalContent);
+        int trailingMessageCount = lastApprovalIndex >= 0 ? originalMessages.Count - 1 - lastApprovalIndex : 0;
+
         // Extract any approval responses where we need to execute or reject the function calls.
         // The original messages are also modified to remove all approval requests and responses.
         var notInvokedResponses = ExtractAndRemoveApprovalRequestsAndResponses(originalMessages);
+
+        // The reconstructed function call/result messages are inserted just before the trailing caller-supplied
+        // messages. Those trailing messages contain no approval content and so are never removed by extraction,
+        // which means they remain at the tail and this index is always valid.
+        int insertIndex = originalMessages.Count - trailingMessageCount;
 
         // Wrap the function call content in message(s).
         ICollection<ChatMessage>? allPreDownstreamCallMessages = ConvertToFunctionCallContentMessages(
@@ -1320,27 +1350,31 @@ public class FunctionInvokingChatClient : DelegatingChatClient
             null;
 
         // Add all the FCC that we generated to the pre-downstream-call history so that they can be returned to the caller as part of the next response.
-        // Also, if we are not dealing with a service thread (i.e. we don't have a conversation ID), add them
-        // into the original messages list so that they are passed to the inner client and can be used to generate a result.
+        // Also, if we are not dealing with a service thread (i.e. we don't have a conversation ID), insert them
+        // into the original messages list at the anchor so that they are passed to the inner client and can be used to generate a result.
         List<ChatMessage>? preDownstreamCallHistory = null;
         if (allPreDownstreamCallMessages is not null)
         {
             preDownstreamCallHistory = [.. allPreDownstreamCallMessages];
             if (!hasConversationId)
             {
-                originalMessages.AddRange(preDownstreamCallHistory);
+                originalMessages.InsertRange(insertIndex, preDownstreamCallHistory);
+                insertIndex += preDownstreamCallHistory.Count;
             }
         }
 
         // Add all the FRC that we generated to the pre-downstream-call history so that they can be returned to the caller as part of the next response.
-        // Also, add them into the original messages list so that they are passed to the inner client and can be used to generate a result.
+        // Also, insert them into the original messages list at the anchor so that they are passed to the inner client and can be used to generate a result.
         if (rejectedPreDownstreamCallResultsMessage is not null)
         {
             (preDownstreamCallHistory ??= []).Add(rejectedPreDownstreamCallResultsMessage);
-            originalMessages.Add(rejectedPreDownstreamCallResultsMessage);
+            originalMessages.Insert(insertIndex, rejectedPreDownstreamCallResultsMessage);
+            insertIndex++;
         }
 
-        return (preDownstreamCallHistory, notInvokedResponses.approvals);
+        // insertIndex now points just after the reconstructed tool-call/rejected-result messages, which is where
+        // any approved function results should be inserted so they stay ahead of trailing caller messages.
+        return (preDownstreamCallHistory, notInvokedResponses.approvals, insertIndex);
     }
 
     /// <summary>
@@ -1743,14 +1777,18 @@ public class FunctionInvokingChatClient : DelegatingChatClient
         ChatOptions? options,
         int consecutiveErrorCount,
         bool isStreaming,
+        int insertIndex,
         CancellationToken cancellationToken)
     {
         // Check if there are any function calls to do for any approved functions and execute them.
         if (notInvokedApprovals is { Count: > 0 })
         {
-            // The FRC that is generated here is already added to originalMessages by ProcessFunctionCallsAsync.
+            // The FRC that is generated here is inserted into originalMessages by ProcessFunctionCallsAsync at the
+            // supplied index so it stays adjacent to the reconstructed tool-call and ahead of any trailing
+            // caller-supplied messages. The trailing messages remain in the list during invocation, so the
+            // invoked function still receives the full input via FunctionInvocationContext.Messages.
             var modeAndMessages = await ProcessFunctionCallsAsync(
-                originalMessages, options, notInvokedApprovals.Select(x => x.Response.ToolCall).OfType<FunctionCallContent>().ToList(), 0, consecutiveErrorCount, isStreaming, cancellationToken);
+                originalMessages, options, notInvokedApprovals.Select(x => x.Response.ToolCall).OfType<FunctionCallContent>().ToList(), 0, consecutiveErrorCount, isStreaming, cancellationToken, insertIndex);
             consecutiveErrorCount = modeAndMessages.NewConsecutiveErrorCount;
 
             // Also mark the request's FCC as InformationalOnly to ensure consistency

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -298,7 +298,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
         int consecutiveErrorCount = 0;
         bool anyToolsRequireApproval = false;
 
-        if (HasAnyApprovalContent(originalMessages))
+        if (HasAnyFunctionApproval(originalMessages))
         {
             // A previous turn may have translated FunctionCallContents from the inner client into approval requests sent back to the caller,
             // for any AIFunctions that were actually ApprovalRequiredAIFunctions. If the incoming chat messages include responses to those
@@ -465,7 +465,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
         // but there's no benefit to doing so.
         string toolMessageId = Guid.NewGuid().ToString("N");
 
-        if (HasAnyApprovalContent(originalMessages))
+        if (HasAnyFunctionApproval(originalMessages))
         {
             // We also need a synthetic ID for the function call content for approved function calls
             // where we don't know what the original message id of the function call was.
@@ -862,23 +862,27 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     /// Gets whether <paramref name="messages"/> contains any <see cref="ToolApprovalRequestContent"/> or <see cref="ToolApprovalResponseContent"/>
     /// instances with a <see cref="FunctionCallContent"/> tool call that the FICC needs to process.
     /// </summary>
-    private static bool HasAnyApprovalContent(List<ChatMessage> messages) =>
-        messages.Exists(MessageHasApprovalContent);
+    private static bool HasAnyFunctionApproval(List<ChatMessage> messages) =>
+        messages.Exists(MessageHasFunctionApproval);
 
-    private static bool MessageHasApprovalContent(ChatMessage message) =>
+    private static bool MessageHasFunctionApproval(ChatMessage message) =>
         message.Contents.Any(static c =>
             c is ToolApprovalRequestContent { ToolCall: FunctionCallContent { InformationalOnly: false } }
             or ToolApprovalResponseContent { ToolCall: FunctionCallContent { InformationalOnly: false } });
 
     /// <summary>
-    /// Determines whether <paramref name="message"/> contains any content that is neither an approval request nor an
-    /// approval response, i.e. genuine caller content (such as text) rather than approval machinery. Such content is
-    /// what causes the reconstructed tool-call/result block to be inserted before the approval message rather than
-    /// appended after it. Preserved approval content (for example MCP or informational-only approvals that survive
-    /// extraction) is intentionally not treated as this kind of content, so it stays ahead of the reconstructed block.
+    /// Determines whether every content item in <paramref name="message"/> is a function approval request or response
+    /// (a <see cref="ToolApprovalRequestContent"/> or <see cref="ToolApprovalResponseContent"/> whose tool call is a
+    /// non-informational <see cref="FunctionCallContent"/>). When this returns <see langword="false"/>, the anchor
+    /// message carries content that survives extraction - genuine caller content (such as text) or approval content
+    /// the FICC does not process itself (for example MCP or informational-only approvals). That surviving content is
+    /// what causes the reconstructed tool-call/result block to be inserted before the anchor message rather than
+    /// appended after it, keeping the reconstructed tool result adjacent to its function tool-call.
     /// </summary>
-    private static bool MessageHasNonApprovalContent(ChatMessage message) =>
-        message.Contents.Any(static c => c is not (ToolApprovalRequestContent or ToolApprovalResponseContent));
+    private static bool MessageContainsOnlyFunctionApprovals(ChatMessage message) =>
+        message.Contents.All(static c =>
+            c is ToolApprovalRequestContent { ToolCall: FunctionCallContent { InformationalOnly: false } }
+            or ToolApprovalResponseContent { ToolCall: FunctionCallContent { InformationalOnly: false } });
 
     /// <summary>Copies any <see cref="FunctionCallContent"/> from <paramref name="messages"/> to <paramref name="functionCalls"/>.</summary>
     private static bool CopyFunctionCalls(
@@ -1332,27 +1336,35 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     {
         // Determine where the reconstructed tool-call/tool-result block is inserted into the outgoing list.
         //
-        // The block is anchored just before the last message that carries approval content. Everything from that
-        // message onwards - its residual content that survives extraction (if the approval response shared a message
-        // with other content), plus every message after it - ends up after the block; everything before it stays
-        // before. This keeps a reconstructed tool result adjacent to the assistant tool-call it belongs to (whether
-        // that tool-call is reconstructed by us in client-managed mode, or held by the service in service-managed
-        // mode) and ahead of any trailing or residual caller-supplied content.
+        // The block is anchored just before the last message that carries function approval content. Everything from
+        // that message onwards - its residual content that survives extraction (if the approval response shared a
+        // message with other content), plus every message after it - ends up after the block; everything before it
+        // stays before. This keeps a reconstructed tool result adjacent to the assistant tool-call it belongs to
+        // (whether that tool-call is reconstructed by us in client-managed conversation mode, or held by the service
+        // in service-managed conversation mode) and ahead of any trailing or residual caller-supplied content.
         //
         // The count is computed before extraction. Any message positioned after lastApprovalIndex carries no
-        // extracted approval content - lastApprovalIndex is the last one that does - so extraction never removes
-        // those messages. The last approval message itself survives only when it has other, non-approval, content.
-        // That makes the trailing count stable across extraction, so the resulting insert index is always in range.
+        // extracted function approval content - lastApprovalIndex is the last one that does - so extraction never
+        // removes those messages. The last approval message itself survives when it also carries other content that
+        // is not a function approval (genuine caller content, or approval content the FICC does not process itself
+        // such as MCP or informational-only approvals). That makes the trailing count stable across extraction, so
+        // the resulting insert index is always in range.
         //
         // Known limitation: content interleaved between multiple approval responses, or placed before an approval
         // response, remains before the block (only the last approval position is used as the anchor). In
-        // service-managed mode - where the service holds every prior tool-call ahead of all new messages - such
-        // interleaved/leading content can therefore break tool_calls->tool adjacency. Interleaving other content
-        // among, or before, approval responses is not a supported usage pattern.
-        int lastApprovalIndex = originalMessages.FindLastIndex(MessageHasApprovalContent);
-        int trailingMessageCount = lastApprovalIndex >= 0
-            ? (originalMessages.Count - 1 - lastApprovalIndex) + (MessageHasNonApprovalContent(originalMessages[lastApprovalIndex]) ? 1 : 0)
-            : 0;
+        // service-managed conversation mode - where the service holds every prior tool-call ahead of all new
+        // messages - such interleaved/leading content can therefore break tool_calls->tool adjacency. Interleaving
+        // other content among, or before, approval responses is not a supported usage pattern.
+        int lastApprovalIndex = originalMessages.FindLastIndex(MessageHasFunctionApproval);
+        int trailingMessageCount = 0;
+        if (lastApprovalIndex >= 0)
+        {
+            trailingMessageCount = originalMessages.Count - (lastApprovalIndex + 1);
+            if (!MessageContainsOnlyFunctionApprovals(originalMessages[lastApprovalIndex]))
+            {
+                trailingMessageCount++;
+            }
+        }
 
         // Extract any approval responses where we need to execute or reject the function calls.
         // The original messages are also modified to remove all approval requests and responses.

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
@@ -1388,8 +1388,67 @@ public class FunctionInvokingChatClientApprovalsTests
         await InvokeAndAssertStreamingAsync(options, input, downstreamClientOutput, output, expectedDownstreamClientInput);
     }
 
-    /// <summary>
-    /// FunctionCallContent updates are buffered until the end of the stream so that the client can check
+    [Fact]
+    public async Task ApprovedResponseThatRequestsTerminationStopsBeforeCallingInnerClientAsync()
+    {
+        // An approved function requests termination of the processing loop. Approval responses are handled before
+        // the main loop, so processing must stop right after the approval block - yielding the reconstructed
+        // tool-call and tool result but never calling the inner client. This covers the streaming yield break and
+        // non-streaming return that fire even though the approval block produced messages.
+        var options = new ChatOptions
+        {
+            Tools =
+            [
+                new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() =>
+                {
+                    FunctionInvokingChatClient.CurrentContext!.Terminate = true;
+                    return "Result 1";
+                }, "Func1")),
+            ],
+        };
+
+        List<ChatMessage> input =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+            new ChatMessage(ChatRole.Assistant,
+            [
+                new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1")),
+            ]) { MessageId = "resp1" },
+            new ChatMessage(ChatRole.User,
+            [
+                new ToolApprovalResponseContent("ficc_callId1", true, new FunctionCallContent("callId1", "Func1")),
+            ]),
+        ];
+
+        List<ChatMessage> expectedOutput =
+        [
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
+        ];
+
+        using (var innerClient = new TestChatClient
+        {
+            GetResponseAsyncCallback = (_, _, _) =>
+                throw new InvalidOperationException("The inner client must not be called after the approved function requests termination."),
+        })
+        {
+            using var service = new FunctionInvokingChatClient(innerClient);
+            var result = await service.GetResponseAsync(CloneInput(input), options);
+            AssertExtensions.EqualMessageLists(expectedOutput, result.Messages.ToList());
+        }
+
+        using (var innerClient = new TestChatClient
+        {
+            GetStreamingResponseAsyncCallback = (_, _, _) =>
+                throw new InvalidOperationException("The inner client must not be called after the approved function requests termination."),
+        })
+        {
+            using var service = new FunctionInvokingChatClient(innerClient);
+            var result = await service.GetStreamingResponseAsync(CloneInput(input), options).ToChatResponseAsync();
+            AssertExtensions.EqualMessageLists(expectedOutput, result.Messages.ToList());
+        }
+    }
+
     /// for matching FunctionResultContent from server-handled function calls and mark those FCCs as
     /// InformationalOnly. This means FCCs are not yielded immediately, even when no approval is required.
     /// </summary>
@@ -1737,10 +1796,6 @@ public class FunctionInvokingChatClientApprovalsTests
             [
                 new ToolApprovalRequestContent("callId2", new McpServerToolCallContent("callId2", "McpCall", "myServer"))
             ]),
-            new ChatMessage(ChatRole.User,
-            [
-                new ToolApprovalResponseContent("callId2", true, new McpServerToolCallContent("callId2", "McpCall", "myServer"))
-            ]),
             new ChatMessage(ChatRole.Assistant,
             [
                 new FunctionCallContent("callId1", "Func")
@@ -1748,6 +1803,10 @@ public class FunctionInvokingChatClientApprovalsTests
             new ChatMessage(ChatRole.Tool,
             [
                 new FunctionResultContent("callId1", result: "Result 1")
+            ]),
+            new ChatMessage(ChatRole.User,
+            [
+                new ToolApprovalResponseContent("callId2", true, new McpServerToolCallContent("callId2", "McpCall", "myServer"))
             ]),
         ];
 
@@ -1820,10 +1879,6 @@ public class FunctionInvokingChatClientApprovalsTests
                 [
                     new ToolApprovalRequestContent("callId2", new McpServerToolCallContent("callId2", "McpCall", "myServer"))
                 ]),
-                new ChatMessage(ChatRole.User,
-                [
-                    new ToolApprovalResponseContent("callId2", approveMcpCall, new McpServerToolCallContent("callId2", "McpCall", "myServer"))
-                ]),
                 new ChatMessage(ChatRole.Assistant,
                 [
                     new FunctionCallContent("callId1", "Func")
@@ -1833,6 +1888,10 @@ public class FunctionInvokingChatClientApprovalsTests
                     approveFuncCall ?
                         new FunctionResultContent("callId1", result: "Result 1") :
                         new FunctionResultContent("callId1", result: "Tool call invocation rejected.")
+                ]),
+                new ChatMessage(ChatRole.User,
+                [
+                    new ToolApprovalResponseContent("callId2", approveMcpCall, new McpServerToolCallContent("callId2", "McpCall", "myServer"))
                 ]),
             ];
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
@@ -1195,11 +1195,7 @@ public class FunctionInvokingChatClientApprovalsTests
         // assistant(tool_calls) -> user(trailing) -> tool(result), which breaks tool_calls->tool adjacency.
         var options = new ChatOptions
         {
-            Tools =
-            [
-                new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => "Result 1", "Func1")),
-                AIFunctionFactory.Create((int i) => $"Result 2: {i}", "Func2"),
-            ],
+            Tools = [new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => "Result 1", "Func1"))],
             ConversationId = "test-conversation",
         };
 
@@ -1208,7 +1204,6 @@ public class FunctionInvokingChatClientApprovalsTests
             new ChatMessage(ChatRole.User,
             [
                 new ToolApprovalResponseContent("ficc_callId1", true, new FunctionCallContent("callId1", "Func1")),
-                new ToolApprovalResponseContent("ficc_callId2", true, new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
             ]),
 
             // A caller-supplied message after the approval response.
@@ -1219,7 +1214,7 @@ public class FunctionInvokingChatClientApprovalsTests
         // re-sent because the service already holds it.
         List<ChatMessage> expectedDownstreamClientInput =
         [
-            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1"), new FunctionResultContent("callId2", result: "Result 2: 42")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
             new ChatMessage(ChatRole.User, "By the way, please keep the answer concise."),
         ];
 
@@ -1230,8 +1225,56 @@ public class FunctionInvokingChatClientApprovalsTests
 
         List<ChatMessage> output =
         [
-            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1"), new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } })]),
-            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1"), new FunctionResultContent("callId2", result: "Result 2: 42")]),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
+            new ChatMessage(ChatRole.Assistant, "world"),
+        ];
+
+        await InvokeAndAssertAsync(options, input, downstreamClientOutput, output, expectedDownstreamClientInput);
+
+        await InvokeAndAssertStreamingAsync(options, input, downstreamClientOutput, output, expectedDownstreamClientInput);
+    }
+
+    [Fact]
+    public async Task ApprovedResponseStaysAdjacentToToolCallWhenApprovalMessageHasOtherContentWithServiceThreadsAsync()
+    {
+        // Regression: the approval response shares a message with other caller content. Extraction removes the
+        // approval response but leaves the other content ("please proceed") in place. In service-managed mode the
+        // service holds the assistant tool-call, so the reconstructed tool result must still be placed ahead of that
+        // residual content, otherwise the effective ordering becomes
+        // assistant(tool_calls) -> user("please proceed") -> tool(result), which breaks tool_calls->tool adjacency.
+        var options = new ChatOptions
+        {
+            Tools = [new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => "Result 1", "Func1"))],
+            ConversationId = "test-conversation",
+        };
+
+        List<ChatMessage> input =
+        [
+            new ChatMessage(ChatRole.User,
+            [
+                new ToolApprovalResponseContent("ficc_callId1", true, new FunctionCallContent("callId1", "Func1")),
+                new TextContent("please proceed"),
+            ]),
+        ];
+
+        // The tool result is positioned at the front, ahead of the residual "please proceed" content that was left
+        // behind in the approval message after the approval response was extracted.
+        List<ChatMessage> expectedDownstreamClientInput =
+        [
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
+            new ChatMessage(ChatRole.User, "please proceed"),
+        ];
+
+        List<ChatMessage> downstreamClientOutput =
+        [
+            new ChatMessage(ChatRole.Assistant, "world"),
+        ];
+
+        List<ChatMessage> output =
+        [
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
             new ChatMessage(ChatRole.Assistant, "world"),
         ];
 
@@ -1248,11 +1291,7 @@ public class FunctionInvokingChatClientApprovalsTests
         // messages end up after the tool result while adjacency is preserved.
         var options = new ChatOptions
         {
-            Tools =
-            [
-                new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => "Result 1", "Func1")),
-                AIFunctionFactory.Create((int i) => $"Result 2: {i}", "Func2"),
-            ]
+            Tools = [new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => "Result 1", "Func1"))],
         };
 
         List<ChatMessage> input =
@@ -1261,12 +1300,10 @@ public class FunctionInvokingChatClientApprovalsTests
             new ChatMessage(ChatRole.Assistant,
             [
                 new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1")),
-                new ToolApprovalRequestContent("ficc_callId2", new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
             ]) { MessageId = "resp1" },
             new ChatMessage(ChatRole.User,
             [
                 new ToolApprovalResponseContent("ficc_callId1", true, new FunctionCallContent("callId1", "Func1")),
-                new ToolApprovalResponseContent("ficc_callId2", true, new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
             ]),
 
             // A caller-supplied message after the approval response.
@@ -1278,8 +1315,8 @@ public class FunctionInvokingChatClientApprovalsTests
         List<ChatMessage> expectedDownstreamClientInput =
         [
             new ChatMessage(ChatRole.User, "hello"),
-            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1"), new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } })]),
-            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1"), new FunctionResultContent("callId2", result: "Result 2: 42")]),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
             new ChatMessage(ChatRole.User, "By the way, please keep the answer concise."),
         ];
 
@@ -1290,8 +1327,59 @@ public class FunctionInvokingChatClientApprovalsTests
 
         List<ChatMessage> output =
         [
-            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1"), new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } })]),
-            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1"), new FunctionResultContent("callId2", result: "Result 2: 42")]),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
+            new ChatMessage(ChatRole.Assistant, "world"),
+        ];
+
+        await InvokeAndAssertAsync(options, input, downstreamClientOutput, output, expectedDownstreamClientInput);
+
+        await InvokeAndAssertStreamingAsync(options, input, downstreamClientOutput, output, expectedDownstreamClientInput);
+    }
+
+    [Fact]
+    public async Task ApprovedResponseStaysAdjacentToToolCallWhenApprovalMessageHasOtherContentWithClientHistoryAsync()
+    {
+        // Client-managed history where the approval response shares a message with other caller content. The
+        // reconstructed tool-call/result block is inserted just before that approval message, so the residual
+        // content ("please proceed") that survives extraction ends up after the reconstructed assistant tool-call
+        // and tool result rather than wedged before them.
+        var options = new ChatOptions
+        {
+            Tools = [new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => "Result 1", "Func1"))],
+        };
+
+        List<ChatMessage> input =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+            new ChatMessage(ChatRole.Assistant,
+            [
+                new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1")),
+            ]) { MessageId = "resp1" },
+            new ChatMessage(ChatRole.User,
+            [
+                new ToolApprovalResponseContent("ficc_callId1", true, new FunctionCallContent("callId1", "Func1")),
+                new TextContent("please proceed"),
+            ]),
+        ];
+
+        List<ChatMessage> expectedDownstreamClientInput =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
+            new ChatMessage(ChatRole.User, "please proceed"),
+        ];
+
+        List<ChatMessage> downstreamClientOutput =
+        [
+            new ChatMessage(ChatRole.Assistant, "world"),
+        ];
+
+        List<ChatMessage> output =
+        [
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
             new ChatMessage(ChatRole.Assistant, "world"),
         ];
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientApprovalsTests.cs
@@ -1186,6 +1186,120 @@ public class FunctionInvokingChatClientApprovalsTests
         await InvokeAndAssertStreamingAsync(options, input, downstreamClientOutput, output, expectedDownstreamClientInput);
     }
 
+    [Fact]
+    public async Task ApprovedResponsesStayAdjacentToToolCallWhenTrailingMessagesPresentWithServiceThreadsAsync()
+    {
+        // Service-managed history: only the new messages are passed and a ConversationId is set. The service
+        // holds the assistant tool-call, so the reconstructed tool result must be positioned ahead of any
+        // trailing caller-supplied message, otherwise the effective ordering seen by the provider becomes
+        // assistant(tool_calls) -> user(trailing) -> tool(result), which breaks tool_calls->tool adjacency.
+        var options = new ChatOptions
+        {
+            Tools =
+            [
+                new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => "Result 1", "Func1")),
+                AIFunctionFactory.Create((int i) => $"Result 2: {i}", "Func2"),
+            ],
+            ConversationId = "test-conversation",
+        };
+
+        List<ChatMessage> input =
+        [
+            new ChatMessage(ChatRole.User,
+            [
+                new ToolApprovalResponseContent("ficc_callId1", true, new FunctionCallContent("callId1", "Func1")),
+                new ToolApprovalResponseContent("ficc_callId2", true, new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
+            ]),
+
+            // A caller-supplied message after the approval response.
+            new ChatMessage(ChatRole.User, "By the way, please keep the answer concise."),
+        ];
+
+        // The tool result must come before the trailing caller message, and the assistant tool-call is not
+        // re-sent because the service already holds it.
+        List<ChatMessage> expectedDownstreamClientInput =
+        [
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1"), new FunctionResultContent("callId2", result: "Result 2: 42")]),
+            new ChatMessage(ChatRole.User, "By the way, please keep the answer concise."),
+        ];
+
+        List<ChatMessage> downstreamClientOutput =
+        [
+            new ChatMessage(ChatRole.Assistant, "world"),
+        ];
+
+        List<ChatMessage> output =
+        [
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1"), new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } })]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1"), new FunctionResultContent("callId2", result: "Result 2: 42")]),
+            new ChatMessage(ChatRole.Assistant, "world"),
+        ];
+
+        await InvokeAndAssertAsync(options, input, downstreamClientOutput, output, expectedDownstreamClientInput);
+
+        await InvokeAndAssertStreamingAsync(options, input, downstreamClientOutput, output, expectedDownstreamClientInput);
+    }
+
+    [Fact]
+    public async Task ApprovedResponsesStayAdjacentToToolCallWhenTrailingMessagesPresentWithClientHistoryAsync()
+    {
+        // Client-managed history: the full history is passed and there is no ConversationId. The reconstructed
+        // assistant tool-call and tool result are inserted at the approval anchor, so trailing caller-supplied
+        // messages end up after the tool result while adjacency is preserved.
+        var options = new ChatOptions
+        {
+            Tools =
+            [
+                new ApprovalRequiredAIFunction(AIFunctionFactory.Create(() => "Result 1", "Func1")),
+                AIFunctionFactory.Create((int i) => $"Result 2: {i}", "Func2"),
+            ]
+        };
+
+        List<ChatMessage> input =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+            new ChatMessage(ChatRole.Assistant,
+            [
+                new ToolApprovalRequestContent("ficc_callId1", new FunctionCallContent("callId1", "Func1")),
+                new ToolApprovalRequestContent("ficc_callId2", new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
+            ]) { MessageId = "resp1" },
+            new ChatMessage(ChatRole.User,
+            [
+                new ToolApprovalResponseContent("ficc_callId1", true, new FunctionCallContent("callId1", "Func1")),
+                new ToolApprovalResponseContent("ficc_callId2", true, new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } }))
+            ]),
+
+            // A caller-supplied message after the approval response.
+            new ChatMessage(ChatRole.User, "By the way, please keep the answer concise."),
+        ];
+
+        // The reconstructed assistant tool-call and tool result are inserted at the approval anchor, so they
+        // remain adjacent and the trailing caller message follows the tool result.
+        List<ChatMessage> expectedDownstreamClientInput =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1"), new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } })]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1"), new FunctionResultContent("callId2", result: "Result 2: 42")]),
+            new ChatMessage(ChatRole.User, "By the way, please keep the answer concise."),
+        ];
+
+        List<ChatMessage> downstreamClientOutput =
+        [
+            new ChatMessage(ChatRole.Assistant, "world"),
+        ];
+
+        List<ChatMessage> output =
+        [
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("callId1", "Func1"), new FunctionCallContent("callId2", "Func2", arguments: new Dictionary<string, object?> { { "i", 42 } })]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1"), new FunctionResultContent("callId2", result: "Result 2: 42")]),
+            new ChatMessage(ChatRole.Assistant, "world"),
+        ];
+
+        await InvokeAndAssertAsync(options, input, downstreamClientOutput, output, expectedDownstreamClientInput);
+
+        await InvokeAndAssertStreamingAsync(options, input, downstreamClientOutput, output, expectedDownstreamClientInput);
+    }
+
     /// <summary>
     /// FunctionCallContent updates are buffered until the end of the stream so that the client can check
     /// for matching FunctionResultContent from server-handled function calls and mark those FCCs as


### PR DESCRIPTION
Fixes #7616

## Summary

When `FunctionInvokingChatClient` (FICC) resumes an approval-gated function call in **service-managed history mode** (a non-empty `ConversationId` is set), it omits the reconstructed `assistant(tool_calls)` message (the service already holds it) but still **appends** the executed tool result to the tail of the outgoing message list. If the caller supplies any message *after* the `ToolApprovalResponseContent` on the continuation turn, that trailing message ends up wedged between the service-held `assistant(tool_calls)` and its `tool` result:

```
assistant(tool_calls) -> user(<trailing message>) -> tool(result)
```

Providers enforcing `tool_calls`→`tool` adjacency (e.g. OpenAI) reject this with HTTP 400.

## Fix

Instead of always appending the reconstructed tool-call/tool-result messages at the tail, they are now inserted just **before any caller-supplied trailing messages**, keeping the tool result adjacent to the `assistant` message that owns the matching `tool_call_id`:

- `ProcessFunctionCallsAsync` gains an optional `int? insertIndex` — when set, results are inserted at that index rather than appended.
- `ProcessFunctionApprovalResponses` computes the trailing-message count (messages after the *last* approval-content message) and inserts the reconstructed `assistant(tool_calls)` + rejected results just before them, returning the running insert index.
- The index is threaded through `InvokeApprovedFunctionApprovalResponsesAsync` so approved tool results land adjacent to the tool-call.
- Applied to both the streaming and non-streaming approval paths.

When there are no trailing messages the insert position degrades to the original tail-append behavior, so existing scenarios are unaffected. The invoked function still receives the full input (trailing messages remain in `context.Messages` during invocation; only the result placement changes).

Resulting valid ordering:

```
assistant(tool_calls) -> tool(result) -> user(<trailing message>)
```

## Tests

Added regression tests (streaming + non-streaming) covering trailing messages after an approval response in both service-managed and client-managed history modes:

- `ApprovedResponsesStayAdjacentToToolCallWhenTrailingMessagesPresentWithServiceThreadsAsync`
- `ApprovedResponsesStayAdjacentToToolCallWhenTrailingMessagesPresentWithClientHistoryAsync`

All existing `FunctionInvokingChatClient` approval tests continue to pass.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7617)

CC @jozkee