### PR TITLE
[Microsoft.Gen.Logging] Clear thread-local state when logging throws

### DIFF
--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
@@ -80,6 +80,8 @@ internal sealed partial class Emitter : EmitterBase
         var stateName = PickUniqueName("state", lm.Parameters.Select(p => p.ParameterName));
 
         OutLn($"var {stateName} = {LoggerMessageHelperType}.ThreadLocalState;");
+        OutLn("try");
+        OutOpenBrace();
         GenTagWrites(lm, stateName, out int numReservedUnclassifiedTags, out int numReservedClassifiedTags);
 
         OutLn();
@@ -140,8 +142,11 @@ internal sealed partial class Emitter : EmitterBase
         OutCloseBraceWithExtra(");");
         Unindent();
 
-        OutLn();
+        OutCloseBrace();
+        OutLn("finally");
+        OutOpenBrace();
         OutLn($"{stateName}.Clear();");
+        OutCloseBrace();
         OutCloseBrace();
 
         /// <summary>

--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
@@ -16,6 +16,43 @@ namespace Microsoft.Gen.Logging.Test;
 
 public class LogMethodTests
 {
+    private sealed class ThrowingLogger : ILogger
+    {
+        public static ThrowingLogger Instance { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => throw new InvalidOperationException("Provider failed.");
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public object? RequestId { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (state is IReadOnlyList<KeyValuePair<string, object?>> fields)
+            {
+                foreach (var field in fields)
+                {
+                    if (field.Key == "RequestId")
+                    {
+                        RequestId = field.Value;
+                    }
+                }
+            }
+        }
+    }
+
     [Fact]
     public void BasicTests()
     {
@@ -164,6 +201,18 @@ public class LogMethodTests
         ArgTestExtensions.Method10(logger, 1);
         Assert.Equal("M101", collector.LatestRecord.Message);
         Assert.Equal(1, collector.Count);
+    }
+
+    [Fact]
+    public void ThreadLocalStateIsClearedWhenLoggerThrows()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            ArgTestExtensions.Method11(ThrowingLogger.Instance, "stale-request", "alpha", "beta", "gamma"));
+
+        var logger = new CapturingLogger();
+        ArgTestExtensions.Method12(logger, "req-123");
+
+        Assert.Equal("req-123", logger.RequestId);
     }
 
     [Fact]

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/ArgTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/ArgTestExtensions.cs
@@ -39,5 +39,11 @@ namespace TestClasses
 
         [LoggerMessage(9, LogLevel.Error, "M10{p1}")]
         public static partial void Method10(ILogger logger, int p1);
+
+        [LoggerMessage(10, LogLevel.Error, "{RequestId} {First} {Second} {Third}")]
+        public static partial void Method11(ILogger logger, string requestId, string first, string second, string third);
+
+        [LoggerMessage(11, LogLevel.Error, "{RequestId}")]
+        public static partial void Method12(ILogger logger, string requestId);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/Verified/ParserTests.ClassWithNullableProperty.verified.txt
+++ b/test/Generators/Microsoft.Gen.Logging/Verified/ParserTests.ClassWithNullableProperty.verified.txt
@@ -20,23 +20,28 @@ namespace Test
                 }
 
                 var state = global::Microsoft.Extensions.Logging.LoggerMessageHelper.ThreadLocalState;
+                try
+                {
 
-                _ = state.ReserveTagSpace(3);
-                state.TagArray[2] = new("{OriginalFormat}", "Testing nullable property within class here...");
-                state.TagArray[1] = new("classWithNullablePropertyParam.NullableDateTime", classWithNullablePropertyParam?.NullableDateTime);
-                state.TagArray[0] = new("classWithNullablePropertyParam.NonNullableDateTime", classWithNullablePropertyParam?.NonNullableDateTime);
+                    _ = state.ReserveTagSpace(3);
+                    state.TagArray[2] = new("{OriginalFormat}", "Testing nullable property within class here...");
+                    state.TagArray[1] = new("classWithNullablePropertyParam.NullableDateTime", classWithNullablePropertyParam?.NullableDateTime);
+                    state.TagArray[0] = new("classWithNullablePropertyParam.NonNullableDateTime", classWithNullablePropertyParam?.NonNullableDateTime);
 
-                logger.Log(
-                    global::Microsoft.Extensions.Logging.LogLevel.Information,
-                    new(0, nameof(LogMethodNullablePropertyInClassMatchesNonNullable)),
-                    state,
-                    null,
-                    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Gen.Logging", "VERSION")] static string (s, _) =>
-                    {
-                        return "Testing nullable property within class here...";
-                    });
-
-                state.Clear();
+                    logger.Log(
+                        global::Microsoft.Extensions.Logging.LogLevel.Information,
+                        new(0, nameof(LogMethodNullablePropertyInClassMatchesNonNullable)),
+                        state,
+                        null,
+                        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Gen.Logging", "VERSION")] static string (s, _) =>
+                        {
+                            return "Testing nullable property within class here...";
+                        });
+                }
+                finally
+                {
+                    state.Clear();
+                }
             }
         }
     }

--- a/test/Generators/Microsoft.Gen.Logging/Verified/ParserTests.MultipleTypeDefinitions.verified.txt
+++ b/test/Generators/Microsoft.Gen.Logging/Verified/ParserTests.MultipleTypeDefinitions.verified.txt
@@ -18,21 +18,26 @@ namespace Test
             }
 
             var state = global::Microsoft.Extensions.Logging.LoggerMessageHelper.ThreadLocalState;
+            try
+            {
 
-            _ = state.ReserveTagSpace(1);
-            state.TagArray[0] = new("{OriginalFormat}", "M1");
+                _ = state.ReserveTagSpace(1);
+                state.TagArray[0] = new("{OriginalFormat}", "M1");
 
-            logger.Log(
-                global::Microsoft.Extensions.Logging.LogLevel.Debug,
-                new(1, nameof(M1)),
-                state,
-                null,
-                [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Gen.Logging", "VERSION")] static string (s, _) =>
-                {
-                    return "M1";
-                });
-
-            state.Clear();
+                logger.Log(
+                    global::Microsoft.Extensions.Logging.LogLevel.Debug,
+                    new(1, nameof(M1)),
+                    state,
+                    null,
+                    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Gen.Logging", "VERSION")] static string (s, _) =>
+                    {
+                        return "M1";
+                    });
+            }
+            finally
+            {
+                state.Clear();
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #7634

Clear LoggerMessageHelper.ThreadLocalState in a finally block to prevent stale structured fields from leaking into subsequent log calls.

Add regression coverage for throwing ILogger implementations.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7682)