### PR TITLE
Fix MEAI001 leak from experimental RequiresConfirmation in source-generated AIContent contexts

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
@@ -47,7 +47,22 @@ public sealed class ToolApprovalRequestContent : InputRequestContent
     /// tool call can be invoked.
     /// </remarks>
     [Experimental(DiagnosticIds.Experiments.AIApprovalsInvocationRequired, UrlFormat = DiagnosticIds.UrlFormat)]
-    public bool RequiresConfirmation { get; set; } = true;
+    [JsonIgnore]
+    public bool RequiresConfirmation
+    {
+        get => RequiresConfirmationCore;
+        set => RequiresConfirmationCore = value;
+    }
+
+    // Including public, experimental properties leaks them into the source-generated
+    // JSON metadata of any consumer, also forcing that consumer to suppress the
+    // experimental diagnostic. The public property is annotated with [JsonIgnore] and
+    // it routes its value through this internal property. The internal property is
+    // annotated with [JsonInclude] and a [JsonPropertyName] to match the public
+    // property's name, making it available in the default serialization options.
+    [JsonInclude]
+    [JsonPropertyName("requiresConfirmation")]
+    internal bool RequiresConfirmationCore { get; set; } = true;
 
     /// <summary>
     /// Creates a <see cref="ToolApprovalResponseContent"/> indicating whether the tool call is approved or rejected.

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Microsoft.Extensions.AI.Evaluation.Reporting.Azure.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Microsoft.Extensions.AI.Evaluation.Reporting.Azure.csproj
@@ -12,7 +12,6 @@
     <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
     <MinCodeCoverage>n/a</MinCodeCoverage>
     <MinMutationScore>n/a</MinMutationScore>
-    <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Microsoft.Extensions.AI.Evaluation.Reporting.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Microsoft.Extensions.AI.Evaluation.Reporting.csproj
@@ -19,7 +19,6 @@
     <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
     <MinCodeCoverage>n/a</MinCodeCoverage>
     <MinMutationScore>n/a</MinMutationScore>
-    <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Libraries/Microsoft.Extensions.AI.Stabilization.Tests/AIContentSerializationRegressionContext.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Stabilization.Tests/AIContentSerializationRegressionContext.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Extensions.AI;
+
+// Regression guard for https://github.com/dotnet/extensions/issues/7658.
+//
+// A consumer that source-generates a JsonSerializerContext containing List<AIContent> must not be
+// forced to suppress MEAI001. This project treats MEAI001 as an error and applies no experimental
+// suppression (see the csproj), so if any [Experimental] member - such as
+// ToolApprovalRequestContent.RequiresConfirmation - leaks into the source generator's metadata for
+// AIContent's polymorphic graph, this file fails to compile and the build breaks.
+[JsonSerializable(typeof(List<AIContent>))]
+internal sealed partial class AIContentSerializationRegressionContext : JsonSerializerContext;

--- a/test/Libraries/Microsoft.Extensions.AI.Stabilization.Tests/AIContentSerializationRegressionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Stabilization.Tests/AIContentSerializationRegressionTests.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class AIContentSerializationRegressionTests
+{
+    // The real guarantee here is compile-time: AIContentSerializationRegressionContext will not build
+    // if an experimental member leaks into its source-generated metadata. This test exercises the
+    // generated context at runtime to prove it is wired up and that a List<AIContent> round-trips
+    // through it. (The intentional persistence of the experimental RequiresConfirmation member is
+    // covered separately by ToolApprovalRequestContentTests.RequiresConfirmation_RoundtripsThroughJson,
+    // in a project that suppresses MEAI001 and can therefore reference the experimental member directly.)
+    [Fact]
+    public void ListAIContent_RoundtripsThroughSourceGeneratedContext()
+    {
+        List<AIContent> contents =
+        [
+            new TextContent("hello"),
+            new UsageContent(new UsageDetails { InputTokenCount = 1, OutputTokenCount = 2 }),
+        ];
+
+        string json = JsonSerializer.Serialize(contents, AIContentSerializationRegressionContext.Default.ListAIContent);
+        List<AIContent>? roundtripped = JsonSerializer.Deserialize(json, AIContentSerializationRegressionContext.Default.ListAIContent);
+
+        Assert.NotNull(roundtripped);
+        Assert.Equal(2, roundtripped.Count);
+        Assert.IsType<TextContent>(roundtripped[0]);
+        Assert.IsType<UsageContent>(roundtripped[1]);
+    }
+}


### PR DESCRIPTION
Tracks #7658

## Problem

`ToolApprovalRequestContent.RequiresConfirmation` is `[Experimental(MEAI001)]`, while `ToolApprovalRequestContent` is a **stable**, statically registered `[JsonDerivedType]` of the `[JsonPolymorphic]` `AIContent` and `InputRequestContent` hierarchies. This regression was introduced in 10.8.0 by [Add ToolApprovalRequestContent.RequiresConfirmation (#7549)](https://github.com/dotnet/extensions/pull/7549).

As a result, System.Text.Json source generation emits the experimental member into the JSON metadata for any consumer context that reaches `AIContent`, even when the consumer never uses approval APIs:

```csharp
[JsonSerializable(typeof(List<AIContent>))]
internal partial class JsonContext : JsonSerializerContext;
```

The build emits `MEAI001` from source-generated code. Consumers are then forced into a project-wide suppression as the only practical remedy, but the suppression does not remove the member from their generated contract: their externally exposed JSON payloads still include the experimental `requiresConfirmation` field without an approval-feature opt-in.

## Fix

`ToolApprovalRequestContent` is stable; only `RequiresConfirmation` is experimental. Keep the type in the static polymorphic contract, but gate its serialization at the member level using the established pattern used by `UsageDetails` token counts and `HostedFileContent`:

```csharp
[Experimental(...)]
[JsonIgnore]
public bool RequiresConfirmation
{
    get => RequiresConfirmationCore;
    set => RequiresConfirmationCore = value;
}

[JsonInclude]
[JsonPropertyName("requiresConfirmation")]
internal bool RequiresConfirmationCore { get; set; } = true;
```

The internal member remains available to the package-owned default serialization path, so persisted conversations continue to round-trip `requiresConfirmation`. Consumer source-generated contracts omit the experimental field, and direct use of the public property continues to require `MEAI001` opt-in.

The two `Microsoft.Extensions.AI.Evaluation.Reporting` projects had gained `<NoWarn>$(NoWarn);MEAI001</NoWarn>` alongside #7549 solely because of this leak. The fix removes both suppressions; their clean builds demonstrate that they were leak-driven. `Abstractions` and `AI` retain their suppressions because they legitimately use experimental APIs directly.

## Regression coverage

Adds a no-suppression consumer-boundary guard in `Microsoft.Extensions.AI.Stabilization.Tests`:

- `AIContentSerializationRegressionContext.cs` source-generates `List<AIContent>`. Any experimental member leaking into the contract produces `MEAI001` at compile time.
- `AIContentSerializationRegressionTests.cs` confirms stable `List<AIContent>` round-trips through that generated context.
- `ToolApprovalRequestContent` tests verify `RequiresConfirmation` still round-trips as both `true` and `false` through `AIJsonUtilities.DefaultOptions` and `AIContent` polymorphism.

## Validation

- `Microsoft.Extensions.AI.Stabilization.Tests`: 90/90 pass across net472, net8.0, net9.0, and net10.0 without an MEAI001 suppression.
- `Microsoft.Extensions.AI.Abstractions.Tests`: 1634 pass; the intended persistence round-trip remains intact.
- Negative proof: restoring the original public serialized property produces `MEAI001` in the generated `AIContentSerializationRegressionContext.ToolApprovalRequestContent.g.cs` across all four target frameworks.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7659)