### PR TITLE
Pass the request's options to the selected client

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatRouting/RoutingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatRouting/RoutingChatClient.cs
@@ -16,12 +16,20 @@ namespace Microsoft.Extensions.AI;
 /// Provides a template for an <see cref="IChatClient"/> that selects and invokes another chat client.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Derived classes implement <see cref="SelectClientAsync"/> to supply one client for each request. The selected
 /// client is invoked once, and its response or failure is propagated to the caller.
 /// The exact client instance represents the selected routing identity. Caller-supplied options may vary per
 /// invocation, but they are ephemeral and do not participate in that identity. Applications can use distinct
 /// configured client wrappers when configurations require distinct routing identities, while custom policies may
 /// maintain separate application-specific grouping keys.
+/// </para>
+/// <para>
+/// <see cref="RoutingContext.ChatOptions"/> holds the options for the request and is what the selected client
+/// receives. Options that belong to a particular route are configured on the client instead, typically with a
+/// <c>ConfigureOptionsChatClient</c> wrapper, which clones the request options and applies the route's own values
+/// on top of them.
+/// </para>
 /// </remarks>
 [Experimental(DiagnosticIds.Experiments.AIRoutingChat, UrlFormat = DiagnosticIds.UrlFormat)]
 public abstract class RoutingChatClient : IChatClient
@@ -44,8 +52,9 @@ public abstract class RoutingChatClient : IChatClient
     /// <param name="cancellationToken">The cancellation token supplied for the request.</param>
     /// <returns>The client to invoke.</returns>
     /// <remarks>
-    /// Client-specific behavior should generally be attached to the returned client. Exceptions from this method
-    /// propagate to the caller.
+    /// Client-specific behavior should generally be attached to the returned client. Modifying
+    /// <see cref="RoutingContext.ChatOptions"/> changes the options for the request itself, including any later
+    /// invocation of a different client for the same request. Exceptions from this method propagate to the caller.
     /// </remarks>
     protected abstract ValueTask<IChatClient> SelectClientAsync(
         RoutingContext context,
@@ -63,7 +72,7 @@ public abstract class RoutingChatClient : IChatClient
 
         return await client.GetResponseAsync(
             context.Messages,
-            options?.Clone(),
+            context.ChatOptions,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -79,7 +88,7 @@ public abstract class RoutingChatClient : IChatClient
             throw new InvalidOperationException($"{nameof(SelectClientAsync)} returned null.");
 
         await foreach (ChatResponseUpdate update in
-            client.GetStreamingResponseAsync(context.Messages, options?.Clone(), cancellationToken)
+            client.GetStreamingResponseAsync(context.Messages, context.ChatOptions, cancellationToken)
                 .WithCancellation(cancellationToken)
                 .ConfigureAwait(false))
         {

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatRouting/RoutingContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatRouting/RoutingContext.cs
@@ -15,8 +15,9 @@ namespace Microsoft.Extensions.AI;
 /// started from the sequence returned by <see cref="IChatClient.GetStreamingResponseAsync"/>.
 /// </para>
 /// <para>
-/// <see cref="ChatOptions"/> is cloned when the context is created. It is provided for client selection and is
-/// independent of both the caller's instance and the options passed to the selected client.
+/// <see cref="ChatOptions"/> is cloned from the caller's instance when the context is created, so the caller's
+/// instance is never handed to a selected client and changes the caller makes after the request begins are not
+/// observed.
 /// </para>
 /// </remarks>
 [Experimental(DiagnosticIds.Experiments.AIRoutingChat, UrlFormat = DiagnosticIds.UrlFormat)]
@@ -41,10 +42,11 @@ public class RoutingContext
     /// </remarks>
     public IEnumerable<ChatMessage> Messages { get; }
 
-    /// <summary>Gets a snapshot of the request options supplied to client selection.</summary>
+    /// <summary>Gets the options for the request.</summary>
     /// <remarks>
-    /// Changes do not affect the caller's instance or the options passed to the selected client. Client-specific
-    /// behavior should generally be attached to the returned client.
+    /// This is a clone of the caller's options and is what the selected client receives. Modifying it shapes the
+    /// request, including any later invocation of a different client for the same request. Options that belong to a
+    /// particular route should be configured on the client instead.
     /// </remarks>
     public ChatOptions? ChatOptions { get; }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatRouting/RoutingContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatRouting/RoutingContext.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Extensions.AI;
 /// started from the sequence returned by <see cref="IChatClient.GetStreamingResponseAsync"/>.
 /// </para>
 /// <para>
-/// <see cref="ChatOptions"/> is cloned from the caller's instance when the context is created, so the caller's
-/// instance is never handed to a selected client and changes the caller makes after the request begins are not
-/// observed.
+/// <see cref="ChatOptions"/> is cloned (via <see cref="ChatOptions.Clone"/>) from the caller-supplied instance when
+/// the context is created, so that instance is never handed to a selected client and subsequent changes to it are not
+/// observed. The clone is shallow, so referenced objects may still be shared.
 /// </para>
 /// </remarks>
 [Experimental(DiagnosticIds.Experiments.AIRoutingChat, UrlFormat = DiagnosticIds.UrlFormat)]

--- a/src/Libraries/Microsoft.Extensions.AI/ChatRouting/FailoverChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatRouting/FailoverChatClient.cs
@@ -108,7 +108,6 @@ public abstract class FailoverChatClient : RoutingChatClient
             IChatClient selectedClient =
                 await SelectClientAsync(context, cancellationToken).ConfigureAwait(false) ??
                 throw new InvalidOperationException($"{nameof(SelectClientAsync)} returned null.");
-            ChatOptions? attemptOptions = options?.Clone();
 
             attemptCount++;
             ChatResponse? response = null;
@@ -119,7 +118,7 @@ public abstract class FailoverChatClient : RoutingChatClient
             {
                 response = await selectedClient.GetResponseAsync(
                     context.Messages,
-                    attemptOptions,
+                    context.ChatOptions,
                     cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -178,7 +177,6 @@ public abstract class FailoverChatClient : RoutingChatClient
             IChatClient selectedClient =
                 await SelectClientAsync(context, cancellationToken).ConfigureAwait(false) ??
                 throw new InvalidOperationException($"{nameof(SelectClientAsync)} returned null.");
-            ChatOptions? attemptOptions = options?.Clone();
 
             attemptCount++;
             bool reachedAttemptLimit = maximumAttempts is int limit && attemptCount >= limit;
@@ -192,7 +190,7 @@ public abstract class FailoverChatClient : RoutingChatClient
                 enumerator = selectedClient
                     .GetStreamingResponseAsync(
                         context.Messages,
-                        attemptOptions,
+                        context.ChatOptions,
                         cancellationToken)
                     .GetAsyncEnumerator(cancellationToken);
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatRouting/RoutingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatRouting/RoutingChatClientTests.cs
@@ -50,9 +50,8 @@ public class RoutingChatClientTests
         Assert.Same(expected, response);
         Assert.Same(messages, observedContext!.Messages);
         Assert.NotSame(options, observedContext.ChatOptions);
-        Assert.NotSame(observedContext.ChatOptions, forwardedOptions);
-        Assert.Equal("selected", observedContext.ChatOptions!.ModelId);
-        Assert.Equal("request", forwardedOptions!.ModelId);
+        Assert.Same(observedContext.ChatOptions, forwardedOptions);
+        Assert.Equal("selected", forwardedOptions!.ModelId);
         Assert.Equal("request", options.ModelId);
         Assert.Equal(cancellationSource.Token, observedToken);
         Assert.Equal(1, selectionCount);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatRouting/FailoverChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatRouting/FailoverChatClientTests.cs
@@ -320,9 +320,7 @@ public class FailoverChatClientTests
             });
 
         _ = streaming
-            ? await router.GetStreamingResponseAsync(
-                [new(ChatRole.User, "hi")],
-                requestOptions).ToChatResponseAsync()
+            ? await router.GetStreamingResponseAsync([new(ChatRole.User, "hi")], requestOptions).ToChatResponseAsync()
             : await router.GetResponseAsync([new(ChatRole.User, "hi")], requestOptions);
 
         Assert.Same(selectedOptions, invokedOptions[0]);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatRouting/FailoverChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatRouting/FailoverChatClientTests.cs
@@ -230,8 +230,10 @@ public class FailoverChatClientTests
         Assert.Equal("request", requestOptions.ModelId);
     }
 
-    [Fact]
-    public async Task Failover_UsesFreshRequestOptionsForEachAttempt()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Failover_UsesRequestOptionsForEveryAttempt(bool streaming)
     {
         var requestOptions = new ChatOptions
         {
@@ -244,8 +246,12 @@ public class FailoverChatClientTests
             GetResponseAsyncCallback = (_, options, _) =>
             {
                 invokedOptions.Add(options!);
-                options!.ModelId = "changed by first client";
                 throw new InvalidOperationException("failed");
+            },
+            GetStreamingResponseAsyncCallback = (_, options, _) =>
+            {
+                invokedOptions.Add(options!);
+                return ThrowingStream("failed");
             },
         };
         ChatResponse expected = new(new ChatMessage(ChatRole.Assistant, "ok"));
@@ -256,23 +262,74 @@ public class FailoverChatClientTests
                 invokedOptions.Add(options!);
                 return Task.FromResult(expected);
             },
+            GetStreamingResponseAsyncCallback = (_, options, _) =>
+            {
+                invokedOptions.Add(options!);
+                return YieldUpdates("ok");
+            },
         };
         int selections = 0;
         using var router = new DelegatingFailoverTestRouter(
             _ => ++selections == 1 ? first : second);
 
-        ChatResponse response = await router.GetResponseAsync(
-            [new(ChatRole.User, "hi")],
-            requestOptions);
+        ChatResponse response = streaming
+            ? await router.GetStreamingResponseAsync(
+                [new(ChatRole.User, "hi")],
+                requestOptions).ToChatResponseAsync()
+            : await router.GetResponseAsync([new(ChatRole.User, "hi")], requestOptions);
 
-        Assert.Same(expected, response);
+        Assert.Equal("ok", response.Text);
         Assert.Equal(2, selections);
         Assert.Equal(2, invokedOptions.Count);
-        Assert.NotSame(invokedOptions[0], invokedOptions[1]);
-        Assert.Equal("changed by first client", invokedOptions[0].ModelId);
-        Assert.Equal("request", invokedOptions[1].ModelId);
-        Assert.Equal("caller", invokedOptions[1].Instructions);
+
+        // Every attempt receives the request's options, which are a clone of the caller's instance.
+        Assert.Same(invokedOptions[0], invokedOptions[1]);
+        Assert.NotSame(requestOptions, invokedOptions[0]);
+        Assert.Equal("request", invokedOptions[0].ModelId);
+        Assert.Equal("caller", invokedOptions[0].Instructions);
         Assert.Equal("request", requestOptions.ModelId);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Failover_SelectionAndInvocationShareRequestOptions(bool streaming)
+    {
+        var requestOptions = new ChatOptions { ModelId = "request" };
+        var invokedOptions = new List<ChatOptions?>();
+        using var inner = new TestChatClient
+        {
+            GetResponseAsyncCallback = (_, options, _) =>
+            {
+                invokedOptions.Add(options);
+                return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+            },
+            GetStreamingResponseAsyncCallback = (_, options, _) =>
+            {
+                invokedOptions.Add(options);
+                return YieldUpdates("ok");
+            },
+        };
+        ChatOptions? selectedOptions = null;
+        using var router = new DelegatingFailoverTestRouter(
+            context =>
+            {
+                selectedOptions = context.ChatOptions;
+
+                // Mutating the request's options during selection shapes the request.
+                context.ChatOptions!.Temperature = 0.25f;
+                return inner;
+            });
+
+        _ = streaming
+            ? await router.GetStreamingResponseAsync(
+                [new(ChatRole.User, "hi")],
+                requestOptions).ToChatResponseAsync()
+            : await router.GetResponseAsync([new(ChatRole.User, "hi")], requestOptions);
+
+        Assert.Same(selectedOptions, invokedOptions[0]);
+        Assert.Equal(0.25f, invokedOptions[0]!.Temperature);
+        Assert.Null(requestOptions.Temperature);
     }
 
     [Fact]
@@ -600,49 +657,6 @@ public class FailoverChatClientTests
 
         Assert.Equal("ok", response.Text);
         Assert.Equal(2, selections);
-    }
-
-    [Fact]
-    public async Task Streaming_FailoverUsesFreshRequestOptionsForEachAttempt()
-    {
-        var requestOptions = new ChatOptions
-        {
-            Instructions = "caller",
-            ModelId = "request",
-        };
-        var invokedOptions = new List<ChatOptions>();
-        using var first = new TestChatClient
-        {
-            GetStreamingResponseAsyncCallback = (_, options, _) =>
-            {
-                invokedOptions.Add(options!);
-                options!.ModelId = "changed by first client";
-                return ThrowingStream("failed");
-            },
-        };
-        using var second = new TestChatClient
-        {
-            GetStreamingResponseAsyncCallback = (_, options, _) =>
-            {
-                invokedOptions.Add(options!);
-                return YieldUpdates("ok");
-            },
-        };
-        int selections = 0;
-        using var router = new DelegatingFailoverTestRouter(
-            _ => ++selections == 1 ? first : second);
-
-        ChatResponse response = await router.GetStreamingResponseAsync(
-            [new(ChatRole.User, "hi")],
-            requestOptions).ToChatResponseAsync();
-
-        Assert.Equal("ok", response.Text);
-        Assert.Equal(2, selections);
-        Assert.NotSame(invokedOptions[0], invokedOptions[1]);
-        Assert.Equal("changed by first client", invokedOptions[0].ModelId);
-        Assert.Equal("request", invokedOptions[1].ModelId);
-        Assert.Equal("caller", invokedOptions[1].Instructions);
-        Assert.Equal("request", requestOptions.ModelId);
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatRouting/FailoverChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatRouting/FailoverChatClientTests.cs
@@ -273,9 +273,7 @@ public class FailoverChatClientTests
             _ => ++selections == 1 ? first : second);
 
         ChatResponse response = streaming
-            ? await router.GetStreamingResponseAsync(
-                [new(ChatRole.User, "hi")],
-                requestOptions).ToChatResponseAsync()
+            ? await router.GetStreamingResponseAsync([new(ChatRole.User, "hi")], requestOptions).ToChatResponseAsync()
             : await router.GetResponseAsync([new(ChatRole.User, "hi")], requestOptions);
 
         Assert.Equal("ok", response.Text);


### PR DESCRIPTION
Follow-up to #7662. Independent of #7684; whichever merges first, the other rebases.

## The problem

`RoutingContext.ChatOptions` and the options handed to the selected client are two independent clones of the caller's instance:

```
callerOptions
   ├─ clone → context.ChatOptions     once, when the context is created
   ├─ clone → attempt 1's options     inside the failover loop
   └─ clone → attempt 2's options     inside the failover loop
```

Nothing keeps them in sync, and both branch off an object the caller still owns. If the caller mutates its `ChatOptions` while the request is in flight, attempt 2 picks the change up and the context does not — so the selector decides using one set of values while the client receives another. Nothing in the API suggests that two things called "the options" can disagree.

The context's options are also never used for anything but inspection today, which is the tell: they are built, handed to the selector, and then ignored by the invocation path.

## Changes

Pass `context.ChatOptions` to the selected client. One snapshot, taken once, used by both selection and invocation. The caller's instance is still cloned when the context is created and is never handed to a client.

## What this settles

Option shaping now has a clean split, and neither half needs new API:

| | where it lives | scope |
| --- | --- | --- |
| Request-level | `context.ChatOptions` | the whole request, including later attempts |
| Route-level | the selected client | that client only |

Route-level options were always expressed by *which client you return* — a `ConfigureOptionsChatClient` wrapper is a client whose identity encodes its options. The two layers compose without routing doing anything, because `ConfigureOptionsChatClient` clones the incoming options and applies its own on top:

```
caller options
  → context.ChatOptions            request-level; selection may shape
  → selected client
      └ ConfigureOptionsChatClient: clone, apply route options
  → provider
```

That is the merge a `(client, options)` selection result would have required routing to implement, already implemented one layer down.

**This is not a revival of the `RoutingSelection` proposal from #7662.** That proposal was for *per-attempt* options: a selection result carrying options scoped to the one invocation it accompanied, so two attempts in the same request could be shaped differently. What this change enables is the opposite scope — modifying `context.ChatOptions` shapes the *request*, and the change persists into every later attempt, because there is one instance. Per-attempt shaping is still expressed by selecting a different client, which is what `ConfigureOptionsChatClient` wrappers are for.

It also answers the concern raised in #7662 that `context.ChatOptions` was both an input to selection and, because it is mutable, an implicit output. Under this split it is only ever input to *selection* and output for *the request*. Route-specific values never touch it.

## Trade-off

Attempts now share one options instance, so a client that mutates the options it was handed in place would affect a later attempt. Previously each attempt got a fresh clone.

That is worth giving up. No middleware in this repo mutates options it was handed — every clone in the pipeline is transform-driven, on an object the transformer just cloned itself. `FunctionInvokingChatClient` states the rule directly: *"We only need to clone the options if we're actually mutating it."* Same in `ConfigureOptionsChatClient`, `ImageGeneratingChatClient`, and `ChatClientStructuredOutputExtensions`. Routing was the only component paying a per-attempt clone to defend against something the rest of the stack assumes does not happen.

In exchange the rule becomes a single sentence — the options are snapshotted once, when the request begins — instead of two that silently disagree. It is also one clone per request instead of `1 + N`.

## Changes

- `RoutingChatClient` — both invocation methods pass `context.ChatOptions`.
- `FailoverChatClient` — the per-attempt clone is removed; every attempt receives `context.ChatOptions`.
- `RoutingContext.ChatOptions` — documentation no longer describes it as a snapshot independent of what the client receives, since that is now false by design. It states that modifying it shapes the request and that route-specific options belong on the client.
- `RoutingChatClient` and `SelectClientAsync` — documentation describes the request-level / route-level split.
- Tests — `Failover_UsesFreshRequestOptionsForEachAttempt` and its streaming counterpart are replaced by `Failover_UsesRequestOptionsForEveryAttempt` (theory over both paths), which asserts every attempt receives the request's options and that the caller's instance is untouched. `Failover_SelectionAndInvocationShareRequestOptions` covers the fix directly, including shaping during selection. `Create_SelectsClientForRequest` asserted that a selector's mutation did *not* reach the client, and now asserts that it does.

## Validation

- Build clean on all target frameworks, 0 warnings.
- `Microsoft.Extensions.AI.Tests` — 761 passed.
- `Microsoft.Extensions.AI.Abstractions.Tests` — 1643 passed.
- No public API change, so no manifest updates.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7685)