### PR TITLE
Fix response body logging under debugger

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/HttpResponseBodyReader.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/HttpResponseBodyReader.cs
@@ -67,8 +67,10 @@ internal sealed class HttpResponseBodyReader
 
         // TimeSpan.Zero cannot be set from user's code as
         // validation prevents values less than one millisecond
-        // However, this is useful during unit tests
-        if (readTimeout <= TimeSpan.Zero)
+        // However, this is useful during unit tests.
+        // Note: the comparison has to be an exact match; when a debugger is attached,
+        // the timeout is Timeout.InfiniteTimeSpan (-1 ms), which means "never time out".
+        if (readTimeout == TimeSpan.Zero)
         {
             // cancel immediately, async cancel not required in tests
 #pragma warning disable CA1849 // Call async methods when in an async method

--- a/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpResponseBodyReaderTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpResponseBodyReaderTest.cs
@@ -275,4 +275,40 @@ public class HttpResponseBodyReaderTest
 
         Assert.Equal(reader.ResponseReadTimeout, timeout);
     }
+
+    [Theory]
+    [CombinatorialData]
+    public async Task Reader_DebuggerAttached_ReadsBodyAndLeavesContentReadable(bool seekable, bool bufferContent)
+    {
+        var options = new LoggingOptions
+        {
+            BodySizeLimit = 32,
+            ResponseBodyContentTypes = new HashSet<string> { TextPlain }
+        };
+
+        var httpResponseBodyReader = new HttpResponseBodyReader(options, DebuggerState.Attached);
+        var content = RandomStringGenerator.Generate(options.BodySizeLimit * 2);
+        var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        using var httpResponse = new HttpResponseMessage
+        {
+            Content = new StreamContent(seekable ? memoryStream : new NotSeekableStream(memoryStream))
+        };
+        httpResponse.Content.Headers.Add("Content-Type", TextPlain);
+
+        var responseBody = await httpResponseBodyReader.ReadAsync(httpResponse, CancellationToken.None);
+
+        responseBody.Should().Be(content.Substring(0, options.BodySizeLimit));
+
+        if (bufferContent)
+        {
+            // This is what HttpClient does once the handler pipeline is done when
+            // HttpCompletionOption.ResponseContentRead is used, i.e. for GetAsync/PostAsJsonAsync.
+            await httpResponse.Content.LoadIntoBufferAsync();
+        }
+
+        // The caller must still be able to read the whole body.
+        var response = await httpResponse.Content.ReadAsStringAsync();
+
+        response.Should().Be(content);
+    }
 }


### PR DESCRIPTION
Fixes #7649

Treat only TimeSpan.Zero as an immediate test timeout. This preserves the infinite timeout used while debugging, allowing the response body to be logged without leaving the content stream consumed.

Add regression coverage for seekable and non-seekable streams, with and without response content buffering.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7678)