### PR TITLE
Add AI-generated content disclosure guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,11 @@
 
 The .NET Extensions repository contains a suite of libraries providing facilities commonly needed when creating production-ready applications. Major areas include AI abstractions, compliance mechanisms, diagnostics, contextual options, resilience (Polly), telemetry, AspNetCore extensions, static analysis, and testing utilities.
 
+## Committing and Pushing Changes
+
+- Never push to an active pull request unless the user explicitly asks you to.
+- Never chain committing and pushing in the same command. Commit first, report what was committed, and then wait for explicit instructions to push.
+
 ## AI-Generated Content Disclosure
 
 Before posting any content to GitHub under a user's credentials - opening PRs, creating issues, commenting on PRs or issues, posting review comments, or taking any other public-facing action - include a concise, visible note at the bottom indicating that the content was AI/Copilot-generated.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,14 @@
 
 The .NET Extensions repository contains a suite of libraries providing facilities commonly needed when creating production-ready applications. Major areas include AI abstractions, compliance mechanisms, diagnostics, contextual options, resilience (Polly), telemetry, AspNetCore extensions, static analysis, and testing utilities.
 
+## AI-Generated Content Disclosure
+
+Before posting any content to GitHub under a user's credentials - opening PRs, creating issues, commenting on PRs or issues, posting review comments, or taking any other public-facing action - include a concise, visible note at the bottom indicating that the content was AI/Copilot-generated.
+
+Exceptions:
+- The account is a recognized bot or Copilot app account (for example, `github-actions[bot]` or `copilot`), where the AI origin is already apparent from the account identity.
+- The user explicitly asks you to omit the disclosure.
+
 ## Working Effectively
 
 ### Prerequisites and Bootstrap


### PR DESCRIPTION
## Summary

- require a concise AI/Copilot-generated content disclosure for public GitHub actions performed under a user's credentials
- exempt recognized bot/Copilot app accounts and cases where the user explicitly requests omission
- require explicit user instruction before pushing to an active pull request, with committing and pushing kept as separate steps

## Testing

Not run (documentation-only change).

> [!NOTE]
> This pull request description was generated by GitHub Copilot.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7663)