### PR TITLE
AI.Abstractions: fix ExcludeFromSchema dropped under concurrent AIFunction creation

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunctionFactory.cs
@@ -735,14 +735,18 @@ public static partial class AIFunctionFactory
         {
             ParameterInfo[] parameters = key.Method.GetParameters();
 
-            // Determine how each parameter should be bound.
-            Dictionary<ParameterInfo, AIFunctionFactoryOptions.ParameterBindingOptions>? boundParameters = null;
+            // Determine how each parameter should be bound. This is keyed on the parameter's position
+            // rather than the ParameterInfo instance: MethodInfo.GetParameters() does not guarantee the
+            // same ParameterInfo instances across concurrent first calls on a cold MethodInfo, and the
+            // schema generator invokes IncludeParameter with ParameterInfo instances from its own
+            // GetParameters() call. Keying on identity would race and silently drop ExcludeFromSchema.
+            AIFunctionFactoryOptions.ParameterBindingOptions[]? boundParameters = null;
             if (parameters.Length != 0 && key.GetBindParameterOptions is not null)
             {
-                boundParameters = new(parameters.Length);
+                boundParameters = new AIFunctionFactoryOptions.ParameterBindingOptions[parameters.Length];
                 for (int i = 0; i < parameters.Length; i++)
                 {
-                    boundParameters[parameters[i]] = key.GetBindParameterOptions(parameters[i]);
+                    boundParameters[i] = key.GetBindParameterOptions(parameters[i]);
                 }
             }
 
@@ -759,8 +763,11 @@ public static partial class AIFunctionFactory
                     }
 
                     // If the parameter is marked as excluded by GetBindParameterOptions, exclude it.
-                    if (boundParameters?.TryGetValue(parameterInfo, out var options) is true &&
-                        options.ExcludeFromSchema)
+                    // Look up by position because the ParameterInfo passed here may be a different
+                    // instance than the one boundParameters was built from (see comment above).
+                    if (boundParameters is not null &&
+                        (uint)parameterInfo.Position < (uint)boundParameters.Length &&
+                        boundParameters[parameterInfo.Position].ExcludeFromSchema)
                     {
                         return false;
                     }
@@ -783,10 +790,8 @@ public static partial class AIFunctionFactory
             bool hasCustomParameterBinding = false;
             for (int i = 0; i < parameters.Length; i++)
             {
-                if (boundParameters?.TryGetValue(parameters[i], out AIFunctionFactoryOptions.ParameterBindingOptions options) is not true)
-                {
-                    options = default;
-                }
+                AIFunctionFactoryOptions.ParameterBindingOptions options =
+                    boundParameters is not null ? boundParameters[i] : default;
 
                 ParameterMarshallers[i] = GetParameterMarshaller(serializerOptions, options, parameters[i]);
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
@@ -559,44 +559,66 @@ public partial class AIFunctionFactoryTest
         IExcludedService service = new ExcludedService();
         int leaks = 0;
 
-        Parallel.For(0, 64, _ =>
+        // Use explicit threads (not Parallel.For) with a Barrier so that every worker begins each
+        // method's creation at the same time, maximizing the cold-start MethodInfo.GetParameters()
+        // window the fix addresses. A Barrier sized to the worker count would deadlock with Parallel.For,
+        // which does not guarantee that many iterations run concurrently.
+        const int Concurrency = 64;
+        using Barrier barrier = new(Concurrency);
+        Thread[] threads = new Thread[Concurrency];
+        for (int t = 0; t < Concurrency; t++)
         {
-            foreach (MethodInfo method in methods)
+            threads[t] = new Thread(() =>
             {
-                AIFunctionFactoryOptions options = new()
+                foreach (MethodInfo method in methods)
                 {
-                    ConfigureParameterBinding = p => p.ParameterType == typeof(IExcludedService)
-                        ? new AIFunctionFactoryOptions.ParameterBindingOptions
-                        {
-                            ExcludeFromSchema = true,
-                            BindParameter = (_, _) => service,
-                        }
-                        : default,
-                };
+                    AIFunctionFactoryOptions options = new()
+                    {
+                        ConfigureParameterBinding = p => p.ParameterType == typeof(IExcludedService)
+                            ? new AIFunctionFactoryOptions.ParameterBindingOptions
+                            {
+                                ExcludeFromSchema = true,
+                                BindParameter = (_, _) => service,
+                            }
+                            : default,
+                    };
 
-                JsonElement schema = AIFunctionFactory.Create(method, target: null, options).JsonSchema;
-                if (schema.TryGetProperty("required", out JsonElement required) &&
-                    required.EnumerateArray().Any(e => e.GetString() == "service"))
-                {
-                    Interlocked.Increment(ref leaks);
+                    // Rendezvous so all workers race the first GetParameters() call on this method together.
+                    barrier.SignalAndWait();
+
+                    JsonElement schema = AIFunctionFactory.Create(method, target: null, options).JsonSchema;
+
+                    bool inRequired = schema.TryGetProperty("required", out JsonElement required) &&
+                        required.EnumerateArray().Any(e => e.GetString() == "service");
+                    bool inProperties = schema.TryGetProperty("properties", out JsonElement properties) &&
+                        properties.TryGetProperty("service", out _);
+                    if (inRequired || inProperties)
+                    {
+                        Interlocked.Increment(ref leaks);
+                    }
                 }
-            }
-        });
+            });
+        }
+
+        foreach (Thread thread in threads)
+        {
+            thread.Start();
+        }
+
+        foreach (Thread thread in threads)
+        {
+            thread.Join();
+        }
 
         Assert.Equal(0, leaks);
     }
 
-    public interface IExcludedService
+    private interface IExcludedService
     {
         string Value { get; }
     }
 
-    private sealed class ExcludedService : IExcludedService
-    {
-        public string Value => "service";
-    }
-
-    public static class ExcludeFromSchemaConcurrencyTools
+    private static class ExcludeFromSchemaConcurrencyTools
     {
         public static string One(IExcludedService service, [Description("q")] string query, [Description("o")] string? optional = null) => $"{service.Value}{query}{optional}";
         public static string Two(IExcludedService service, [Description("o")] string? optional = null) => $"{service.Value}{optional}";
@@ -606,6 +628,11 @@ public partial class AIFunctionFactoryTest
         public static string Six(IExcludedService service, [Description("c")] string? category = null) => $"{service.Value}{category}";
         public static string Seven(IExcludedService service, [Description("t")] string? topic = null) => $"{service.Value}{topic}";
         public static string Eight(IExcludedService service) => service.Value;
+    }
+
+    private sealed class ExcludedService : IExcludedService
+    {
+        public string Value => "service";
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
@@ -559,56 +559,33 @@ public partial class AIFunctionFactoryTest
         IExcludedService service = new ExcludedService();
         int leaks = 0;
 
-        // Use explicit threads (not Parallel.For) with a Barrier so that every worker begins each
-        // method's creation at the same time, maximizing the cold-start MethodInfo.GetParameters()
-        // window the fix addresses. A Barrier sized to the worker count would deadlock with Parallel.For,
-        // which does not guarantee that many iterations run concurrently.
-        const int Concurrency = 64;
-        using Barrier barrier = new(Concurrency);
-        Thread[] threads = new Thread[Concurrency];
-        for (int t = 0; t < Concurrency; t++)
+        Parallel.For(0, 64, _ =>
         {
-            threads[t] = new Thread(() =>
+            foreach (MethodInfo method in methods)
             {
-                foreach (MethodInfo method in methods)
+                AIFunctionFactoryOptions options = new()
                 {
-                    AIFunctionFactoryOptions options = new()
-                    {
-                        ConfigureParameterBinding = p => p.ParameterType == typeof(IExcludedService)
-                            ? new AIFunctionFactoryOptions.ParameterBindingOptions
-                            {
-                                ExcludeFromSchema = true,
-                                BindParameter = (_, _) => service,
-                            }
-                            : default,
-                    };
+                    ConfigureParameterBinding = p => p.ParameterType == typeof(IExcludedService)
+                        ? new AIFunctionFactoryOptions.ParameterBindingOptions
+                        {
+                            ExcludeFromSchema = true,
+                            BindParameter = (_, _) => service,
+                        }
+                        : default,
+                };
 
-                    // Rendezvous so all workers race the first GetParameters() call on this method together.
-                    barrier.SignalAndWait();
+                JsonElement schema = AIFunctionFactory.Create(method, target: null, options).JsonSchema;
 
-                    JsonElement schema = AIFunctionFactory.Create(method, target: null, options).JsonSchema;
-
-                    bool inRequired = schema.TryGetProperty("required", out JsonElement required) &&
-                        required.EnumerateArray().Any(e => e.GetString() == "service");
-                    bool inProperties = schema.TryGetProperty("properties", out JsonElement properties) &&
-                        properties.TryGetProperty("service", out _);
-                    if (inRequired || inProperties)
-                    {
-                        Interlocked.Increment(ref leaks);
-                    }
+                bool inRequired = schema.TryGetProperty("required", out JsonElement required) &&
+                    required.EnumerateArray().Any(e => e.GetString() == "service");
+                bool inProperties = schema.TryGetProperty("properties", out JsonElement properties) &&
+                    properties.TryGetProperty("service", out JsonElement _);
+                if (inRequired || inProperties)
+                {
+                    Interlocked.Increment(ref leaks);
                 }
-            });
-        }
-
-        foreach (Thread thread in threads)
-        {
-            thread.Start();
-        }
-
-        foreach (Thread thread in threads)
-        {
-            thread.Join();
-        }
+            }
+        });
 
         Assert.Equal(0, leaks);
     }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
@@ -552,6 +552,63 @@ public partial class AIFunctionFactoryTest
     }
 
     [Fact]
+    public void AIFunctionFactoryOptions_ExcludeFromSchema_HonoredUnderConcurrentCreation()
+    {
+        MethodInfo[] methods = typeof(ExcludeFromSchemaConcurrencyTools)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static);
+        IExcludedService service = new ExcludedService();
+        int leaks = 0;
+
+        Parallel.For(0, 64, _ =>
+        {
+            foreach (MethodInfo method in methods)
+            {
+                AIFunctionFactoryOptions options = new()
+                {
+                    ConfigureParameterBinding = p => p.ParameterType == typeof(IExcludedService)
+                        ? new AIFunctionFactoryOptions.ParameterBindingOptions
+                        {
+                            ExcludeFromSchema = true,
+                            BindParameter = (_, _) => service,
+                        }
+                        : default,
+                };
+
+                JsonElement schema = AIFunctionFactory.Create(method, target: null, options).JsonSchema;
+                if (schema.TryGetProperty("required", out JsonElement required) &&
+                    required.EnumerateArray().Any(e => e.GetString() == "service"))
+                {
+                    Interlocked.Increment(ref leaks);
+                }
+            }
+        });
+
+        Assert.Equal(0, leaks);
+    }
+
+    public interface IExcludedService
+    {
+        string Value { get; }
+    }
+
+    private sealed class ExcludedService : IExcludedService
+    {
+        public string Value => "service";
+    }
+
+    public static class ExcludeFromSchemaConcurrencyTools
+    {
+        public static string One(IExcludedService service, [Description("q")] string query, [Description("o")] string? optional = null) => $"{service.Value}{query}{optional}";
+        public static string Two(IExcludedService service, [Description("o")] string? optional = null) => $"{service.Value}{optional}";
+        public static string Three(IExcludedService service, [Description("n")] string name) => $"{service.Value}{name}";
+        public static string Four(IExcludedService service, [Description("n")] string name, [Description("a")] string? aspect = null) => $"{service.Value}{name}{aspect}";
+        public static string Five(IExcludedService service, [Description("q")] string query, [Description("f")] string framework) => $"{service.Value}{query}{framework}";
+        public static string Six(IExcludedService service, [Description("c")] string? category = null) => $"{service.Value}{category}";
+        public static string Seven(IExcludedService service, [Description("t")] string? topic = null) => $"{service.Value}{topic}";
+        public static string Eight(IExcludedService service) => service.Value;
+    }
+
+    [Fact]
     public void AIFunctionFactoryOptions_SupportsSkippingReturnSchema()
     {
         AIFunction func = AIFunctionFactory.Create(


### PR DESCRIPTION
## Summary

Fixes #7675.

`AIFunctionFactory` (via `ReflectionAIFunctionDescriptor`) could silently drop a parameter's `ExcludeFromSchema = true` setting under concurrent first-time function creation, leaking an excluded parameter (e.g. an injected DI service) into the generated JSON schema's `properties` and `required`.

## Root cause

The descriptor built a `Dictionary<ParameterInfo, ParameterBindingOptions>` keyed by `ParameterInfo` **reference** from `key.Method.GetParameters()`. The schema generator (`AIJsonUtilities.CreateFunctionJsonSchema`) invokes the descriptor's `IncludeParameter` delegate with `ParameterInfo` instances obtained from its **own** `method.GetParameters()` call. `MethodInfo.GetParameters()` does not guarantee identical `ParameterInfo` instances across concurrent first calls on a cold `MethodInfo` — racing threads each materialize their own array. When the two arrays differ, the reference-keyed lookup misses, `ExcludeFromSchema` is ignored, and the parameter lands in the schema. Once the runtime's parameter cache settles this stops, which is why it's a startup-only phenomenon. Callers that pass a fresh `ConfigureParameterBinding` delegate per creation (every MCP host, via `McpServerTool.Create`) defeat the descriptor cache and stay exposed for the duration of the cold window.

## Fix

Key the parameter-binding options by parameter **`Position`** (an index-based `ParameterBindingOptions[]`) instead of `ParameterInfo` identity. `IncludeParameter` is constructed per descriptor and only ever invoked with the descriptor method's parameters, so `Position` is a stable, unique key that is independent of which `GetParameters()` array a thread happens to hold. This is allocation-lighter than the dictionary and removes the race entirely.

## Validation

- Added regression test `AIFunctionFactoryOptions_ExcludeFromSchema_HonoredUnderConcurrentCreation` (64-way parallel creation with a fresh `ConfigureParameterBinding` per call over 8 methods), asserting the excluded parameter never appears in `required`.
- A standalone reproduction (the exact repro from the issue) leaked 3–12 of 512 on every run before the fix and 0 of 512 across 15 consecutive runs after.
- Full `Microsoft.Extensions.AI.Tests` suite: 698 passed, 0 failed.

## Notes for reviewers

The marshaller loop that also reads the binding options was already using `parameters[i]` from the descriptor's own array (not the cross-array path), so it was never affected; it now reads `boundParameters[i]` directly. Any other code mapping `ParameterInfo`/`MemberInfo` to per-method state by reference has the same exposure and is worth a look, but is out of scope here.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7677)