### PR TITLE
Prepare 10.8.3 Servicing Release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
   <PropertyGroup Label="Version settings">
     <MajorVersion>10</MajorVersion>
     <MinorVersion>8</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <PatchVersion>3</PatchVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/ToolApprovalRequestContent.cs
@@ -47,7 +47,22 @@ public sealed class ToolApprovalRequestContent : InputRequestContent
     /// tool call can be invoked.
     /// </remarks>
     [Experimental(DiagnosticIds.Experiments.AIApprovalsInvocationRequired, UrlFormat = DiagnosticIds.UrlFormat)]
-    public bool RequiresConfirmation { get; set; } = true;
+    [JsonIgnore]
+    public bool RequiresConfirmation
+    {
+        get => RequiresConfirmationCore;
+        set => RequiresConfirmationCore = value;
+    }
+
+    // Including public, experimental properties leaks them into the source-generated
+    // JSON metadata of any consumer, also forcing that consumer to suppress the
+    // experimental diagnostic. The public property is annotated with [JsonIgnore] and
+    // it routes its value through this internal property. The internal property is
+    // annotated with [JsonInclude] and a [JsonPropertyName] to match the public
+    // property's name, making it available in the default serialization options.
+    [JsonInclude]
+    [JsonPropertyName("requiresConfirmation")]
+    internal bool RequiresConfirmationCore { get; set; } = true;
 
     /// <summary>
     /// Creates a <see cref="ToolApprovalResponseContent"/> indicating whether the tool call is approved or rejected.

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Microsoft.Extensions.AI.Evaluation.Reporting.Azure.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Microsoft.Extensions.AI.Evaluation.Reporting.Azure.csproj
@@ -12,7 +12,6 @@
     <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
     <MinCodeCoverage>n/a</MinCodeCoverage>
     <MinMutationScore>n/a</MinMutationScore>
-    <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Microsoft.Extensions.AI.Evaluation.Reporting.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting/CSharp/Microsoft.Extensions.AI.Evaluation.Reporting.csproj
@@ -19,7 +19,6 @@
     <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
     <MinCodeCoverage>n/a</MinCodeCoverage>
     <MinMutationScore>n/a</MinMutationScore>
-    <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Libraries/Microsoft.Extensions.AI.Stabilization.Tests/AIContentSerializationRegressionContext.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Stabilization.Tests/AIContentSerializationRegressionContext.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Extensions.AI;
+
+// Regression guard for https://github.com/dotnet/extensions/issues/7658.
+//
+// A consumer that source-generates a JsonSerializerContext containing List<AIContent> must not be
+// forced to suppress MEAI001. This project treats MEAI001 as an error and applies no experimental
+// suppression (see the csproj), so if any [Experimental] member - such as
+// ToolApprovalRequestContent.RequiresConfirmation - leaks into the source generator's metadata for
+// AIContent's polymorphic graph, this file fails to compile and the build breaks.
+[JsonSerializable(typeof(List<AIContent>))]
+internal sealed partial class AIContentSerializationRegressionContext : JsonSerializerContext;

--- a/test/Libraries/Microsoft.Extensions.AI.Stabilization.Tests/AIContentSerializationRegressionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Stabilization.Tests/AIContentSerializationRegressionTests.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class AIContentSerializationRegressionTests
+{
+    // The real guarantee here is compile-time: AIContentSerializationRegressionContext will not build
+    // if an experimental member leaks into its source-generated metadata. This test exercises the
+    // generated context at runtime to prove it is wired up and that a List<AIContent> round-trips
+    // through it. (The intentional persistence of the experimental RequiresConfirmation member is
+    // covered separately by ToolApprovalRequestContentTests.RequiresConfirmation_RoundtripsThroughJson,
+    // in a project that suppresses MEAI001 and can therefore reference the experimental member directly.)
+    [Fact]
+    public void ListAIContent_RoundtripsThroughSourceGeneratedContext()
+    {
+        List<AIContent> contents =
+        [
+            new TextContent("hello"),
+            new UsageContent(new UsageDetails { InputTokenCount = 1, OutputTokenCount = 2 }),
+        ];
+
+        string json = JsonSerializer.Serialize(contents, AIContentSerializationRegressionContext.Default.ListAIContent);
+        List<AIContent>? roundtripped = JsonSerializer.Deserialize(json, AIContentSerializationRegressionContext.Default.ListAIContent);
+
+        Assert.NotNull(roundtripped);
+        Assert.Equal(2, roundtripped.Count);
+        Assert.IsType<TextContent>(roundtripped[0]);
+        Assert.IsType<UsageContent>(roundtripped[1]);
+    }
+}


### PR DESCRIPTION
Prepares the 10.8.3 servicing release for the following packages:
- Microsoft.Extensions.AI.Abstractions (10.8.3)
- Microsoft.Extensions.AI (10.8.3)
- Microsoft.Extensions.AI.OpenAI (10.8.3)

## Affected but intentionally excluded from servicing publish scope
- Microsoft.Extensions.AI.Evaluation.Reporting - only MEAI001 suppression cleanup (`<NoWarn>$(NoWarn);MEAI001</NoWarn>` removed)
- Microsoft.Extensions.AI.Evaluation.Reporting.Azure - only MEAI001 suppression cleanup (`<NoWarn>$(NoWarn);MEAI001</NoWarn>` removed)

## Commits included
- Bump version to 10.8.3
- Clean cherry-pick #7659
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7661)