### PR TITLE
Add a routing context factory for request-scoped policy state

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatRouting/RoutingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatRouting/RoutingChatClient.cs
@@ -39,6 +39,25 @@ public abstract class RoutingChatClient : IChatClient
         return new CallbackRoutingChatClient(clientSelector);
     }
 
+    /// <summary>Creates the context supplied to client selection for one request.</summary>
+    /// <param name="messages">The messages to route.</param>
+    /// <param name="options">The options supplied by the caller, or <see langword="null"/>.</param>
+    /// <returns>The context for the request.</returns>
+    /// <remarks>
+    /// <para>
+    /// The default implementation returns a new <see cref="RoutingContext"/>. A derived class can return its own
+    /// <see cref="RoutingContext"/> subclass to supply additional request inputs or to carry request-scoped policy
+    /// state, which <see cref="SelectClientAsync"/> then reads by casting the supplied context. State stored on the
+    /// context is released with the request.
+    /// </para>
+    /// <para>
+    /// This method is called once per request by <see cref="GetResponseAsync"/> and
+    /// <see cref="GetStreamingResponseAsync"/>. Exceptions from this method propagate to the caller.
+    /// </para>
+    /// </remarks>
+    protected virtual RoutingContext CreateContext(IEnumerable<ChatMessage> messages, ChatOptions? options) =>
+        new(messages, options);
+
     /// <summary>Selects the client to invoke for the request.</summary>
     /// <param name="context">The request-specific inputs.</param>
     /// <param name="cancellationToken">The cancellation token supplied for the request.</param>
@@ -57,7 +76,8 @@ public abstract class RoutingChatClient : IChatClient
     {
         _ = Throw.IfNull(messages);
 
-        var context = new RoutingContext(messages, options);
+        RoutingContext context = CreateContext(messages, options) ??
+            throw new InvalidOperationException($"{nameof(CreateContext)} returned null.");
         IChatClient client = await SelectClientAsync(context, cancellationToken).ConfigureAwait(false) ??
             throw new InvalidOperationException($"{nameof(SelectClientAsync)} returned null.");
 
@@ -74,7 +94,8 @@ public abstract class RoutingChatClient : IChatClient
     {
         _ = Throw.IfNull(messages);
 
-        var context = new RoutingContext(messages, options);
+        RoutingContext context = CreateContext(messages, options) ??
+            throw new InvalidOperationException($"{nameof(CreateContext)} returned null.");
         IChatClient client = await SelectClientAsync(context, cancellationToken).ConfigureAwait(false) ??
             throw new InvalidOperationException($"{nameof(SelectClientAsync)} returned null.");
 

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -3979,6 +3979,10 @@
           "Stage": "Experimental"
         },
         {
+          "Member": "virtual Microsoft.Extensions.AI.RoutingContext Microsoft.Extensions.AI.RoutingChatClient.CreateContext(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages, Microsoft.Extensions.AI.ChatOptions? options);",
+          "Stage": "Experimental"
+        },
+        {
           "Member": "void Microsoft.Extensions.AI.RoutingChatClient.Dispose();",
           "Stage": "Experimental"
         },

--- a/src/Libraries/Microsoft.Extensions.AI/ChatRouting/FailoverChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatRouting/FailoverChatClient.cs
@@ -29,6 +29,12 @@ namespace Microsoft.Extensions.AI;
 /// client selection, policy state, selection-failure cleanup, and the lifetime of clients they retain.
 /// </para>
 /// <para>
+/// One <see cref="RoutingContext"/> is created for each request and is supplied to every selection and routing
+/// update for that request. A derived class that keeps request-scoped policy state can override
+/// <see cref="RoutingChatClient.CreateContext"/> to return its own <see cref="RoutingContext"/> subclass and store
+/// that state on the context, which releases it with the request instead of requiring explicit cleanup.
+/// </para>
+/// <para>
 /// Once streaming enumeration begins, callers must dispose the enumerator. Abandoning an active enumerator without
 /// disposing it prevents both inner enumerator disposal and the terminal routing update.
 /// </para>
@@ -99,7 +105,8 @@ public abstract class FailoverChatClient : RoutingChatClient
     {
         _ = Throw.IfNull(messages);
 
-        var context = new RoutingContext(messages, options);
+        RoutingContext context = CreateContext(messages, options) ??
+            throw new InvalidOperationException($"{nameof(CreateContext)} returned null.");
         int? maximumAttempts = MaximumAttemptsPerRequest;
         int attemptCount = 0;
 
@@ -169,7 +176,8 @@ public abstract class FailoverChatClient : RoutingChatClient
     {
         _ = Throw.IfNull(messages);
 
-        var context = new RoutingContext(messages, options);
+        RoutingContext context = CreateContext(messages, options) ??
+            throw new InvalidOperationException($"{nameof(CreateContext)} returned null.");
         int? maximumAttempts = MaximumAttemptsPerRequest;
         int attemptCount = 0;
 

--- a/src/Libraries/Microsoft.Extensions.AI/ChatRouting/OrderedFailoverChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatRouting/OrderedFailoverChatClient.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -30,10 +29,6 @@ public sealed class OrderedFailoverChatClient : FailoverChatClient
 {
     private readonly bool _leaveOpen;
     private readonly IChatClient[] _clients;
-
-    // Holds the next client index for a request that has a failed attempt. A nonterminal update is always followed
-    // by another selection, so a stored index is always in range.
-    private readonly ConcurrentDictionary<RoutingContext, int> _requestStates = new();
     private bool _disposed;
 
     /// <summary>Initializes a new instance of the <see cref="OrderedFailoverChatClient"/> class.</summary>
@@ -67,16 +62,17 @@ public sealed class OrderedFailoverChatClient : FailoverChatClient
     }
 
     /// <inheritdoc/>
+    protected override RoutingContext CreateContext(IEnumerable<ChatMessage> messages, ChatOptions? options) =>
+        new OrderedRoutingContext(messages, options);
+
+    /// <inheritdoc/>
     protected override ValueTask<IChatClient> SelectClientAsync(
         RoutingContext context,
         CancellationToken cancellationToken)
     {
-        _ = Throw.IfNull(context);
         _ = cancellationToken;
 
-        int clientIndex = _requestStates.TryGetValue(context, out int nextClientIndex) ? nextClientIndex : 0;
-
-        return new(_clients[clientIndex]);
+        return new(_clients[GetState(context).NextClientIndex]);
     }
 
     /// <inheritdoc/>
@@ -90,22 +86,20 @@ public sealed class OrderedFailoverChatClient : FailoverChatClient
 
         if (isTerminal)
         {
-            _ = _requestStates.TryRemove(context, out _);
             return default;
         }
 
         Exception? exception = attempt.Exception;
         Debug.Assert(exception is not null, "A nonterminal update always reports a failed invocation.");
 
-        int nextClientIndex = (_requestStates.TryGetValue(context, out int attemptedIndex) ? attemptedIndex : 0) + 1;
-        if (nextClientIndex < _clients.Length)
+        OrderedRoutingContext state = GetState(context);
+        if (state.NextClientIndex + 1 < _clients.Length)
         {
-            _requestStates[context] = nextClientIndex;
+            state.NextClientIndex++;
             return default;
         }
 
-        // Every client has failed. Release the state before the final failure ends routing.
-        _ = _requestStates.TryRemove(context, out _);
+        // Every client has failed, so the final failure ends routing.
         ExceptionDispatchInfo.Capture(exception!).Throw();
         throw exception!;
     }
@@ -119,7 +113,6 @@ public sealed class OrderedFailoverChatClient : FailoverChatClient
         }
 
         _disposed = true;
-        _requestStates.Clear();
 
         if (disposing && !_leaveOpen)
         {
@@ -130,5 +123,24 @@ public sealed class OrderedFailoverChatClient : FailoverChatClient
         }
 
         base.Dispose(disposing);
+    }
+
+    private static OrderedRoutingContext GetState(RoutingContext context)
+    {
+        if (context is not OrderedRoutingContext state)
+        {
+            Throw.ArgumentException(
+                nameof(context),
+                $"The context was not created by {nameof(CreateContext)}.");
+            return null!;
+        }
+
+        return state;
+    }
+
+    private sealed class OrderedRoutingContext(IEnumerable<ChatMessage> messages, ChatOptions? chatOptions)
+        : RoutingContext(messages, chatOptions)
+    {
+        public int NextClientIndex { get; set; }
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatRouting/OrderedFailoverChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatRouting/OrderedFailoverChatClient.cs
@@ -70,6 +70,7 @@ public sealed class OrderedFailoverChatClient : FailoverChatClient
         RoutingContext context,
         CancellationToken cancellationToken)
     {
+        _ = Throw.IfNull(context);
         _ = cancellationToken;
 
         return new(_clients[GetState(context).NextClientIndex]);
@@ -127,15 +128,8 @@ public sealed class OrderedFailoverChatClient : FailoverChatClient
 
     private static OrderedRoutingContext GetState(RoutingContext context)
     {
-        if (context is not OrderedRoutingContext state)
-        {
-            Throw.ArgumentException(
-                nameof(context),
-                $"The context was not created by {nameof(CreateContext)}.");
-            return null!;
-        }
-
-        return state;
+        Debug.Assert(context is OrderedRoutingContext, "The context was created by CreateContext.");
+        return (OrderedRoutingContext)context;
     }
 
     private sealed class OrderedRoutingContext(IEnumerable<ChatMessage> messages, ChatOptions? chatOptions)

--- a/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.json
+++ b/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.json
@@ -1492,6 +1492,10 @@
           "Stage": "Experimental"
         },
         {
+          "Member": "override Microsoft.Extensions.AI.RoutingContext Microsoft.Extensions.AI.OrderedFailoverChatClient.CreateContext(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages, Microsoft.Extensions.AI.ChatOptions? options);",
+          "Stage": "Experimental"
+        },
+        {
           "Member": "override void Microsoft.Extensions.AI.OrderedFailoverChatClient.Dispose(bool disposing);",
           "Stage": "Experimental"
         },

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatRouting/RoutingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatRouting/RoutingChatClientTests.cs
@@ -117,6 +117,40 @@ public class RoutingChatClientTests
         Assert.Equal(0, selected.DisposeCount);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CreateContext_SuppliesCustomContextToSelection(bool streaming)
+    {
+        ChatResponse expected = new(new ChatMessage(ChatRole.Assistant, "ok"));
+        using var selected = new TestChatClient
+        {
+            GetResponseAsyncCallback = (_, _, _) => Task.FromResult(expected),
+            GetStreamingResponseAsyncCallback = (_, _, _) => YieldUpdates("ok"),
+        };
+        using var router = new CustomContextTestRouter(selected);
+
+        ChatResponse response = streaming
+            ? await router.GetStreamingResponseAsync([new(ChatRole.User, "hi")]).ToChatResponseAsync()
+            : await router.GetResponseAsync([new(ChatRole.User, "hi")]);
+
+        Assert.Equal("ok", response.Text);
+        Assert.Equal(1, router.ContextsCreated);
+        Assert.Equal(1, router.CustomContextsObserved);
+    }
+
+    [Fact]
+    public async Task CreateContext_NullResultThrows()
+    {
+        using var selected = new TestChatClient();
+        using var router = new NullContextTestRouter(selected);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => router.GetResponseAsync([new(ChatRole.User, "hi")]));
+
+        Assert.Contains("CreateContext", exception.Message, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void GetService_ReturnsSelfAndNullForUnknownOrKeyed()
     {
@@ -127,6 +161,15 @@ public class RoutingChatClientTests
         Assert.Same(client, client.GetService(typeof(IChatClient)));
         Assert.Null(client.GetService(typeof(DelegatingTestRouter), serviceKey: "key"));
         Assert.Null(client.GetService(typeof(string)));
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> YieldUpdates(params string[] texts)
+    {
+        foreach (string text in texts)
+        {
+            await Task.Yield();
+            yield return new ChatResponseUpdate(ChatRole.Assistant, text);
+        }
     }
 
     private static async Task<List<ChatResponseUpdate>> CollectAsync(
@@ -154,6 +197,61 @@ public class RoutingChatClientTests
             RoutingContext context,
             CancellationToken cancellationToken) =>
             new(_select(context));
+    }
+
+    private sealed class CustomContextTestRouter : RoutingChatClient
+    {
+        private readonly IChatClient _client;
+
+        public CustomContextTestRouter(IChatClient client)
+        {
+            _client = client;
+        }
+
+        public int ContextsCreated { get; private set; }
+
+        public int CustomContextsObserved { get; private set; }
+
+        protected override RoutingContext CreateContext(
+            IEnumerable<ChatMessage> messages, ChatOptions? options)
+        {
+            ContextsCreated++;
+            return new TaggedRoutingContext(messages, options);
+        }
+
+        protected override ValueTask<IChatClient> SelectClientAsync(
+            RoutingContext context,
+            CancellationToken cancellationToken)
+        {
+            if (context is TaggedRoutingContext)
+            {
+                CustomContextsObserved++;
+            }
+
+            return new(_client);
+        }
+
+        private sealed class TaggedRoutingContext(IEnumerable<ChatMessage> messages, ChatOptions? chatOptions)
+            : RoutingContext(messages, chatOptions);
+    }
+
+    private sealed class NullContextTestRouter : RoutingChatClient
+    {
+        private readonly IChatClient _client;
+
+        public NullContextTestRouter(IChatClient client)
+        {
+            _client = client;
+        }
+
+        protected override RoutingContext CreateContext(
+            IEnumerable<ChatMessage> messages, ChatOptions? options) =>
+            null!;
+
+        protected override ValueTask<IChatClient> SelectClientAsync(
+            RoutingContext context,
+            CancellationToken cancellationToken) =>
+            new(_client);
     }
 
     private sealed class CountingDisposeClient : IChatClient

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatRouting/FailoverChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatRouting/FailoverChatClientTests.cs
@@ -27,6 +27,46 @@ public class FailoverChatClientTests
         Assert.Throws<ArgumentOutOfRangeException>(() => client.MaximumAttemptsPerRequest = -1);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CreateContext_SuppliesCustomContextToSelectionAndUpdates(bool streaming)
+    {
+        using var failing = new TestChatClient
+        {
+            GetResponseAsyncCallback = (_, _, _) => throw new InvalidOperationException("failed"),
+            GetStreamingResponseAsyncCallback = (_, _, _) => ThrowingStream("failed"),
+        };
+        ChatResponse expected = new(new ChatMessage(ChatRole.Assistant, "ok"));
+        using var succeeding = new TestChatClient
+        {
+            GetResponseAsyncCallback = (_, _, _) => Task.FromResult(expected),
+            GetStreamingResponseAsyncCallback = (_, _, _) => YieldUpdates("ok"),
+        };
+        using var router = new StatefulFailoverTestRouter(failing, succeeding);
+
+        ChatResponse response = streaming
+            ? await router.GetStreamingResponseAsync([new(ChatRole.User, "hi")]).ToChatResponseAsync()
+            : await router.GetResponseAsync([new(ChatRole.User, "hi")]);
+
+        Assert.Equal("ok", response.Text);
+        Assert.Equal(2, router.ObservedContexts.Count);
+        Assert.Same(router.ObservedContexts[0], router.ObservedContexts[1]);
+        Assert.Equal(1, router.LastObservedAttemptNumber);
+    }
+
+    [Fact]
+    public async Task CreateContext_NullResultThrows()
+    {
+        using var selected = new TestChatClient();
+        using var router = new NullContextFailoverTestRouter(selected);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => router.GetResponseAsync([new(ChatRole.User, "hi")]));
+
+        Assert.Contains("CreateContext", exception.Message, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task Failover_RejectsNullMessagesForNonStreamingAndStreaming()
     {
@@ -1222,6 +1262,74 @@ public class FailoverChatClientTests
             _onRoutingUpdate?.Invoke(context, attempt, isTerminal);
             return default;
         }
+    }
+
+    private sealed class StatefulFailoverTestRouter : FailoverChatClient
+    {
+        private readonly IChatClient[] _clients;
+
+        public StatefulFailoverTestRouter(params IChatClient[] clients)
+        {
+            _clients = clients;
+        }
+
+        public List<RoutingContext> ObservedContexts { get; } = [];
+
+        public int LastObservedAttemptNumber { get; private set; }
+
+        protected override RoutingContext CreateContext(
+            IEnumerable<ChatMessage> messages, ChatOptions? options) =>
+            new CountingRoutingContext(messages, options);
+
+        protected override ValueTask<IChatClient> SelectClientAsync(
+            RoutingContext context,
+            CancellationToken cancellationToken)
+        {
+            ObservedContexts.Add(context);
+            var state = (CountingRoutingContext)context;
+            return new(_clients[state.AttemptNumber]);
+        }
+
+        protected override ValueTask OnRoutingUpdateAsync(
+            RoutingContext context,
+            FailoverChatClientAttempt attempt,
+            bool isTerminal,
+            CancellationToken cancellationToken)
+        {
+            var state = (CountingRoutingContext)context;
+            LastObservedAttemptNumber = state.AttemptNumber;
+            if (!isTerminal)
+            {
+                state.AttemptNumber++;
+            }
+
+            return default;
+        }
+
+        private sealed class CountingRoutingContext(IEnumerable<ChatMessage> messages, ChatOptions? chatOptions)
+            : RoutingContext(messages, chatOptions)
+        {
+            public int AttemptNumber { get; set; }
+        }
+    }
+
+    private sealed class NullContextFailoverTestRouter : FailoverChatClient
+    {
+        private readonly IChatClient _client;
+
+        public NullContextFailoverTestRouter(IChatClient client)
+        {
+            _client = client;
+        }
+
+        protected override RoutingContext CreateContext(
+            IEnumerable<ChatMessage> messages, ChatOptions? options) =>
+            null!;
+
+        protected override ValueTask<IChatClient> SelectClientAsync(
+            RoutingContext context,
+            CancellationToken cancellationToken) =>
+            new(_client);
     }
 
     private sealed class ThrowingGetAsyncEnumeratorEnumerable : IAsyncEnumerable<ChatResponseUpdate>

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatRouting/OrderedFailoverChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatRouting/OrderedFailoverChatClientTests.cs
@@ -189,11 +189,16 @@ public class OrderedFailoverChatClientTests
     }
 
     [Fact]
-    public async Task OrderedFailover_ReleasesStateWhenStreamingEnds()
+    public async Task OrderedFailover_AbandonedStreamDoesNotAffectLaterRequests()
     {
+        int firstCalls = 0;
         using var first = new TestChatClient
         {
-            GetStreamingResponseAsyncCallback = (_, _, _) => ThrowingStream("failed"),
+            GetStreamingResponseAsyncCallback = (_, _, _) =>
+            {
+                firstCalls++;
+                return ThrowingStream("failed");
+            },
         };
         using var second = new TestChatClient
         {
@@ -201,14 +206,18 @@ public class OrderedFailoverChatClientTests
         };
         using var client = new OrderedFailoverChatClient([first, second]);
 
-        await using (IAsyncEnumerator<ChatResponseUpdate> enumerator =
-            client.GetStreamingResponseAsync([new(ChatRole.User, "hi")]).GetAsyncEnumerator())
-        {
-            Assert.True(await enumerator.MoveNextAsync());
-            Assert.Equal("first", enumerator.Current.Text);
-        }
+        // Abandon the enumerator mid-stream without disposing it, so no terminal routing update is made.
+        IAsyncEnumerator<ChatResponseUpdate> abandoned =
+            client.GetStreamingResponseAsync([new(ChatRole.User, "hi")]).GetAsyncEnumerator();
+        Assert.True(await abandoned.MoveNextAsync());
+        Assert.Equal("first", abandoned.Current.Text);
 
-        Assert.Equal(0, GetOrderedFailoverRequestStateCount(client));
+        // A later request still starts from the first client because state is scoped to its own context.
+        ChatResponse response =
+            await client.GetStreamingResponseAsync([new(ChatRole.User, "again")]).ToChatResponseAsync();
+
+        Assert.Equal(2, firstCalls);
+        Assert.Equal("firstsecond", response.Text);
     }
 
     [Fact]
@@ -362,16 +371,6 @@ public class OrderedFailoverChatClientTests
         ChatResponse response = await outer.GetResponseAsync([new(ChatRole.User, "hi")]);
 
         Assert.Same(expected, response);
-    }
-
-    private static int GetOrderedFailoverRequestStateCount(OrderedFailoverChatClient client)
-    {
-        object requestStates = typeof(OrderedFailoverChatClient)
-            .GetField(
-                "_requestStates",
-                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
-            .GetValue(client)!;
-        return (int)requestStates.GetType().GetProperty("Count")!.GetValue(requestStates)!;
     }
 
     private sealed class CountingDisposeClient : IChatClient


### PR DESCRIPTION
Follow-up to #7662.

## Summary

Adds one `protected virtual` method to `RoutingChatClient`:

```csharp
protected virtual RoutingContext CreateContext(
    IEnumerable<ChatMessage> messages,
    ChatOptions? options) => new(messages, options);
```

`GetResponseAsync` and `GetStreamingResponseAsync` call it instead of constructing a `RoutingContext` directly, so a derived class can return its own subclass and have it flow through selection and, for `FailoverChatClient`, every routing update for that request.

`OrderedFailoverChatClient` moves onto it, which removes its `ConcurrentDictionary<RoutingContext, int>`.

## Why

Nothing here is newly possible. A router can already keep whatever it wants in a side table keyed by the context — that is what `OrderedFailoverChatClient` does today for its next-client index, and `RoutingContext` does not override `Equals`/`GetHashCode`, so reference-keying is sound. The question is only where that state should live.

| | side table | context state |
| --- | --- | --- |
| Capability | same | same |
| Lifetime | manual: every exit path must remove the entry | automatic: collected with the context |
| Leak if a request ends without a terminal update | yes | not possible |
| Concurrency | needs `ConcurrentDictionary`; every access hashes and may contend | a field on a per-request object; no synchronization |
| Access cost | hash lookup per selection and per update | field read |
| Typing | dictionary value type, unpacked at each use | typed property |
| Disposal | must clear the dictionary | nothing to clear |

The leak is the substantive row. State must survive from a nonterminal update to the following selection, so it cannot be removed eagerly, and a request can end without a terminal update — an abandoned streaming enumerator, or selection failing after state was already stored. Today the derived class is responsible for cleaning up on those paths. Context-owned state hands that responsibility to the GC.

The rest is ergonomics, and it compounds when a selector needs more *inputs* rather than more state. `SelectClientAsync` takes a `RoutingContext`, so a router wanting to hand its callback anything else has to carry a second object and correlate the two. Agent Framework's routing client (microsoft/agent-framework#6932) needs the current agent, the session, its registered destination map, and the session's active destination available to its routing callback, so it declares a standalone context type and copies messages and options into it. That works, and it is why `Microsoft.Agents.AI.RoutingContext` and `Microsoft.Extensions.AI.RoutingContext` are currently unrelated types with the same name: two objects per request, and a routing callback written against one does not compose with the other.

`RoutingContext` is a non-sealed `public class` with a public constructor, so it is already shaped for that subclass to exist. The base class just never lets one through — both invocation methods hardcode `new RoutingContext(...)`, so whatever a derived class builds cannot reach `SelectClientAsync`. This finishes that rather than introducing a new concept.

Two things worth noting: this is not ambient state, since the context is an explicit parameter to `SelectClientAsync` and `OnRoutingUpdateAsync` and nothing depends on `ExecutionContext` flowing — which is what the `AsyncLocal` suggestion in #7662 was aimed at, without the `SuppressFlow` hazard raised against it there. And `RoutingContext` still clones the caller's options in its constructor, which a subclass has to call, so the caller's instance stays protected either way.

## Trade-offs

- **The downcast is unchecked.** A dictionary is type-safe by construction; a context subclass is reached by casting. That is sound when the router is sealed, as `OrderedFailoverChatClient` is, and weaker when it is not.
- **One context per request, of one type.** Two independent layers cannot each attach state unless one's context derives from the other's. A dictionary has no such constraint. This does not bite today because `FailoverChatClient` stores nothing on the context, but it does mean that if the base class ever wants its own context state, existing derived contexts would have to re-parent.
- **New failure mode.** `CreateContext` can return `null`, so both invocation methods guard for it.

## Changes

- `RoutingChatClient` — adds `CreateContext`; both invocation methods call it, with a `null` guard matching the existing `SelectClientAsync` check.
- `FailoverChatClient` — no new API. It inherits `CreateContext`, and because it declares both invocation methods `sealed override`, the factory is guaranteed to run for its derived types.
- `OrderedFailoverChatClient` — moves its next-client index onto a private context subclass; removes the `ConcurrentDictionary`, the per-call lookups, both cleanup paths, and the `_requestStates.Clear()` in `Dispose`.
- Tests — `CreateContext` coverage at both the `RoutingChatClient` and `FailoverChatClient` levels, including a `null` return; `OrderedFailover_AbandonedStreamDoesNotAffectLaterRequests` replaces the test that used reflection to inspect the removed dictionary.

## Notes

- A derived class that overrides `CreateContext` casts the context back to its own type in `SelectClientAsync`. `OrderedFailoverChatClient` asserts the type rather than checking it at runtime: it is sealed, `FailoverChatClient` seals both invocation methods, and selection and updates are protected, so the only context those methods can receive is the one `CreateContext` produced. Reaching a different type would take a change to the library itself, which the assert catches in Debug.
- Additive and experimental: the virtual has a working default, so existing subclasses are unaffected.
- A generic `RoutingChatClient<TContext>` would remove the downcast, at the cost of a type parameter across the whole hierarchy.

## Validation

- Build clean on all target frameworks, 0 warnings.
- `Microsoft.Extensions.AI.Tests` — 762 passed.
- `Microsoft.Extensions.AI.Abstractions.Tests` — 1646 passed.
- API manifests updated by hand and verified against `MakeApiBaselines.ps1` output.
