### PR TITLE
Hybrid Cache add DisableLocalCacheSerialization - Partially fixes #6063

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/HybridCacheOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/HybridCacheOptions.cs
@@ -27,7 +27,7 @@ public class HybridCacheOptions
 
     /// <summary>
     /// Gets or sets a value indicating whether values stored in the local cache should be returned by reference
-    /// instead of being serialized and deserialized to provide defensive copies.
+    /// instead of using serialization round-trips to create defensive copies.
     /// </summary>
     /// <remarks>
     /// When enabled, mutable values may be shared between callers and changes made to a cached value are visible

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/HybridCacheOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/HybridCacheOptions.cs
@@ -26,6 +26,18 @@ public class HybridCacheOptions
     public bool DisableCompression { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether values stored in the local cache should be returned by reference
+    /// instead of being serialized and deserialized to provide defensive copies.
+    /// </summary>
+    /// <remarks>
+    /// When enabled, mutable values may be shared between callers and changes made to a cached value are visible
+    /// to subsequent callers. Values are still serialized when required for the distributed cache. Local cache
+    /// size accounting continues to use the serialized payload size and may not reflect the size of the retained
+    /// object graph.
+    /// </remarks>
+    public bool DisableLocalCacheSerialization { get; set; }
+
+    /// <summary>
     /// Gets or sets the maximum size of cache items.
     /// </summary>
     /// <value>

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.CacheItem.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.CacheItem.cs
@@ -133,7 +133,9 @@ internal partial class DefaultHybridCache
             static void Throw() => throw new ObjectDisposedException("The cache item has been recycled before the value was obtained");
         }
 
-        internal static CacheItem<T> Create(long creationTimestamp, TagSet tags) => ImmutableTypeCache<T>.IsImmutable
-            ? new ImmutableCacheItem<T>(creationTimestamp, tags) : new MutableCacheItem<T>(creationTimestamp, tags);
+        internal static CacheItem<T> Create(long creationTimestamp, TagSet tags, bool disableLocalCacheWrite)
+            => ImmutableTypeCache<T>.IsImmutable || disableLocalCacheWrite
+            ? new ImmutableCacheItem<T>(creationTimestamp, tags)
+            : new MutableCacheItem<T>(creationTimestamp, tags);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.CacheItem.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.CacheItem.cs
@@ -133,8 +133,8 @@ internal partial class DefaultHybridCache
             static void Throw() => throw new ObjectDisposedException("The cache item has been recycled before the value was obtained");
         }
 
-        internal static CacheItem<T> Create(long creationTimestamp, TagSet tags, bool disableLocalCacheWrite)
-            => ImmutableTypeCache<T>.IsImmutable || disableLocalCacheWrite
+        internal static CacheItem<T> Create(long creationTimestamp, TagSet tags, bool disableLocalCacheSerialization)
+            => ImmutableTypeCache<T>.IsImmutable || disableLocalCacheSerialization
             ? new ImmutableCacheItem<T>(creationTimestamp, tags)
             : new MutableCacheItem<T>(creationTimestamp, tags);
     }

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.StampedeStateT.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.StampedeStateT.cs
@@ -323,6 +323,9 @@ internal partial class DefaultHybridCache
                     // SizeLimit (we can't know - it is an abstraction), and for *that* we need to know the item size.
                     // Likewise, if we're writing to a MutableCacheItem, we'll be serializing *anyway* for the payload.
                     //
+                    // Rephrasing that: the only scenario in which we *do not* need to serialize is if:
+                    // - it is an ImmutableCacheItem (so we don't need bytes for the CacheItem, L1)
+                    // - we're not writing to L2
                     CacheItem cacheItem = CacheItem;
                     bool skipSerialize = cacheItem is ImmutableCacheItem<T> && (activeFlags & FlagsDisableL1AndL2Write) == FlagsDisableL1AndL2Write;
 

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.StampedeStateT.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.StampedeStateT.cs
@@ -31,13 +31,13 @@ internal partial class DefaultHybridCache
             => _result?.TrySetResult(value);
 
         public StampedeState(DefaultHybridCache cache, in StampedeKey key, TagSet tags, bool canBeCanceled)
-            : base(cache, key, CacheItem<T>.Create(cache.CurrentTimestamp(), tags), canBeCanceled)
+            : base(cache, key, CacheItem<T>.Create(cache.CurrentTimestamp(), tags, cache.Options.DisableLocalCacheSerialization), canBeCanceled)
         {
             _result = new(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
         public StampedeState(DefaultHybridCache cache, in StampedeKey key, TagSet tags, CancellationToken token)
-            : base(cache, key, CacheItem<T>.Create(cache.CurrentTimestamp(), tags), token)
+            : base(cache, key, CacheItem<T>.Create(cache.CurrentTimestamp(), tags, cache.Options.DisableLocalCacheSerialization), token)
         {
             // no TCS in this case - this is for SetValue only
         }
@@ -323,9 +323,6 @@ internal partial class DefaultHybridCache
                     // SizeLimit (we can't know - it is an abstraction), and for *that* we need to know the item size.
                     // Likewise, if we're writing to a MutableCacheItem, we'll be serializing *anyway* for the payload.
                     //
-                    // Rephrasing that: the only scenario in which we *do not* need to serialize is if:
-                    // - it is an ImmutableCacheItem (so we don't need bytes for the CacheItem, L1)
-                    // - we're not writing to L2
                     CacheItem cacheItem = CacheItem;
                     bool skipSerialize = cacheItem is ImmutableCacheItem<T> && (activeFlags & FlagsDisableL1AndL2Write) == FlagsDisableL1AndL2Write;
 

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Microsoft.Extensions.Caching.Hybrid.json
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Microsoft.Extensions.Caching.Hybrid.json
@@ -42,6 +42,10 @@
           "Stage": "Stable"
         },
         {
+          "Member": "bool Microsoft.Extensions.Caching.Hybrid.HybridCacheOptions.DisableLocalCacheSerialization { get; set; }",
+          "Stage": "Stable"
+        },
+        {
           "Member": "object? Microsoft.Extensions.Caching.Hybrid.HybridCacheOptions.DistributedCacheServiceKey { get; set; }",
           "Stage": "Stable"
         },

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/BufferReleaseTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/BufferReleaseTests.cs
@@ -243,7 +243,7 @@ public class BufferReleaseTests : IClassFixture<TestEventListener>
     [Fact]
     public void ImmutableCacheItem_Reservation()
     {
-        var obj = Assert.IsType<ImmutableCacheItem<string>>(CacheItem<string>.Create(12345, TagSet.Empty));
+        var obj = Assert.IsType<ImmutableCacheItem<string>>(CacheItem<string>.Create(12345, TagSet.Empty, false));
         Assert.True(obj.DebugIsImmutable);
         obj.SetValue("abc", 3);
         Assert.False(obj.TryReserveBuffer(out _));
@@ -258,7 +258,7 @@ public class BufferReleaseTests : IClassFixture<TestEventListener>
     {
         using ServiceProvider services = new ServiceCollection().BuildServiceProvider();
 
-        var obj = Assert.IsType<MutableCacheItem<Customer>>(CacheItem<Customer>.Create(12345, TagSet.Empty));
+        var obj = Assert.IsType<MutableCacheItem<Customer>>(CacheItem<Customer>.Create(12345, TagSet.Empty, false));
 
         Assert.True(new DefaultJsonSerializerFactory(services).TryCreateSerializer<Customer>(out var serializer));
         var target = RecyclableArrayBufferWriter<byte>.Create(int.MaxValue);

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/L2Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/L2Tests.cs
@@ -32,13 +32,13 @@ public class L2Tests(ITestOutputHelper log) : IClassFixture<TestEventListener>
         T IOptions<T>.Value => value;
     }
 
-    private ServiceProvider GetDefaultCache(bool buffers, out DefaultHybridCache cache)
+    private ServiceProvider GetDefaultCache(bool buffers, out DefaultHybridCache cache, bool disableLocalCacheSerialization = false)
     {
         var services = new ServiceCollection();
         var localCacheOptions = new Options<MemoryDistributedCacheOptions>(new());
         var localCache = new MemoryDistributedCache(localCacheOptions);
         services.AddSingleton<IDistributedCache>(buffers ? new BufferLoggingCache(Log, localCache) : new LoggingCache(Log, localCache));
-        services.AddHybridCache();
+        services.AddHybridCache(options => options.DisableLocalCacheSerialization = disableLocalCacheSerialization);
         ServiceProvider provider = services.BuildServiceProvider();
         cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
         return provider;
@@ -153,6 +153,54 @@ public class L2Tests(ITestOutputHelper log) : IClassFixture<TestEventListener>
         var t = await cache.GetOrCreateAsync(Me(), ct => new ValueTask<Foo>(new Foo { Value = CreateString(true) }), _expiry);
         Assert.NotEqual(s.Value, t.Value);
         Assert.Equal(12, backend.OpCount); // GET, SET
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task DisableLocalCacheSerialization_ReturnsSameMutableInstance(bool buffers)
+    {
+        using var provider = GetDefaultCache(buffers, out var cache, disableLocalCacheSerialization: true);
+        var backend = Assert.IsAssignableFrom<LoggingCache>(cache.BackendCache);
+
+        Foo original = await cache.GetOrCreateAsync(Me(), _ => new ValueTask<Foo>(new Foo { Value = "value" }));
+        Foo fromL1 = await cache.GetOrCreateAsync(Me(), _ => new ValueTask<Foo>(new Foo { Value = "unused" }));
+
+        Assert.Same(original, fromL1);
+
+        cache.LocalCache.Remove(Me());
+        Foo fromL2 = await cache.GetOrCreateAsync(Me(), _ => new ValueTask<Foo>(new Foo { Value = "unused" }));
+        Foo fromL1AfterL2 = await cache.GetOrCreateAsync(Me(), _ => new ValueTask<Foo>(new Foo { Value = "unused" }));
+
+        Assert.NotSame(original, fromL2);
+        Assert.Same(fromL2, fromL1AfterL2);
+        Assert.Equal(4, backend.OpCount); // wildcard timestamp GET, GET, SET, GET
+    }
+
+    [Fact]
+    public async Task DisableLocalCacheSerialization_DoesNotSerializeWhenCacheWritesAreDisabled()
+    {
+        var services = new ServiceCollection();
+        services.AddHybridCache(options => options.DisableLocalCacheSerialization = true);
+        services.AddSingleton<IHybridCacheSerializer<Foo>>(new ThrowingFooSerializer());
+        using ServiceProvider provider = services.BuildServiceProvider();
+        HybridCache cache = provider.GetRequiredService<HybridCache>();
+        var value = new Foo { Value = "value" };
+        var options = new HybridCacheEntryOptions
+        {
+            Flags = HybridCacheEntryFlags.DisableLocalCacheWrite | HybridCacheEntryFlags.DisableDistributedCacheWrite,
+        };
+
+        Foo actual = await cache.GetOrCreateAsync(Me(), _ => new ValueTask<Foo>(value), options);
+
+        Assert.Same(value, actual);
+    }
+
+    private sealed class ThrowingFooSerializer : IHybridCacheSerializer<Foo>
+    {
+        public Foo Deserialize(ReadOnlySequence<byte> source) => throw new NotSupportedException();
+
+        public void Serialize(Foo value, IBufferWriter<byte> target) => throw new NotSupportedException();
     }
 
     private class BufferLoggingCache : LoggingCache, IBufferDistributedCache


### PR DESCRIPTION
This add a `DisableLocalCacheSerialization` option to hybrid cache. Partially fixes [#6063](https://github.com/dotnet/extensions/issues/6063)

It enables the hybrid cache to skip serialization when storing or fetching from L1 (in memory) cache. This speeds up the cache when possible, and allows getting the same object instance.

It "partially" fixes the issue because I realized after I started that I couldn't add a flag in here: 
[HybridCacheEntryFlags.cs](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/Hybrid/HybridCacheEntryFlags.cs) since it's in another repo. 

I wanted to get the conversation going again before I spend more time on it, but the better choice in my opinion would be to add a flag for each entry instead of globally like I did in this PR. But thisrequires doing a PR in the runtime repo too.
If this implementation seems good conceptually I will just need guidance into how to create and synchronize the 2 PR required to change both the "extensions" and the "runtime" repo :) 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7641)