### PR TITLE
Rename HttpLatencyTelemetry extensions class and drop redundant TFM guard

### DIFF
--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/HttpLatencyTelemetryServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/HttpLatencyTelemetryServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET8_0_OR_GREATER
-
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Diagnostics.Latency;
 using Microsoft.Shared.DiagnosticIds;
@@ -14,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// Extensions for enriching incoming HTTP request logs with latency telemetry.
 /// </summary>
 [Experimental(diagnosticId: DiagnosticIds.Experiments.HttpLogging, UrlFormat = DiagnosticIds.UrlFormat)]
-public static class HttpLatencyTelemetryExtensions
+public static class HttpLatencyTelemetryServiceCollectionExtensions
 {
     /// <summary>
     /// Adds an enricher that appends latency information from the request's latency context to incoming HTTP request logs.
@@ -34,4 +32,3 @@ public static class HttpLatencyTelemetryExtensions
         return services.AddHttpLogEnricher<HttpLatencyLogEnricher>();
     }
 }
-#endif

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/Internal/HttpLatencyLogEnricher.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/Internal/HttpLatencyLogEnricher.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET8_0_OR_GREATER
-
 using System;
 using System.Text;
 using Microsoft.AspNetCore.Diagnostics.Logging;
@@ -105,4 +103,3 @@ internal sealed class HttpLatencyLogEnricher : IHttpLogEnricher
         }
     }
 }
-#endif

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Microsoft.AspNetCore.Diagnostics.Middleware.json
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Microsoft.AspNetCore.Diagnostics.Middleware.json
@@ -2,11 +2,11 @@
   "Name": "Microsoft.AspNetCore.Diagnostics.Middleware, Version=10.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
   "Types": [
     {
-      "Type": "static class Microsoft.Extensions.DependencyInjection.HttpLatencyTelemetryExtensions",
+      "Type": "static class Microsoft.Extensions.DependencyInjection.HttpLatencyTelemetryServiceCollectionExtensions",
       "Stage": "Experimental",
       "Methods": [
         {
-          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.DependencyInjection.HttpLatencyTelemetryExtensions.AddHttpLatencyTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.DependencyInjection.HttpLatencyTelemetryServiceCollectionExtensions.AddHttpLatencyTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
           "Stage": "Experimental"
         }
       ]

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/HttpLatencyTelemetryServiceCollectionExtensionsTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/HttpLatencyTelemetryServiceCollectionExtensionsTests.cs
@@ -8,13 +8,13 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Diagnostics.Latency.Test;
 
-public class HttpLatencyTelemetryExtensionsTests
+public class HttpLatencyTelemetryServiceCollectionExtensionsTests
 {
     [Fact]
     public void AddHttpLatencyTelemetry_NullArguments_Throws()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            HttpLatencyTelemetryExtensions.AddHttpLatencyTelemetry(null!));
+            HttpLatencyTelemetryServiceCollectionExtensions.AddHttpLatencyTelemetry(null!));
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #7602 addressing post-merge review feedback from @evgenyfedorov2.

- **Rename `HttpLatencyTelemetryExtensions` → `HttpLatencyTelemetryServiceCollectionExtensions`.** Aligns with the `*ServiceCollectionExtensions` naming convention used by sibling extension classes in this library (`RequestLatencyTelemetryServiceCollectionExtensions`, `HttpLoggingServiceCollectionExtensions`, `RequestHeadersEnricherServiceCollectionExtensions`).
- **Remove the `#if NET8_0_OR_GREATER` guard** from `HttpLatencyLogEnricher` and its extensions. The project only targets `net8.0`+ (`NetCoreTargetFrameworks` = net8/net9/net10), so the guard never excluded any target framework — it was dead/misleading.

The type is still `[Experimental]`, so this is not a breaking public API change. API baseline updated accordingly.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7645)