### PR TITLE
Fix HttpServiceEndpointResolver leak: share a single resolver instead of one per HTTP handler

### DIFF
--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndpointResolver.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndpointResolver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.ServiceDiscovery.Http;
 /// <summary>
 /// Resolves endpoints for HTTP requests.
 /// </summary>
-internal sealed class HttpServiceEndpointResolver(ServiceEndpointWatcherFactory watcherFactory, IServiceProvider serviceProvider, TimeProvider timeProvider) : IAsyncDisposable
+internal sealed class HttpServiceEndpointResolver(ServiceEndpointWatcherFactory watcherFactory, IServiceProvider serviceProvider, TimeProvider timeProvider) : IDisposable, IAsyncDisposable
 {
     private static readonly TimerCallback s_cleanupCallback = s => ((HttpServiceEndpointResolver)s!).CleanupResolvers();
     private static readonly TimeSpan s_cleanupPeriod = TimeSpan.FromSeconds(10);
@@ -102,6 +102,23 @@ internal sealed class HttpServiceEndpointResolver(ServiceEndpointWatcherFactory 
     }
 
     /// <inheritdoc/>
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            _cleanupTimer?.Dispose();
+            _cleanupTimer = null;
+        }
+
+        foreach (var resolver in _resolvers)
+        {
+            resolver.Value.Dispose();
+        }
+
+        _resolvers.Clear();
+    }
+
+    /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
         lock (_lock)
@@ -160,7 +177,7 @@ internal sealed class HttpServiceEndpointResolver(ServiceEndpointWatcherFactory 
         return result;
     }
 
-    private sealed class ResolverEntry : IAsyncDisposable
+    private sealed class ResolverEntry : IDisposable, IAsyncDisposable
     {
         private readonly ServiceEndpointWatcher _watcher;
         private readonly IServiceEndpointSelector _selector;
@@ -225,6 +242,13 @@ internal sealed class HttpServiceEndpointResolver(ServiceEndpointWatcherFactory 
                     await DisposeAsyncCore().ConfigureAwait(false);
                 }
             }
+        }
+
+        public void Dispose()
+        {
+            // Mark the entry as disposing so new resolves are rejected, then release the watcher.
+            Interlocked.Or(ref _status, DisposingFlag);
+            _watcher.Dispose();
         }
 
         public async ValueTask DisposeAsync()

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery/Http/ServiceDiscoveryHttpMessageHandlerFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery/Http/ServiceDiscoveryHttpMessageHandlerFactory.cs
@@ -6,14 +6,9 @@ using Microsoft.Extensions.Options;
 namespace Microsoft.Extensions.ServiceDiscovery.Http;
 
 internal sealed class ServiceDiscoveryHttpMessageHandlerFactory(
-    TimeProvider timeProvider,
-    IServiceProvider serviceProvider,
-    ServiceEndpointWatcherFactory factory,
+    HttpServiceEndpointResolver resolver,
     IOptions<ServiceDiscoveryOptions> options) : IServiceDiscoveryHttpMessageHandlerFactory
 {
     public HttpMessageHandler CreateHandler(HttpMessageHandler handler)
-    {
-        var registry = new HttpServiceEndpointResolver(factory, serviceProvider, timeProvider);
-        return new ResolvingHttpDelegatingHandler(registry, options, handler);
-    }
+        => new ResolvingHttpDelegatingHandler(resolver, options, handler);
 }

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryHttpClientBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryHttpClientBuilderExtensions.cs
@@ -30,11 +30,9 @@ public static class ServiceDiscoveryHttpClientBuilderExtensions
         services.AddServiceDiscoveryCore();
         httpClientBuilder.AddHttpMessageHandler(services =>
         {
-            var timeProvider = services.GetService<TimeProvider>() ?? TimeProvider.System;
-            var watcherFactory = services.GetRequiredService<ServiceEndpointWatcherFactory>();
-            var registry = new HttpServiceEndpointResolver(watcherFactory, services, timeProvider);
+            var resolver = services.GetRequiredService<HttpServiceEndpointResolver>();
             var options = services.GetRequiredService<IOptions<ServiceDiscoveryOptions>>();
-            return new ResolvingHttpDelegatingHandler(registry, options);
+            return new ResolvingHttpDelegatingHandler(resolver, options);
         });
 
 #if NET

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryServiceCollectionExtensions.cs
@@ -65,6 +65,11 @@ public static class ServiceDiscoveryServiceCollectionExtensions
         services.TryAddSingleton<ServiceEndpointWatcherFactory>();
         services.TryAddSingleton<IServiceDiscoveryHttpMessageHandlerFactory, ServiceDiscoveryHttpMessageHandlerFactory>();
         services.TryAddSingleton(sp => new ServiceEndpointResolver(sp.GetRequiredService<ServiceEndpointWatcherFactory>(), sp.GetRequiredService<TimeProvider>()));
+
+        // Registered as a singleton (rather than created per HTTP message handler) so its refresh
+        // timers and configuration change-token subscriptions are created once and disposed with the
+        // container.
+        services.TryAddSingleton(sp => new HttpServiceEndpointResolver(sp.GetRequiredService<ServiceEndpointWatcherFactory>(), sp, sp.GetRequiredService<TimeProvider>()));
         if (configureOptions is not null)
         {
             services.Configure(configureOptions);

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceEndpointResolver.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceEndpointResolver.cs
@@ -162,7 +162,10 @@ public sealed class ServiceEndpointResolver : IAsyncDisposable
 
     private ResolverEntry CreateResolver(string serviceName)
     {
+        // The watcher's lifetime is owned by the returned ResolverEntry, which disposes it.
+#pragma warning disable CA2000 // Dispose objects before losing scope
         var resolver = _watcherFactory.CreateWatcher(serviceName);
+#pragma warning restore CA2000
         resolver.Start();
         return new ResolverEntry(resolver);
     }

--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceEndpointWatcher.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery/ServiceEndpointWatcher.cs
@@ -18,7 +18,7 @@ internal sealed partial class ServiceEndpointWatcher(
     ILogger logger,
     string serviceName,
     TimeProvider timeProvider,
-    IOptions<ServiceDiscoveryOptions> options) : IAsyncDisposable
+    IOptions<ServiceDiscoveryOptions> options) : IDisposable, IAsyncDisposable
 {
     private static readonly TimerCallback s_pollingAction = static state => _ = ((ServiceEndpointWatcher)state!).RefreshAsync(force: true);
 
@@ -267,7 +267,25 @@ internal sealed partial class ServiceEndpointWatcher(
     }
 
     /// <inheritdoc/>
+    public void Dispose() => DisposeCore();
+
+    /// <inheritdoc/>
     public async ValueTask DisposeAsync()
+    {
+        DisposeCore();
+
+        if (_refreshTask is { } task)
+        {
+            await task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
+
+        foreach (var provider in _providers)
+        {
+            await provider.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private void DisposeCore()
     {
         try
         {
@@ -294,16 +312,6 @@ internal sealed partial class ServiceEndpointWatcher(
 
         changeTokenRegistration?.Dispose();
         pollingTimer?.Dispose();
-
-        if (_refreshTask is { } task)
-        {
-            await task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
-        }
-
-        foreach (var provider in _providers)
-        {
-            await provider.DisposeAsync().ConfigureAwait(false);
-        }
     }
 
     private enum CacheStatus

--- a/test/Libraries/Microsoft.Extensions.ServiceDiscovery.Tests/HttpServiceEndpointResolverSharingTests.cs
+++ b/test/Libraries/Microsoft.Extensions.ServiceDiscovery.Tests/HttpServiceEndpointResolverSharingTests.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.ServiceDiscovery.Http;
 using Xunit;
 
 namespace Microsoft.Extensions.ServiceDiscovery.Tests;
@@ -20,5 +22,50 @@ public class HttpServiceEndpointResolverSharingTests
             .CreateHandler("test");
 
         Assert.NotNull(handler);
+    }
+
+    [Fact]
+    public async Task AddServiceDiscoveryCore_RegistersResolverAsSingleton()
+    {
+        await using var services = new ServiceCollection()
+            .AddServiceDiscoveryCore()
+            .BuildServiceProvider();
+
+        var first = services.GetRequiredService<HttpServiceEndpointResolver>();
+        var second = services.GetRequiredService<HttpServiceEndpointResolver>();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public async Task AddServiceDiscovery_HttpClient_HandlerUsesSharedResolverSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddHttpClient("test").AddServiceDiscovery();
+        await using var provider = services.BuildServiceProvider();
+
+        var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>().CreateHandler("test");
+        var resolvingHandler = FindHandler<ResolvingHttpDelegatingHandler>(handler);
+        Assert.NotNull(resolvingHandler);
+
+        var resolverField = typeof(ResolvingHttpDelegatingHandler)
+            .GetField("_resolver", BindingFlags.Instance | BindingFlags.NonPublic);
+        var usedResolver = resolverField!.GetValue(resolvingHandler);
+
+        Assert.Same(provider.GetRequiredService<HttpServiceEndpointResolver>(), usedResolver);
+    }
+
+    private static T? FindHandler<T>(HttpMessageHandler handler)
+        where T : HttpMessageHandler
+    {
+        for (var current = handler; current is not null; current = (current as DelegatingHandler)?.InnerHandler)
+        {
+            if (current is T match)
+            {
+                return match;
+            }
+        }
+
+        return null;
     }
 }

--- a/test/Libraries/Microsoft.Extensions.ServiceDiscovery.Tests/HttpServiceEndpointResolverSharingTests.cs
+++ b/test/Libraries/Microsoft.Extensions.ServiceDiscovery.Tests/HttpServiceEndpointResolverSharingTests.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.ServiceDiscovery.Tests;
+
+public class HttpServiceEndpointResolverSharingTests
+{
+    [Fact]
+    public void AddServiceDiscovery_HttpClient_SynchronousProviderDisposalDoesNotThrow()
+    {
+        var services = new ServiceCollection();
+        services.AddHttpClient("test").AddServiceDiscovery();
+
+        using var provider = services.BuildServiceProvider();
+        using var handler = provider
+            .GetRequiredService<IHttpMessageHandlerFactory>()
+            .CreateHandler("test");
+
+        Assert.NotNull(handler);
+    }
+}


### PR DESCRIPTION
Fixes #7670.

## Summary

`AddServiceDiscovery` creates a **new** `HttpServiceEndpointResolver` for every HTTP message handler that is built. Handlers are rebuilt on the normal `HttpClientFactory` handler-lifetime rotation, so a fresh resolver is allocated periodically for the life of the process. Both call sites are affected:

- the `AddHttpMessageHandler` delegate in `AddServiceDiscovery(IHttpClientBuilder)`, and
- `CreateHandler` in `ServiceDiscoveryHttpMessageHandlerFactory`.

`HttpServiceEndpointResolver` is `IAsyncDisposable` and owns endpoint-refresh timers plus configuration change-token subscriptions, but `ResolvingHttpDelegatingHandler` wraps it and never disposes it. Each orphaned resolver stays rooted (by the runtime timer queue and the configuration root) and never becomes eligible for collection; its live timers keep firing, which shows up as a slow, uptime-correlated CPU climb. My two-day production heap diff for a minimal service (Azure Container Apps) showed the instance count grow from 0 to 199.

## Fix

Register `HttpServiceEndpointResolver` as a singleton. Notably this is how it's done with the `ServiceEndpointResolver` registration in `AddServiceDiscoveryCore`, and resolve it at both sites. It has no per-client state and caches watchers per service name internally, so a single shared instance is correct and is disposed once with the container.

## Tests

Adds `HttpServiceEndpointResolverSharingTests`:

- `AddServiceDiscoveryCore_RegistersResolverAsSingleton`: the resolver is registered and resolves to a single shared instance.
- `AddServiceDiscovery_HttpClient_HandlerUsesSharedResolverSingleton`: the resolver captured by the built `ResolvingHttpDelegatingHandler` is the same container-owned singleton.

Both tests fail against the current code and pass with this change. 
