### PR TITLE
Fix DNS SRV provider ignoring query suffix

### DIFF
--- a/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndpointProviderFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndpointProviderFactory.cs
@@ -41,15 +41,15 @@ internal sealed partial class DnsSrvServiceEndpointProviderFactory(
 
         var srvQuery = optionsValue.ServiceDomainNameCallback != null
             ? optionsValue.ServiceDomainNameCallback(query)
-            : DefaultServiceDomainNameCallback(query, optionsValue);
+            : DefaultServiceDomainNameCallback(query, _querySuffix!);
         provider = new DnsSrvServiceEndpointProvider(query, srvQuery, hostName: query.ServiceName, options, logger, resolver, timeProvider);
         return true;
     }
 
-    private static string DefaultServiceDomainNameCallback(ServiceEndpointQuery query, DnsSrvServiceEndpointProviderOptions options)
+    private static string DefaultServiceDomainNameCallback(ServiceEndpointQuery query, string querySuffix)
     {
         var portName = query.EndpointName ?? "default";
-        return $"_{portName}._tcp.{query.ServiceName}.{options.QuerySuffix}";
+        return $"_{portName}._tcp.{query.ServiceName}.{querySuffix}";
     }
 
     private static string? GetKubernetesHostDomain()

--- a/test/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndpointResolverTests.cs
+++ b/test/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndpointResolverTests.cs
@@ -35,7 +35,7 @@ public class DnsSrvServiceEndpointResolverTests
 
     /// <summary>
     /// Regression test for https://github.com/dotnet/extensions/issues/7175: the query suffix used to build the SRV
-    /// query must be the normalized one, which has its leading dot trimmed and falls back to the inferred Kubernetes domain.
+    /// query must be normalized (leading dot trimmed) before composing the SRV query.
     /// </summary>
     [Theory]
     [InlineData(".ns")]

--- a/test/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndpointResolverTests.cs
+++ b/test/Libraries/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndpointResolverTests.cs
@@ -33,6 +33,86 @@ public class DnsSrvServiceEndpointResolverTests
         public ValueTask<ServiceResult[]> ResolveServiceAsync(string name, CancellationToken cancellationToken = default) => ResolveServiceAsyncFunc!.Invoke(name, cancellationToken);
     }
 
+    /// <summary>
+    /// Regression test for https://github.com/dotnet/extensions/issues/7175: the query suffix used to build the SRV
+    /// query must be the normalized one, which has its leading dot trimmed and falls back to the inferred Kubernetes domain.
+    /// </summary>
+    [Theory]
+    [InlineData(".ns")]
+    [InlineData("ns")]
+    public async Task ResolveServiceEndpoint_DnsSrv_UsesQuerySuffix(string querySuffix)
+    {
+        string? srvQuery = null;
+        var dnsClientMock = new FakeDnsResolver
+        {
+            ResolveServiceAsyncFunc = (name, cancellationToken) =>
+            {
+                srvQuery = name;
+                ServiceResult[] response = [
+                    new ServiceResult(DateTime.UtcNow.AddSeconds(60), 99, 66, 8888, "srv-a", [new AddressResult(DateTime.UtcNow.AddSeconds(64), IPAddress.Parse("10.10.10.10"))])
+                ];
+
+                return ValueTask.FromResult(response);
+            }
+        };
+        var services = new ServiceCollection()
+            .AddSingleton<IDnsResolver>(dnsClientMock)
+            .AddServiceDiscoveryCore()
+            .AddDnsSrvServiceEndpointProvider(options => options.QuerySuffix = querySuffix)
+            .BuildServiceProvider();
+        var watcherFactory = services.GetRequiredService<ServiceEndpointWatcherFactory>();
+        ServiceEndpointWatcher watcher;
+        await using ((watcher = watcherFactory.CreateWatcher("http://basket")).ConfigureAwait(false))
+        {
+            var tcs = new TaskCompletionSource<ServiceEndpointResolverResult>();
+            watcher.OnEndpointsUpdated = tcs.SetResult;
+            watcher.Start();
+            var initialResult = await tcs.Task;
+            Assert.True(initialResult.ResolvedSuccessfully);
+        }
+
+        Assert.Equal("_default._tcp.basket.ns", srvQuery);
+    }
+
+    [Fact]
+    public async Task ResolveServiceEndpoint_DnsSrv_ServiceDomainNameCallbackTakesPrecedenceOverQuerySuffix()
+    {
+        string? srvQuery = null;
+        var dnsClientMock = new FakeDnsResolver
+        {
+            ResolveServiceAsyncFunc = (name, cancellationToken) =>
+            {
+                srvQuery = name;
+                ServiceResult[] response = [
+                    new ServiceResult(DateTime.UtcNow.AddSeconds(60), 99, 66, 8888, "srv-a", [new AddressResult(DateTime.UtcNow.AddSeconds(64), IPAddress.Parse("10.10.10.10"))])
+                ];
+
+                return ValueTask.FromResult(response);
+            }
+        };
+        var services = new ServiceCollection()
+            .AddSingleton<IDnsResolver>(dnsClientMock)
+            .AddServiceDiscoveryCore()
+            .AddDnsSrvServiceEndpointProvider(options =>
+            {
+                options.QuerySuffix = ".ns";
+                options.ServiceDomainNameCallback = query => $"{query.ServiceName}.service.consul";
+            })
+            .BuildServiceProvider();
+        var watcherFactory = services.GetRequiredService<ServiceEndpointWatcherFactory>();
+        ServiceEndpointWatcher watcher;
+        await using ((watcher = watcherFactory.CreateWatcher("http://basket")).ConfigureAwait(false))
+        {
+            var tcs = new TaskCompletionSource<ServiceEndpointResolverResult>();
+            watcher.OnEndpointsUpdated = tcs.SetResult;
+            watcher.Start();
+            var initialResult = await tcs.Task;
+            Assert.True(initialResult.ResolvedSuccessfully);
+        }
+
+        Assert.Equal("basket.service.consul", srvQuery);
+    }
+
     [Fact]
     public async Task ResolveServiceEndpoint_DnsSrv()
     {


### PR DESCRIPTION
Fixes #7175

Infer Kubernetes namespace in DnsSrvServiceEndpointProviderFactory.

Add tests for suffix normalization and ServiceDomainNameCallback precedence.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7688)