### PR TITLE
fix: throw InvalidOperationException when MarkItDownMcpReader encounters IsError.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.DataIngestion.MarkItDown/MarkItDownMcpReader.cs
+++ b/src/Libraries/Microsoft.Extensions.DataIngestion.MarkItDown/MarkItDownMcpReader.cs
@@ -87,7 +87,28 @@ public class MarkItDownMcpReader : IngestionDocumentReader
                 };
 
                 // Call the convert_to_markdown tool
-                var result = await client.CallToolAsync("convert_to_markdown", parameters, cancellationToken: cancellationToken).ConfigureAwait(false);
+               var result = await client.CallToolAsync("convert_to_markdown", parameters, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                // FIX: Check if the tool execution returned an error
+                if (result.IsError)
+                {
+                    // Extract the error message from the content block if available, or fall back to a default error
+                    string errorText = "An unknown error occurred during document conversion.";
+                    
+                    if (result.Content != null && result.Content.Count > 0)
+                    {
+                        foreach (var content in result.Content)
+                        {
+                            if (content.Type == "text" && content is TextContentBlock textBlock)
+                            {
+                                errorText = textBlock.Text;
+                                break;
+                            }
+                        }
+                    }
+
+                    throw new InvalidOperationException($"Failed to convert document to markdown: {errorText}");
+                }
 
                 // Extract markdown content from result
                 // The result is expected to be in the format: { "content": [{ "type": "text", "text": "markdown content" }] }

--- a/src/Libraries/Microsoft.Extensions.DataIngestion.MarkItDown/MarkItDownMcpReader.cs
+++ b/src/Libraries/Microsoft.Extensions.DataIngestion.MarkItDown/MarkItDownMcpReader.cs
@@ -87,14 +87,14 @@ public class MarkItDownMcpReader : IngestionDocumentReader
                 };
 
                 // Call the convert_to_markdown tool
-               var result = await client.CallToolAsync("convert_to_markdown", parameters, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var result = await client.CallToolAsync("convert_to_markdown", parameters, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-                // FIX: Check if the tool execution returned an error
-                if (result.IsError)
+                // FIX: Check if the tool execution returned an error (handles bool?)
+                if (result.IsError == true)
                 {
                     // Extract the error message from the content block if available, or fall back to a default error
                     string errorText = "An unknown error occurred during document conversion.";
-                    
+
                     if (result.Content != null && result.Content.Count > 0)
                     {
                         foreach (var content in result.Content)


### PR DESCRIPTION
This PR resolves an issue where MarkItDownMcpReader silently ignores tool errors during document conversion.

Related Issues
Closes #7618
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7627)