### PR TITLE
Add CCKR adaptive log reservoir sampler to Microsoft.Extensions.Telem…

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/Admission.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/Admission.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Extensions.Diagnostics.Sampling;
+
+/// <summary>
+/// The result of an admission attempt. For an <see cref="AdmissionKind.Admit"/> outcome it also
+/// carries the EXP rank that must be handed back verbatim to
+/// <see cref="ILogSampler{TCallsite, TPayload}.Insert"/> so the sampler can order its heap.
+/// </summary>
+internal readonly struct Admission : IEquatable<Admission>
+{
+    private Admission(AdmissionKind kind, double key)
+    {
+        Kind = kind;
+        Key = key;
+    }
+
+    /// <summary>
+    /// Gets a shared <see cref="AdmissionKind.Skip"/> admission.
+    /// </summary>
+    public static Admission Skip { get; } = new(AdmissionKind.Skip, double.NaN);
+
+    /// <summary>
+    /// Gets a shared <see cref="AdmissionKind.Preserve"/> admission.
+    /// </summary>
+    public static Admission Preserve { get; } = new(AdmissionKind.Preserve, double.NaN);
+
+    /// <summary>
+    /// Gets the admission category.
+    /// </summary>
+    public AdmissionKind Kind { get; }
+
+    /// <summary>
+    /// Gets the EXP rank <c>-ln(u) / w_c</c> used for bottom-K heap ordering. Only meaningful when
+    /// <see cref="Kind"/> is <see cref="AdmissionKind.Admit"/>; otherwise <see cref="double.NaN"/>.
+    /// </summary>
+    public double Key { get; }
+
+    public static bool operator ==(Admission left, Admission right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(Admission left, Admission right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="AdmissionKind.Admit"/> admission carrying its EXP rank.
+    /// </summary>
+    /// <param name="key">The EXP rank <c>-ln(u) / w_c</c> for heap ordering.</param>
+    /// <returns>An admit admission.</returns>
+    public static Admission Admit(double key) => new(AdmissionKind.Admit, key);
+
+    /// <inheritdoc/>
+    public bool Equals(Admission other) => Kind == other.Kind && Key.Equals(other.Key);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is Admission other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => (Kind, Key).GetHashCode();
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/AdmissionKind.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/AdmissionKind.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Diagnostics.Sampling;
+
+/// <summary>
+/// The category of an <see cref="ILogSampler{TCallsite, TPayload}.Admit(TCallsite)"/> decision.
+/// </summary>
+internal enum AdmissionKind
+{
+    /// <summary>
+    /// The event must be dropped. The caller must not format the log record; this is the fast path
+    /// that yields the CPU and allocation savings.
+    /// </summary>
+    Skip,
+
+    /// <summary>
+    /// The event was admitted into the statistical (bottom-K) sample. The caller must format the
+    /// payload and call <see cref="ILogSampler{TCallsite, TPayload}.Insert"/> with the admission.
+    /// </summary>
+    Admit,
+
+    /// <summary>
+    /// The event was rejected by the statistical sample but accepted by the bounded novelty preserve
+    /// as a weight-0 observational record. The caller must format the payload and call
+    /// <see cref="ILogSampler{TCallsite, TPayload}.Insert"/> with the admission.
+    /// </summary>
+    Preserve,
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/Cckr.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/Cckr.cs
@@ -1,0 +1,426 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.Diagnostics.Sampling;
+
+#pragma warning disable CA5394 // Do not use insecure randomness - acceptable for the purposes of sampling
+
+/// <summary>
+/// CCKR — the Chao-Cohen-Kaplan-Reservoir adaptive log sampler.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CCKR is a bottom-(K+1) weighted reservoir sketch with exponential ranks (a WS-sketch, Cohen &amp;
+/// Kaplan 2007, built on the priority sampling of Duffield, Lund &amp; Thorup 2007). Across periods it
+/// feeds the previous period's per-callsite arrival counts back as inverse-frequency weights, so
+/// chatty callsites are sampled hard while rare ones are kept. A Chao1 / Good-Turing estimate (Chao
+/// 1984) weights as-yet-unseen callsites, and a bounded novelty preserve keeps one example of each
+/// first-rejected callsite as a weight-0 observational record for tail coverage.
+/// </para>
+/// <para>
+/// The type is single-threaded by design: use one instance per thread. The <see cref="Admit"/> fast
+/// path avoids formatting the payload for dropped events, which is the source of the CPU and
+/// allocation savings.
+/// </para>
+/// </remarks>
+/// <typeparam name="TCallsite">The callsite identifier type (in production, the durable ID).</typeparam>
+/// <typeparam name="TPayload">The formatted log payload type.</typeparam>
+internal sealed class Cckr<TCallsite, TPayload> : ILogSampler<TCallsite, TPayload>
+    where TCallsite : notnull
+{
+    private const long DefaultMinPeriodCount = 32;
+
+    private readonly int _reservoirCapacity;
+    private readonly int _preserveCapacity;
+    private readonly long _minPeriodCount;
+    private readonly UnseenWeightMode _unseenWeightMode;
+    private readonly Random _rng;
+    private readonly List<HeapEntry> _heap;
+    private readonly Dictionary<TCallsite, CallsiteState> _states;
+
+    private Dictionary<TCallsite, long> _freqPrev;
+    private Dictionary<TCallsite, long> _freqCurr;
+    private long _seqCounter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cckr{TCallsite, TPayload}"/> class using the
+    /// default preserve capacity (equal to <paramref name="reservoirCapacity"/>), the default Chao1
+    /// stability threshold, <see cref="UnseenWeightMode.Chao1"/>, and an OS-derived seed.
+    /// </summary>
+    /// <param name="reservoirCapacity">The sample size <c>T</c> per period. Must be at least 1.</param>
+    public Cckr(int reservoirCapacity)
+        : this(reservoirCapacity, reservoirCapacity, DefaultMinPeriodCount, UnseenWeightMode.Chao1, null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cckr{TCallsite, TPayload}"/> class with explicit
+    /// configuration.
+    /// </summary>
+    /// <param name="reservoirCapacity">The sample size <c>T</c> per period. Must be at least 1.</param>
+    /// <param name="preserveCapacity">The novelty-preserve capacity <c>R</c> (<c>0</c> disables the preserve). Must not be negative.</param>
+    /// <param name="minPeriodCount">The minimum prior-period arrival count below which the frozen table is discarded and the next period is treated as warmup. Must not be negative.</param>
+    /// <param name="unseenWeightMode">The strategy used to weight unseen callsites.</param>
+    /// <param name="seed">An optional RNG seed for deterministic behavior; <see langword="null"/> uses an OS-derived seed.</param>
+    public Cckr(int reservoirCapacity, int preserveCapacity, long minPeriodCount, UnseenWeightMode unseenWeightMode, int? seed)
+    {
+        _reservoirCapacity = Throw.IfLessThan(reservoirCapacity, 1);
+        _preserveCapacity = Throw.IfLessThan(preserveCapacity, 0);
+        _minPeriodCount = Throw.IfLessThan(minPeriodCount, 0);
+        _unseenWeightMode = unseenWeightMode;
+        _rng = seed.HasValue ? new Random(seed.Value) : new Random();
+        _heap = new List<HeapEntry>(reservoirCapacity + 1);
+        _states = new Dictionary<TCallsite, CallsiteState>(reservoirCapacity + preserveCapacity);
+        _freqPrev = new Dictionary<TCallsite, long>(reservoirCapacity);
+        _freqCurr = new Dictionary<TCallsite, long>(reservoirCapacity);
+        _seqCounter = 0;
+        ReserveLength = 0;
+        Tau = double.PositiveInfinity;
+
+        // Until the first flush every callsite is "unseen" with weight 1.0, i.e. we behave as a
+        // uniform reservoir.
+        UnseenWeight = 1.0;
+    }
+
+    /// <summary>
+    /// Gets the current threshold <c>tau</c>. Decreases monotonically within a period and resets to
+    /// <see cref="double.PositiveInfinity"/> at flush. Exposed for tests and metrics.
+    /// </summary>
+    public double Tau { get; private set; }
+
+    /// <summary>
+    /// Gets the current unseen-callsite weight, frozen at the last flush. Exposed for tests and metrics.
+    /// </summary>
+    public double UnseenWeight { get; private set; }
+
+    /// <summary>
+    /// Gets the number of callsites in the prior-period frozen table.
+    /// </summary>
+    public int FrozenCallsites => _freqPrev.Count;
+
+    /// <summary>
+    /// Gets the current novelty-preserve occupancy.
+    /// </summary>
+    public int ReserveLength { get; private set; }
+
+    /// <inheritdoc/>
+    public Admission Admit(TCallsite callsite)
+    {
+        // Always count arrivals for the next period's frozen table, even when skipped.
+        _freqCurr[callsite] = _freqCurr.TryGetValue(callsite, out var current) ? current + 1 : 1;
+
+        double wC = WeightFor(_freqPrev, callsite, UnseenWeight);
+        double u = _rng.NextDouble();
+        if (u <= 0.0)
+        {
+            u = 1e-300;
+        }
+
+        // EXP rank: -ln(U(0,1]) / w ~ Exp(w). See Cohen & Kaplan for the rank-function family.
+        double k = -Math.Log(u) / wC;
+
+        if (k < Tau)
+        {
+            return Admission.Admit(k);
+        }
+
+        // K-rejected. Consider the novelty preserve. Skip when the callsite is already represented
+        // anywhere in the state map (heap presence would violate disjointness; preserve presence is
+        // the first-rejection-wins rule).
+        if (ReserveLength < _preserveCapacity && !_states.ContainsKey(callsite))
+        {
+            return Admission.Preserve;
+        }
+
+        return Admission.Skip;
+    }
+
+    /// <inheritdoc/>
+    public void Insert(TCallsite callsite, Admission admission, TPayload payload)
+    {
+        switch (admission.Kind)
+        {
+            case AdmissionKind.Admit:
+                InsertAdmit(callsite, admission.Key, payload);
+                break;
+
+            case AdmissionKind.Preserve:
+                InsertPreserve(callsite, payload);
+                break;
+
+            default:
+                // Skip admissions must never reach Insert.
+                Throw.ArgumentException(nameof(admission), "Insert must not be called for a Skip admission.");
+                break;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void FlushInto(ICollection<SampledRecord<TCallsite, TPayload>> output)
+    {
+        _ = Throw.IfNull(output);
+
+        double finalTau = Tau;
+
+        // (1) Drain the bottom-T heap with Horvitz-Thompson weights.
+        foreach (var entry in _heap)
+        {
+            double wC = WeightFor(_freqPrev, entry.Callsite, UnseenWeight);
+            double samplingCount;
+            if (double.IsInfinity(finalTau))
+            {
+                samplingCount = 1.0;
+            }
+            else
+            {
+                // EXP-rank inclusion probability: pi = 1 - exp(-tau * w_c).
+                double pi = -Expm1(-finalTau * wC);
+                samplingCount = pi > 0.0 ? Math.Max(1.0, 1.0 / pi) : 1.0;
+            }
+
+            output.Add(new SampledRecord<TCallsite, TPayload>(entry.Callsite, entry.Payload, samplingCount));
+        }
+
+        _heap.Clear();
+
+        // (2) Drain the preserve slots as weight-0 observational novelty records. Heap entries were
+        // already emitted above, and the heap/preserve disjointness invariant guarantees these
+        // callsites are not double-counted.
+        foreach (var pair in _states)
+        {
+            if (pair.Value.Preserve is { } preserve)
+            {
+                output.Add(new SampledRecord<TCallsite, TPayload>(pair.Key, preserve.Payload, 0.0));
+            }
+        }
+
+        _states.Clear();
+        ReserveLength = 0;
+
+        // (3) Period-boundary bookkeeping.
+        long observed = 0;
+        foreach (var value in _freqCurr.Values)
+        {
+            observed += value;
+        }
+
+        if (observed < _minPeriodCount)
+        {
+            _freqPrev.Clear();
+            UnseenWeight = 1.0;
+        }
+        else
+        {
+            UnseenWeight = ComputeUnseenWeight();
+            (_freqPrev, _freqCurr) = (_freqCurr, _freqPrev);
+        }
+
+        _freqCurr.Clear();
+        Tau = double.PositiveInfinity;
+    }
+
+    /// <inheritdoc/>
+    public List<SampledRecord<TCallsite, TPayload>> Flush()
+    {
+        var output = new List<SampledRecord<TCallsite, TPayload>>(_heap.Count + ReserveLength);
+        FlushInto(output);
+        return output;
+    }
+
+    private static double WeightFor(Dictionary<TCallsite, long> freqPrev, TCallsite callsite, double unseenWeight)
+        => freqPrev.TryGetValue(callsite, out var frequency) ? 1.0 / frequency : unseenWeight;
+
+    /// <summary>
+    /// A netstandard2.0-safe <c>exp(x) - 1</c> that stays accurate near zero, where the inclusion
+    /// probability would otherwise suffer catastrophic cancellation.
+    /// </summary>
+    /// <param name="x">The exponent.</param>
+    /// <returns><c>exp(x) - 1</c>.</returns>
+    private static double Expm1(double x)
+    {
+        if (Math.Abs(x) < 1e-5)
+        {
+            // Two-term Taylor series; the truncation error is O(x^3) which is negligible here.
+            return x + (0.5 * x * x);
+        }
+
+        return Math.Exp(x) - 1.0;
+    }
+
+    private void InsertAdmit(TCallsite callsite, double key, TPayload payload)
+    {
+        if (!_states.TryGetValue(callsite, out var state))
+        {
+            state = new CallsiteState();
+            _states[callsite] = state;
+        }
+
+        // A heap admission supplants any pre-existing preserve slot for this callsite.
+        if (state.Preserve.HasValue)
+        {
+            state.Preserve = null;
+            ReserveLength--;
+        }
+
+        state.HeapCount++;
+        HeapPush(new HeapEntry(key, callsite, payload));
+
+        if (_heap.Count > _reservoirCapacity)
+        {
+            HeapEntry evicted = HeapPopMax();
+
+            // The evicted entry may be the one just pushed (when its key is the new maximum), in which
+            // case the increment and decrement cancel.
+            if (_states.TryGetValue(evicted.Callsite, out var evictedState))
+            {
+                evictedState.HeapCount--;
+                if (evictedState.IsEmpty)
+                {
+                    _ = _states.Remove(evicted.Callsite);
+                }
+            }
+
+            // The (T+1)-th smallest rank is gone; the new root is the largest of the remaining T
+            // smallest, which is the new threshold.
+            Tau = _heap[0].Key;
+        }
+    }
+
+    private void InsertPreserve(TCallsite callsite, TPayload payload)
+    {
+        long seq = _seqCounter;
+        _seqCounter++;
+
+        // Only create the preserve slot when the callsite has no current heap or preserve entry: heap
+        // presence wins by disjointness, preserve presence by first-rejection-wins.
+        if (!_states.ContainsKey(callsite))
+        {
+            _states[callsite] = new CallsiteState { Preserve = (payload, seq) };
+            ReserveLength++;
+        }
+    }
+
+    private double ComputeUnseenWeight()
+    {
+        if (_unseenWeightMode == UnseenWeightMode.RarestSeen)
+        {
+            // The rarest seen callsite has the smallest frequency, hence the largest weight.
+            long minFrequency = 0;
+            foreach (var value in _freqCurr.Values)
+            {
+                if (value > 0 && (minFrequency == 0 || value < minFrequency))
+                {
+                    minFrequency = value;
+                }
+            }
+
+            if (minFrequency == 0)
+            {
+                return 1.0;
+            }
+
+            double weight = 1.0 / minFrequency;
+            return weight < 1.0 ? weight : 1.0;
+        }
+
+        return ChaoEstimator.Chao1UnseenWeight(_freqCurr.Values);
+    }
+
+    private void HeapPush(HeapEntry entry)
+    {
+        _heap.Add(entry);
+        int i = _heap.Count - 1;
+        while (i > 0)
+        {
+            int parent = (i - 1) / 2;
+            if (_heap[parent].Key >= _heap[i].Key)
+            {
+                break;
+            }
+
+            (_heap[parent], _heap[i]) = (_heap[i], _heap[parent]);
+            i = parent;
+        }
+    }
+
+    private HeapEntry HeapPopMax()
+    {
+        HeapEntry root = _heap[0];
+        int last = _heap.Count - 1;
+        _heap[0] = _heap[last];
+        _heap.RemoveAt(last);
+        if (_heap.Count > 0)
+        {
+            SiftDown(0);
+        }
+
+        return root;
+    }
+
+    private void SiftDown(int start)
+    {
+        int i = start;
+        int count = _heap.Count;
+        while (true)
+        {
+            int left = (2 * i) + 1;
+            int right = (2 * i) + 2;
+            int largest = i;
+
+            if (left < count && _heap[left].Key > _heap[largest].Key)
+            {
+                largest = left;
+            }
+
+            if (right < count && _heap[right].Key > _heap[largest].Key)
+            {
+                largest = right;
+            }
+
+            if (largest == i)
+            {
+                break;
+            }
+
+            (_heap[i], _heap[largest]) = (_heap[largest], _heap[i]);
+            i = largest;
+        }
+    }
+
+    /// <summary>
+    /// One heap entry. <see cref="Key"/> is the EXP rank; the containing list is maintained as a
+    /// max-heap so its root is the current threshold <c>tau</c>.
+    /// </summary>
+    private readonly struct HeapEntry
+    {
+        public HeapEntry(double key, TCallsite callsite, TPayload payload)
+        {
+            Key = key;
+            Callsite = callsite;
+            Payload = payload;
+        }
+
+        public double Key { get; }
+
+        public TCallsite Callsite { get; }
+
+        public TPayload Payload { get; }
+    }
+
+    /// <summary>
+    /// Per-callsite live state: reservoir multiplicity plus an optional novelty-preserve slot. The two
+    /// are mutually exclusive.
+    /// </summary>
+    private sealed class CallsiteState
+    {
+        public uint HeapCount { get; set; }
+
+        public (TPayload Payload, long Seq)? Preserve { get; set; }
+
+        public bool IsEmpty => HeapCount == 0 && !Preserve.HasValue;
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/CckrLogBuffer.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/CckrLogBuffer.cs
@@ -1,0 +1,238 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#if NET9_0_OR_GREATER
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.Diagnostics.Buffering;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.Diagnostics.Sampling;
+
+/// <summary>
+/// A <see cref="LogBuffer"/> implementation backed by the CCKR adaptive reservoir. It plugs into the
+/// existing logging pipeline through the standard buffer seam: <see cref="TryEnqueue"/> holds an
+/// admitted record in a per-category reservoir instead of writing it, and <see cref="Flush"/> emits
+/// the period's kept records &#8212; each carrying its Horvitz-Thompson <c>sampling.count</c> weight
+/// &#8212; through the same <see cref="IBufferedLogger"/> callback the global buffer uses.
+/// </summary>
+/// <remarks>
+/// The paired <see cref="CckrLoggingSampler"/> makes the admission decision at the
+/// <see cref="LoggingSampler"/> seam and stashes the result for this thread; <see cref="TryEnqueue"/>
+/// reuses it so the reservoir is consulted once per record. When used without that sampler,
+/// <see cref="TryEnqueue"/> makes the admission decision itself.
+/// </remarks>
+internal sealed class CckrLogBuffer : LogBuffer, IDisposable
+{
+    private readonly ConcurrentDictionary<string, CategoryReservoir> _categories = new(StringComparer.Ordinal);
+    private readonly ReservoirSamplingConfig _config;
+    private readonly TimeProvider _timeProvider;
+    private readonly ThreadLocal<PendingAdmission> _pending = new();
+    private readonly object _flushClock = new();
+
+    private DateTimeOffset _nextFlush;
+
+    public CckrLogBuffer(ReservoirSamplingConfig config, TimeProvider timeProvider)
+    {
+        _config = config;
+        _timeProvider = timeProvider;
+        _nextFlush = timeProvider.GetUtcNow() + config.FlushInterval;
+    }
+
+    /// <summary>
+    /// Makes and records this thread's admission decision for a callsite. Called from the paired
+    /// <see cref="CckrLoggingSampler"/> at the sampling seam, before <see cref="TryEnqueue"/>.
+    /// </summary>
+    /// <returns><see langword="true"/> if the record should be processed and held; otherwise <see langword="false"/>.</returns>
+    public bool Admit(string category, EventId eventId)
+    {
+        CategoryReservoir reservoir = GetCategory(category);
+        Admission admission = reservoir.Admit(eventId);
+        _pending.Value = new PendingAdmission(category, eventId.Id, admission);
+        return admission.Kind != AdmissionKind.Skip;
+    }
+
+    /// <inheritdoc/>
+    public override bool TryEnqueue<TState>(IBufferedLogger bufferedLogger, in LogEntry<TState> logEntry)
+    {
+        string category = logEntry.Category;
+        CategoryReservoir reservoir = GetCategory(category);
+
+        // Reuse the admission computed by the paired sampler on this thread; otherwise decide now.
+        Admission admission;
+        PendingAdmission pending = _pending.Value;
+        if (pending.HasValue && pending.EventId == logEntry.EventId.Id && string.Equals(pending.Category, category, StringComparison.Ordinal))
+        {
+            admission = pending.Admission;
+            _pending.Value = default;
+        }
+        else
+        {
+            admission = reservoir.Admit(logEntry.EventId);
+        }
+
+        if (admission.Kind == AdmissionKind.Skip)
+        {
+            // Consumed by the reservoir (counted) but not kept: drop without writing.
+            MaybeFlush();
+            return true;
+        }
+
+        IReadOnlyList<KeyValuePair<string, object?>>? attributes = logEntry.State as IReadOnlyList<KeyValuePair<string, object?>>;
+        if (attributes is null)
+        {
+            Throw.InvalidOperationException(
+                $"Unsupported type of log state detected: {typeof(TState)}, expected IReadOnlyList<KeyValuePair<string, object?>>");
+        }
+
+        SerializedLogRecord record = SerializedLogRecordFactory.Create(
+            logEntry.LogLevel,
+            logEntry.EventId,
+            _timeProvider.GetUtcNow(),
+            attributes,
+            logEntry.Exception,
+            logEntry.Formatter(logEntry.State, logEntry.Exception));
+
+        reservoir.Insert(bufferedLogger, logEntry.EventId, admission, record);
+
+        MaybeFlush();
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override void Flush()
+    {
+        foreach (CategoryReservoir reservoir in _categories.Values)
+        {
+            reservoir.Flush();
+        }
+
+        lock (_flushClock)
+        {
+            _nextFlush = _timeProvider.GetUtcNow() + _config.FlushInterval;
+        }
+    }
+
+    public void Dispose() => _pending.Dispose();
+
+    private CategoryReservoir GetCategory(string category)
+        => _categories.GetOrAdd(category, static (_, cfg) => new CategoryReservoir(cfg), _config);
+
+    private void MaybeFlush()
+    {
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+        lock (_flushClock)
+        {
+            if (now < _nextFlush)
+            {
+                return;
+            }
+
+            _nextFlush = now + _config.FlushInterval;
+        }
+
+        foreach (CategoryReservoir reservoir in _categories.Values)
+        {
+            reservoir.Flush();
+        }
+    }
+
+    /// <summary>
+    /// This thread's admission decision, carried from the sampler seam to <see cref="TryEnqueue"/>.
+    /// </summary>
+    private readonly struct PendingAdmission
+    {
+        public PendingAdmission(string category, int eventId, Admission admission)
+        {
+            Category = category;
+            EventId = eventId;
+            Admission = admission;
+        }
+
+        public bool HasValue => Category is not null;
+
+        public string? Category { get; }
+
+        public int EventId { get; }
+
+        public Admission Admission { get; }
+    }
+
+    /// <summary>
+    /// One category's reservoir plus the buffered-logger callback used to emit its flushed records.
+    /// </summary>
+    private sealed class CategoryReservoir
+    {
+        private readonly Cckr<int, SerializedLogRecord> _reservoir;
+        private readonly object _lock = new();
+        private IBufferedLogger? _bufferedLogger;
+
+        public CategoryReservoir(ReservoirSamplingConfig config)
+        {
+            _reservoir = new Cckr<int, SerializedLogRecord>(
+                config.Capacity,
+                config.PreserveCapacity,
+                config.MinPeriodCount,
+                config.UnseenWeightMode,
+                seed: null);
+        }
+
+        public Admission Admit(EventId eventId)
+        {
+            lock (_lock)
+            {
+                return _reservoir.Admit(eventId.Id);
+            }
+        }
+
+        public void Insert(IBufferedLogger bufferedLogger, EventId eventId, Admission admission, SerializedLogRecord record)
+        {
+            lock (_lock)
+            {
+                _bufferedLogger = bufferedLogger;
+                _reservoir.Insert(eventId.Id, admission, record);
+            }
+        }
+
+        public void Flush()
+        {
+            List<SampledRecord<int, SerializedLogRecord>> drained;
+            IBufferedLogger? bufferedLogger;
+            lock (_lock)
+            {
+                bufferedLogger = _bufferedLogger;
+                drained = _reservoir.Flush();
+            }
+
+            if (bufferedLogger is null || drained.Count == 0)
+            {
+                return;
+            }
+
+            var records = new List<BufferedLogRecord>(drained.Count);
+            foreach (SampledRecord<int, SerializedLogRecord> sampled in drained)
+            {
+                SerializedLogRecord serialized = sampled.Payload;
+
+                var attributes = new List<KeyValuePair<string, object?>>(serialized.Attributes.Count + 1);
+                attributes.AddRange(serialized.Attributes);
+                attributes.Add(new KeyValuePair<string, object?>("sampling.count", sampled.SamplingCount));
+
+                records.Add(new DeserializedLogRecord(
+                    serialized.Timestamp,
+                    serialized.LogLevel,
+                    serialized.EventId,
+                    serialized.Exception,
+                    serialized.FormattedMessage,
+                    attributes));
+            }
+
+            bufferedLogger.LogRecords(records);
+        }
+    }
+}
+#endif

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/CckrLoggingSampler.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/CckrLoggingSampler.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#if NET9_0_OR_GREATER
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.Diagnostics.Sampling;
+
+/// <summary>
+/// A <see cref="LoggingSampler"/> that makes the CCKR admission decision at the sampling seam &#8212;
+/// dropping records the reservoir rejects before they are buffered &#8212; and shares its reservoir
+/// with the paired <see cref="CckrLogBuffer"/>, which holds the admitted records and emits them,
+/// weighted, at each flush.
+/// </summary>
+internal sealed class CckrLoggingSampler : LoggingSampler
+{
+    private readonly CckrLogBuffer _buffer;
+
+    public CckrLoggingSampler(CckrLogBuffer buffer)
+    {
+        _buffer = Throw.IfNull(buffer);
+    }
+
+    /// <inheritdoc/>
+    public override bool ShouldSample<TState>(in LogEntry<TState> logEntry)
+        => _buffer.Admit(logEntry.Category, logEntry.EventId);
+}
+#endif

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/CckrSamplingLoggingBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/CckrSamplingLoggingBuilderExtensions.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#if NET9_0_OR_GREATER
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.Buffering;
+using Microsoft.Extensions.Diagnostics.Sampling;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Registers the CCKR adaptive log sampler, which reuses the existing logging pipeline seams: the
+/// <see cref="LoggingSampler"/> for the admit/drop decision and the <see cref="LogBuffer"/> for
+/// holding admitted records and emitting them &#8212; weighted &#8212; at each period flush.
+/// </summary>
+public static class CckrSamplingLoggingBuilderExtensions
+{
+    /// <summary>
+    /// Adds the CCKR adaptive reservoir sampler to the logging infrastructure. Registers a single
+    /// reservoir as both the pipeline's <see cref="LoggingSampler"/> and its <see cref="LogBuffer"/>.
+    /// </summary>
+    /// <param name="builder">The logging builder.</param>
+    /// <param name="configure">An optional delegate to configure the reservoir.</param>
+    /// <returns>The value of <paramref name="builder"/>.</returns>
+    public static ILoggingBuilder AddCckrLogSampling(this ILoggingBuilder builder, Action<ReservoirSamplingConfig>? configure = null)
+    {
+        _ = Throw.IfNull(builder);
+
+        var config = new ReservoirSamplingConfig();
+        configure?.Invoke(config);
+
+        // Register one reservoir instance and expose it through both pipeline seams. The DI container
+        // owns its lifetime (and disposal); the LoggingSampler resolves the same instance.
+        builder.Services.TryAddSingleton<CckrLogBuffer>(_ => new CckrLogBuffer(config, TimeProvider.System));
+        builder.Services.TryAddSingleton<LogBuffer>(static sp => sp.GetRequiredService<CckrLogBuffer>());
+
+        return builder.AddSampler<CckrLoggingSampler>();
+    }
+}
+#endif

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/ChaoEstimator.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/ChaoEstimator.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Diagnostics.Sampling;
+
+/// <summary>
+/// Chao1 / Good-Turing estimators used to weight as-yet-unseen callsites so the tail of the
+/// distribution is not systematically under-sampled. See Chao, <i>Scand. J. Statist.</i> (1984).
+/// </summary>
+internal static class ChaoEstimator
+{
+    /// <summary>
+    /// Computes the Good-Turing-derived <c>unseen_weight</c> from a sample of per-callsite frequencies
+    /// using Chao1's species-richness lower bound. The returned value is <c>1 / f_unseen</c> where
+    /// <c>f_unseen</c> is the expected per-unseen-callsite frequency. Falls back to <c>1.0</c> (treat
+    /// unseen callsites as singletons) in degenerate cases.
+    /// </summary>
+    /// <param name="frequencies">The per-callsite arrival counts observed in the period.</param>
+    /// <returns>The weight to assign to callsites not seen in the frozen table.</returns>
+    public static double Chao1UnseenWeight(IEnumerable<long> frequencies)
+    {
+        long n = 0;
+        long seen = 0;
+        long f1 = 0;
+        long f2 = 0;
+        foreach (var f in frequencies)
+        {
+            if (f == 0)
+            {
+                continue;
+            }
+
+            n += f;
+            seen++;
+            if (f == 1)
+            {
+                f1++;
+            }
+            else if (f == 2)
+            {
+                f2++;
+            }
+        }
+
+        if (n == 0 || f1 == 0)
+        {
+            return 1.0;
+        }
+
+        double nf = n;
+        double f1f = f1;
+        double f2f = f2;
+        double seenf = seen;
+
+        // Chao1 richness (lower bound on total number of distinct callsites).
+        double chao1 = f2 > 0
+            ? seenf + (((nf - 1.0) / nf) * (f1f * f1f) / (2.0 * f2f))
+            : seenf + (((nf - 1.0) / nf) * (f1f * (f1f - 1.0)) / 2.0);
+
+        double unseenSpecies = chao1 - seenf;
+        if (unseenSpecies <= 0.0)
+        {
+            return 1.0;
+        }
+
+        // Good-Turing missing-mass estimate: f1 / n.
+        double missingMass = f1f / nf;
+        if (missingMass <= 0.0)
+        {
+            return 1.0;
+        }
+
+        double perUnseenProbability = missingMass / unseenSpecies;
+        double unseenFrequency = nf * perUnseenProbability;
+        if (double.IsNaN(unseenFrequency) || double.IsInfinity(unseenFrequency) || unseenFrequency <= 0.0)
+        {
+            return 1.0;
+        }
+
+        // Cap at 1.0: an unseen callsite should never be weighted as if it had been seen more than
+        // once on average.
+        double weight = 1.0 / unseenFrequency;
+        return weight < 1.0 ? weight : 1.0;
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/ILogSampler.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/ILogSampler.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Diagnostics.Sampling;
+
+/// <summary>
+/// A per-thread adaptive log-event sampler. Callers first ask <see cref="Admit(TCallsite)"/> whether
+/// an event should be kept; only for a non-<see cref="AdmissionKind.Skip"/> result do they format the
+/// payload and call <see cref="Insert"/>. Periodically the caller drains the current period via
+/// <see cref="Flush"/> / <see cref="FlushInto"/>.
+/// </summary>
+/// <typeparam name="TCallsite">
+/// The callsite identifier type. In production this is the durable log identifier: a stable key per
+/// logging statement is what makes adaptive, per-callsite sampling possible.
+/// </typeparam>
+/// <typeparam name="TPayload">The formatted log payload type.</typeparam>
+internal interface ILogSampler<TCallsite, TPayload>
+    where TCallsite : notnull
+{
+    /// <summary>
+    /// Hot path: decide whether an event for <paramref name="callsite"/> should be kept. When the
+    /// result is <see cref="AdmissionKind.Skip"/> the caller must drop the event without formatting
+    /// it. Otherwise the caller must format the payload and pass the returned admission verbatim to
+    /// <see cref="Insert"/>.
+    /// </summary>
+    /// <param name="callsite">The callsite identifier (durable ID).</param>
+    /// <returns>The admission decision.</returns>
+    Admission Admit(TCallsite callsite);
+
+    /// <summary>
+    /// Store a formatted payload previously approved by <see cref="Admit(TCallsite)"/>.
+    /// </summary>
+    /// <param name="callsite">The callsite identifier.</param>
+    /// <param name="admission">The admission returned by <see cref="Admit(TCallsite)"/>.</param>
+    /// <param name="payload">The formatted payload.</param>
+    void Insert(TCallsite callsite, Admission admission, TPayload payload);
+
+    /// <summary>
+    /// Drain the current period's sample into a caller-supplied buffer, avoiding the per-flush
+    /// allocation of <see cref="Flush"/>. The sum of
+    /// <see cref="SampledRecord{TCallsite, TPayload}.SamplingCount"/> is an unbiased Horvitz-Thompson
+    /// estimator of the period's total arrival count.
+    /// </summary>
+    /// <param name="output">The buffer to append records to.</param>
+    void FlushInto(ICollection<SampledRecord<TCallsite, TPayload>> output);
+
+    /// <summary>
+    /// Drain the current period's sample. Allocates a fresh list each call; use <see cref="FlushInto"/>
+    /// to recycle a buffer.
+    /// </summary>
+    /// <returns>The sampled records for the period.</returns>
+    List<SampledRecord<TCallsite, TPayload>> Flush();
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/ReservoirSamplingConfig.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/ReservoirSamplingConfig.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Extensions.Diagnostics.Sampling;
+
+/// <summary>
+/// Configuration for the adaptive (CCKR) log reservoir sampler wired into the logging pipeline.
+/// </summary>
+public sealed class ReservoirSamplingConfig
+{
+    /// <summary>
+    /// Gets or sets the per-period reservoir capacity (<c>T</c>).
+    /// </summary>
+    public int Capacity { get; set; } = 128;
+
+    /// <summary>
+    /// Gets or sets the per-period novelty-preserve capacity (<c>R</c>). <c>0</c> disables the preserve.
+    /// </summary>
+    public int PreserveCapacity { get; set; } = 128;
+
+    /// <summary>
+    /// Gets or sets the minimum prior-period arrival count below which the frozen frequency table is
+    /// discarded and the next period is treated as warmup.
+    /// </summary>
+    public long MinPeriodCount { get; set; } = 32;
+
+    /// <summary>
+    /// Gets or sets the period length. When this much time has elapsed the reservoir is flushed and a
+    /// new period begins.
+    /// </summary>
+    public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Gets or sets the strategy used to weight callsites unseen in the frozen table.
+    /// </summary>
+    public UnseenWeightMode UnseenWeightMode { get; set; } = UnseenWeightMode.Chao1;
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/SampledRecord.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/SampledRecord.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Diagnostics.Sampling;
+
+/// <summary>
+/// A single record produced when a sampling period is flushed. The <see cref="SamplingCount"/> is the
+/// Horvitz-Thompson weight: summed across all records of a callsite it is an unbiased estimate of that
+/// callsite's true arrival count for the period.
+/// </summary>
+/// <typeparam name="TCallsite">The callsite identifier type (in production, the durable ID).</typeparam>
+/// <typeparam name="TPayload">The formatted log payload type.</typeparam>
+internal readonly struct SampledRecord<TCallsite, TPayload> : IEquatable<SampledRecord<TCallsite, TPayload>>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SampledRecord{TCallsite, TPayload}"/> struct.
+    /// </summary>
+    /// <param name="callsite">The callsite identifier.</param>
+    /// <param name="payload">The formatted payload.</param>
+    /// <param name="samplingCount">
+    /// The Horvitz-Thompson weight. A value of <c>0</c> marks an observational novelty-preserve record
+    /// that does not contribute to count estimates.
+    /// </param>
+    public SampledRecord(TCallsite callsite, TPayload payload, double samplingCount)
+    {
+        Callsite = callsite;
+        Payload = payload;
+        SamplingCount = samplingCount;
+    }
+
+    /// <summary>
+    /// Gets the callsite identifier.
+    /// </summary>
+    public TCallsite Callsite { get; }
+
+    /// <summary>
+    /// Gets the formatted payload.
+    /// </summary>
+    public TPayload Payload { get; }
+
+    /// <summary>
+    /// Gets the Horvitz-Thompson sampling weight. A value greater than or equal to <c>1</c> means the
+    /// record stands in for that many events; a value of <c>0</c> is an observational novelty record
+    /// that does not contribute to estimates.
+    /// </summary>
+    public double SamplingCount { get; }
+
+    public static bool operator ==(SampledRecord<TCallsite, TPayload> left, SampledRecord<TCallsite, TPayload> right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(SampledRecord<TCallsite, TPayload> left, SampledRecord<TCallsite, TPayload> right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(SampledRecord<TCallsite, TPayload> other)
+    {
+        return EqualityComparer<TCallsite>.Default.Equals(Callsite, other.Callsite)
+            && EqualityComparer<TPayload>.Default.Equals(Payload, other.Payload)
+            && SamplingCount.Equals(other.SamplingCount);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is SampledRecord<TCallsite, TPayload> other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => (Callsite, Payload, SamplingCount).GetHashCode();
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/UnseenWeightMode.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Sampling/UnseenWeightMode.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Diagnostics.Sampling;
+
+/// <summary>
+/// Strategy for weighting callsites that were not present in the previous period's frozen
+/// frequency table.
+/// </summary>
+public enum UnseenWeightMode
+{
+    /// <summary>
+    /// Chao1 / Good-Turing missing-mass estimate.
+    /// </summary>
+    Chao1,
+
+    /// <summary>
+    /// Rarest-seen rule: an unseen callsite is weighted the same as the rarest callsite already
+    /// observed (the inverse of the smallest observed frequency).
+    /// </summary>
+    RarestSeen,
+}


### PR DESCRIPTION
…etry

Implements the CCKR (Chao-Cohen-Kaplan-Reservoir) adaptive log sampler as implementations of the existing LoggingSampler and LogBuffer seams, so no changes to the logging pipeline are required:

- Cckr<TCallsite,TPayload>: bottom-(K+1) weighted reservoir with EXP ranks, cross-period inverse-frequency feedback, Chao1 unseen-weight, bounded novelty preserve, and Horvitz-Thompson sampling weights (faithful port of the reference algorithm).

- CckrLoggingSampler (LoggingSampler): the admit/drop decision. CckrLogBuffer (LogBuffer): holds admitted records per category and emits the kept records carrying the sampling.count weight at each flush, reusing SerializedLogRecord/DeserializedLogRecord/IBufferedLogger.

- AddCckrLogSampling registers one reservoir instance as both seams. Public API: AddCckrLogSampling, ReservoirSamplingConfig, UnseenWeightMode.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7676)