### PR TITLE
 Fix HTTP client logging config binding 

### DIFF
--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Logging/HttpLoggingServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Logging/HttpLoggingServiceCollectionExtensions.cs
@@ -64,10 +64,8 @@ public static class HttpLoggingServiceCollectionExtensions
         _ = Throw.IfNull(services);
         _ = Throw.IfNull(section);
 
-        _ = services
-            .AddSingleton<IConfigureOptions<LoggingRedactionOptions>>(new LoggingRedactionOptionsConfigureOptions(section))
-            .AddSingleton<IOptionsChangeTokenSource<LoggingRedactionOptions>>(
-                new ConfigurationChangeTokenSource<LoggingRedactionOptions>(section));
+        _ = services.AddSingleton<IConfigureOptions<LoggingRedactionOptions>>(
+            new LoggingRedactionOptionsConfigureOptions(section));
 
         return services.AddHttpLoggingRedaction();
     }

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Logging/HttpLoggingServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Logging/HttpLoggingServiceCollectionExtensions.cs
@@ -6,10 +6,12 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Diagnostics.Logging;
+using Microsoft.AspNetCore.Diagnostics.Logging.Internal;
 using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http.Diagnostics;
+using Microsoft.Extensions.Options;
 using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
@@ -59,9 +61,15 @@ public static class HttpLoggingServiceCollectionExtensions
     [Experimental(diagnosticId: DiagnosticIds.Experiments.HttpLogging, UrlFormat = DiagnosticIds.UrlFormat)]
     public static IServiceCollection AddHttpLoggingRedaction(this IServiceCollection services, IConfigurationSection section)
     {
+        _ = Throw.IfNull(services);
         _ = Throw.IfNull(section);
 
-        return services.AddHttpLoggingRedaction(o => section.Bind(o));
+        _ = services
+            .AddSingleton<IConfigureOptions<LoggingRedactionOptions>>(new LoggingRedactionOptionsConfigureOptions(section))
+            .AddSingleton<IOptionsChangeTokenSource<LoggingRedactionOptions>>(
+                new ConfigurationChangeTokenSource<LoggingRedactionOptions>(section));
+
+        return services.AddHttpLoggingRedaction();
     }
 
     /// <summary>

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Logging/Internal/LoggingRedactionOptionsConfigureOptions.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Logging/Internal/LoggingRedactionOptionsConfigureOptions.cs
@@ -1,62 +1,49 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if NET8_0_OR_GREATER
+
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using Microsoft.Extensions.Compliance.Classification;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Http.Diagnostics;
 using Microsoft.Extensions.Options;
 using Microsoft.Shared.Diagnostics;
 
-namespace Microsoft.Extensions.Http.Logging.Internal;
+namespace Microsoft.AspNetCore.Diagnostics.Logging.Internal;
 
-internal sealed class LoggingOptionsConfigureOptions : IConfigureNamedOptions<LoggingOptions>
+/// <remarks>
+/// The configuration binding source generator ignores the type converter of
+/// <see cref="DataClassification"/>, so the options are bound explicitly.
+/// </remarks>
+internal sealed class LoggingRedactionOptionsConfigureOptions : IConfigureOptions<LoggingRedactionOptions>
 {
 #pragma warning disable EXTEXP0002 // DataClassificationTypeConverter is experimental.
     private static readonly DataClassificationTypeConverter _dataClassificationConverter = new();
 #pragma warning restore EXTEXP0002
 
-    private readonly string? _name;
     private readonly IConfigurationSection _section;
 
-    public LoggingOptionsConfigureOptions(string? name, IConfigurationSection section)
+    public LoggingRedactionOptionsConfigureOptions(IConfigurationSection section)
     {
-        _name = name;
         _section = Throw.IfNull(section);
     }
 
-    void IConfigureOptions<LoggingOptions>.Configure(LoggingOptions options) => Configure(Options.Options.DefaultName, options);
-
-    public void Configure(string? name, LoggingOptions options)
+    public void Configure(LoggingRedactionOptions options)
     {
-        if (!string.Equals(name, _name, StringComparison.Ordinal) || !_section.Exists())
+        if (!_section.Exists())
         {
             return;
         }
 
-        BindValue(_section, nameof(LoggingOptions.LogRequestStart), bool.Parse, value => options.LogRequestStart = value);
-        BindDataClassifications(_section.GetSection(nameof(LoggingOptions.RequestQueryParametersDataClasses)), options.RequestQueryParametersDataClasses);
-        BindValue(_section, nameof(LoggingOptions.LogBody), bool.Parse, value => options.LogBody = value);
-        BindValue(
-            _section,
-            nameof(LoggingOptions.BodySizeLimit),
-            static value => int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture),
-            value => options.BodySizeLimit = value);
-        BindValue(
-            _section,
-            nameof(LoggingOptions.BodyReadTimeout),
-            static value => TimeSpan.Parse(value, CultureInfo.InvariantCulture),
-            value => options.BodyReadTimeout = value);
-        BindSet(_section.GetSection(nameof(LoggingOptions.RequestBodyContentTypes)), options.RequestBodyContentTypes);
-        BindSet(_section.GetSection(nameof(LoggingOptions.ResponseBodyContentTypes)), options.ResponseBodyContentTypes);
-        BindDataClassifications(_section.GetSection(nameof(LoggingOptions.RequestHeadersDataClasses)), options.RequestHeadersDataClasses);
-        BindDataClassifications(_section.GetSection(nameof(LoggingOptions.ResponseHeadersDataClasses)), options.ResponseHeadersDataClasses);
-        BindEnum<OutgoingPathLoggingMode>(_section, nameof(LoggingOptions.RequestPathLoggingMode), value => options.RequestPathLoggingMode = value);
-        BindEnum<HttpRouteParameterRedactionMode>(_section, nameof(LoggingOptions.RequestPathParameterRedactionMode), value => options.RequestPathParameterRedactionMode = value);
-        BindDataClassifications(_section.GetSection(nameof(LoggingOptions.RouteParameterDataClasses)), options.RouteParameterDataClasses);
-        BindValue(_section, nameof(LoggingOptions.LogContentHeaders), bool.Parse, value => options.LogContentHeaders = value);
+        BindEnum<IncomingPathLoggingMode>(_section, nameof(LoggingRedactionOptions.RequestPathLoggingMode), value => options.RequestPathLoggingMode = value);
+        BindEnum<HttpRouteParameterRedactionMode>(_section, nameof(LoggingRedactionOptions.RequestPathParameterRedactionMode), value => options.RequestPathParameterRedactionMode = value);
+        BindDataClassifications(_section.GetSection(nameof(LoggingRedactionOptions.RouteParameterDataClasses)), options.RouteParameterDataClasses);
+        BindDataClassifications(_section.GetSection(nameof(LoggingRedactionOptions.RequestHeadersDataClasses)), options.RequestHeadersDataClasses);
+        BindDataClassifications(_section.GetSection(nameof(LoggingRedactionOptions.ResponseHeadersDataClasses)), options.ResponseHeadersDataClasses);
+        BindSet(_section.GetSection(nameof(LoggingRedactionOptions.ExcludePathStartsWith)), options.ExcludePathStartsWith);
+        BindValue(_section, nameof(LoggingRedactionOptions.IncludeUnmatchedRoutes), bool.Parse, value => options.IncludeUnmatchedRoutes = value);
     }
 
     private static void BindSet(IConfigurationSection section, ISet<string> destination)
@@ -132,3 +119,5 @@ internal sealed class LoggingOptionsConfigureOptions : IConfigureNamedOptions<Lo
     private static InvalidOperationException CreateBindingException(string path, Type type, Exception innerException)
         => new($"Failed to convert configuration value at '{path}' to type '{type}'.", innerException);
 }
+
+#endif

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Logging/Internal/LoggingRedactionOptionsConfigureOptions.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Logging/Internal/LoggingRedactionOptionsConfigureOptions.cs
@@ -67,6 +67,7 @@ internal sealed class LoggingRedactionOptionsConfigureOptions : IConfigureOption
 
     private static DataClassification ParseDataClassification(IConfigurationSection section)
     {
+        // A classification is either a string ("None", "Unknown" or "Taxonomy:Value") or a { TaxonomyName, Value } object.
         try
         {
 #pragma warning disable EXTEXP0002 // DataClassificationTypeConverter is experimental.
@@ -76,7 +77,6 @@ internal sealed class LoggingRedactionOptionsConfigureOptions : IConfigureOption
             }
 #pragma warning restore EXTEXP0002
 
-            // The configuration binding source generator used to accept the object form, so it stays supported.
             return new DataClassification(
                 section[nameof(DataClassification.TaxonomyName)]!,
                 section[nameof(DataClassification.Value)]!);
@@ -115,7 +115,7 @@ internal sealed class LoggingRedactionOptionsConfigureOptions : IConfigureOption
         }
     }
 
-    // Deliberately excludes the offending value: configuration can hold secrets.
+    // Only the path is reported, since a configuration value may be a secret.
     private static InvalidOperationException CreateBindingException(string path, Type type, Exception innerException)
         => new($"Failed to convert configuration value at '{path}' to type '{type}'.", innerException);
 }

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Logging/Internal/LoggingRedactionOptionsConfigureOptions.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Logging/Internal/LoggingRedactionOptionsConfigureOptions.cs
@@ -14,8 +14,9 @@ using Microsoft.Shared.Diagnostics;
 namespace Microsoft.AspNetCore.Diagnostics.Logging.Internal;
 
 /// <remarks>
-/// The configuration binding source generator ignores the type converter of
-/// <see cref="DataClassification"/>, so the options are bound explicitly.
+/// This is a workaround for <see href="https://github.com/dotnet/runtime/issues/83599">dotnet/runtime#83599</see>
+/// and can be removed when the configuration binding source generator supports custom conversion for
+/// <see cref="DataClassification"/>.
 /// </remarks>
 internal sealed class LoggingRedactionOptionsConfigureOptions : IConfigureOptions<LoggingRedactionOptions>
 {

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/HttpClientLoggingHttpClientBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/HttpClientLoggingHttpClientBuilderExtensions.cs
@@ -76,7 +76,7 @@ public static class HttpClientLoggingHttpClientBuilderExtensions
         _ = Throw.IfNull(builder);
         _ = Throw.IfNull(section);
 
-        return AddExtendedHttpClientLoggingInternal(builder, options => options.Bind(section), wrapHandlersPipeline: true);
+        return AddExtendedHttpClientLoggingInternal(builder, options => options.BindConfigurationSection(section), wrapHandlersPipeline: true);
     }
 
     /// <summary>
@@ -100,7 +100,7 @@ public static class HttpClientLoggingHttpClientBuilderExtensions
         _ = Throw.IfNull(builder);
         _ = Throw.IfNull(section);
 
-        return AddExtendedHttpClientLoggingInternal(builder, options => options.Bind(section), wrapHandlersPipeline);
+        return AddExtendedHttpClientLoggingInternal(builder, options => options.BindConfigurationSection(section), wrapHandlersPipeline);
     }
 
     /// <summary>

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/HttpClientLoggingServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/HttpClientLoggingServiceCollectionExtensions.cs
@@ -65,7 +65,7 @@ public static class HttpClientLoggingServiceCollectionExtensions
 
         _ = services
             .AddOptionsWithValidateOnStart<LoggingOptions, LoggingOptionsValidator>()
-            .Bind(section);
+            .BindConfigurationSection(section);
 
         return services.AddExtendedHttpClientLogging();
     }

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggingOptionsBinder.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggingOptionsBinder.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Http.Logging.Internal;
+
+internal static class LoggingOptionsBinder
+{
+    /// <summary>
+    /// Binds <see cref="LoggingOptions"/> to a configuration section.
+    /// </summary>
+    /// <param name="builder">The options builder.</param>
+    /// <param name="section">The configuration section to bind to.</param>
+    /// <returns>The value of <paramref name="builder"/>.</returns>
+    /// <remarks>
+    /// A dedicated configurator is used because the configuration binding source generator doesn't honor the
+    /// type converter used by <see cref="Compliance.Classification.DataClassification"/>.
+    /// </remarks>
+    public static OptionsBuilder<LoggingOptions> BindConfigurationSection(this OptionsBuilder<LoggingOptions> builder, IConfigurationSection section)
+    {
+        _ = builder.Services
+            .AddSingleton<IConfigureOptions<LoggingOptions>>(
+                new LoggingOptionsConfigureOptions(builder.Name, section))
+            .AddSingleton<IOptionsChangeTokenSource<LoggingOptions>>(
+                new ConfigurationChangeTokenSource<LoggingOptions>(builder.Name, section));
+
+        return builder;
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggingOptionsBinder.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggingOptionsBinder.cs
@@ -16,8 +16,9 @@ internal static class LoggingOptionsBinder
     /// <param name="section">The configuration section to bind to.</param>
     /// <returns>The value of <paramref name="builder"/>.</returns>
     /// <remarks>
-    /// A dedicated configurator is used because the configuration binding source generator doesn't honor the
-    /// type converter used by <see cref="Compliance.Classification.DataClassification"/>.
+    /// This is a workaround for <see href="https://github.com/dotnet/runtime/issues/83599">dotnet/runtime#83599</see>.
+    /// The dedicated configurator can be removed when the configuration binding source generator supports custom
+    /// conversion for <see cref="Microsoft.Extensions.Compliance.Classification.DataClassification"/>.
     /// </remarks>
     public static OptionsBuilder<LoggingOptions> BindConfigurationSection(this OptionsBuilder<LoggingOptions> builder, IConfigurationSection section)
     {

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggingOptionsConfigureOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggingOptionsConfigureOptions.cs
@@ -12,6 +12,11 @@ using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.Http.Logging.Internal;
 
+/// <remarks>
+/// This is a workaround for <see href="https://github.com/dotnet/runtime/issues/83599">dotnet/runtime#83599</see>
+/// and can be removed when the configuration binding source generator supports custom conversion for
+/// <see cref="DataClassification"/>.
+/// </remarks>
 internal sealed class LoggingOptionsConfigureOptions : IConfigureNamedOptions<LoggingOptions>
 {
 #pragma warning disable EXTEXP0002 // DataClassificationTypeConverter is experimental.

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggingOptionsConfigureOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggingOptionsConfigureOptions.cs
@@ -1,0 +1,152 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Extensions.Compliance.Classification;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Http.Diagnostics;
+using Microsoft.Extensions.Options;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.Http.Logging.Internal;
+
+internal sealed class LoggingOptionsConfigureOptions : IConfigureNamedOptions<LoggingOptions>
+{
+    private readonly string? _name;
+    private readonly IConfigurationSection _section;
+
+    public LoggingOptionsConfigureOptions(string? name, IConfigurationSection section)
+    {
+        _name = name;
+        _section = Throw.IfNull(section);
+    }
+
+    public void Configure(LoggingOptions options) => Configure(global::Microsoft.Extensions.Options.Options.DefaultName, options);
+
+    public void Configure(string? name, LoggingOptions options)
+    {
+        _ = Throw.IfNull(options);
+
+        if (!string.Equals(name, _name, StringComparison.Ordinal) || !_section.Exists())
+        {
+            return;
+        }
+
+        BindValue(_section, nameof(LoggingOptions.LogRequestStart), bool.Parse, value => options.LogRequestStart = value);
+        BindDataClassifications(_section.GetSection(nameof(LoggingOptions.RequestQueryParametersDataClasses)), options.RequestQueryParametersDataClasses);
+        BindValue(_section, nameof(LoggingOptions.LogBody), bool.Parse, value => options.LogBody = value);
+        BindValue(
+            _section,
+            nameof(LoggingOptions.BodySizeLimit),
+            static value => int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture),
+            value => options.BodySizeLimit = value);
+        BindValue(
+            _section,
+            nameof(LoggingOptions.BodyReadTimeout),
+            static value => TimeSpan.Parse(value, CultureInfo.InvariantCulture),
+            value => options.BodyReadTimeout = value);
+        BindSet(_section.GetSection(nameof(LoggingOptions.RequestBodyContentTypes)), options.RequestBodyContentTypes);
+        BindSet(_section.GetSection(nameof(LoggingOptions.ResponseBodyContentTypes)), options.ResponseBodyContentTypes);
+        BindDataClassifications(_section.GetSection(nameof(LoggingOptions.RequestHeadersDataClasses)), options.RequestHeadersDataClasses);
+        BindDataClassifications(_section.GetSection(nameof(LoggingOptions.ResponseHeadersDataClasses)), options.ResponseHeadersDataClasses);
+        BindEnum<OutgoingPathLoggingMode>(_section, nameof(LoggingOptions.RequestPathLoggingMode), value => options.RequestPathLoggingMode = value);
+        BindEnum<HttpRouteParameterRedactionMode>(_section, nameof(LoggingOptions.RequestPathParameterRedactionMode), value => options.RequestPathParameterRedactionMode = value);
+        BindDataClassifications(_section.GetSection(nameof(LoggingOptions.RouteParameterDataClasses)), options.RouteParameterDataClasses);
+        BindValue(_section, nameof(LoggingOptions.LogContentHeaders), bool.Parse, value => options.LogContentHeaders = value);
+    }
+
+    private static void BindSet(IConfigurationSection section, ISet<string> destination)
+    {
+        foreach (IConfigurationSection child in section.GetChildren())
+        {
+            if (child.Value is string value)
+            {
+                _ = destination.Add(value);
+            }
+        }
+    }
+
+    private static void BindDataClassifications(IConfigurationSection section, IDictionary<string, DataClassification> destination)
+    {
+        foreach (IConfigurationSection child in section.GetChildren())
+        {
+            destination[child.Key] = ParseDataClassification(child);
+        }
+    }
+
+    private static DataClassification ParseDataClassification(IConfigurationSection section)
+    {
+        if (section.Value is string value)
+        {
+            try
+            {
+                if (value == nameof(DataClassification.None))
+                {
+                    return DataClassification.None;
+                }
+
+                if (value == nameof(DataClassification.Unknown))
+                {
+                    return DataClassification.Unknown;
+                }
+
+                int delimiterIndex = value.IndexOf(":", StringComparison.Ordinal);
+                if (delimiterIndex > 0 && delimiterIndex < value.Length - 1)
+                {
+                    return new DataClassification(value.Substring(0, delimiterIndex), value.Substring(delimiterIndex + 1));
+                }
+
+                throw new FormatException($"Invalid data classification format: '{value}'.");
+            }
+            catch (Exception exception)
+            {
+                throw CreateBindingException(value, section.Path, typeof(DataClassification), exception);
+            }
+        }
+
+        string? taxonomyName = section[nameof(DataClassification.TaxonomyName)];
+        string? classificationValue = section[nameof(DataClassification.Value)];
+
+        try
+        {
+            return new DataClassification(taxonomyName!, classificationValue!);
+        }
+        catch (Exception exception)
+        {
+            throw CreateBindingException(section.Value, section.Path, typeof(DataClassification), exception);
+        }
+    }
+
+    private static void BindEnum<TEnum>(IConfigurationSection section, string key, Action<TEnum> setter)
+        where TEnum : struct
+        => BindValue(section, key, ParseEnum<TEnum>, setter);
+
+    private static TEnum ParseEnum<TEnum>(string value)
+        where TEnum : struct
+        => Enum.TryParse(value, ignoreCase: true, out TEnum result)
+            ? result
+            : throw new FormatException($"'{value}' is not a valid value for {typeof(TEnum)}.");
+
+    private static void BindValue<T>(IConfigurationSection section, string key, Func<string, T> parser, Action<T> setter)
+    {
+        IConfigurationSection valueSection = section.GetSection(key);
+        if (valueSection.Value is not string value)
+        {
+            return;
+        }
+
+        try
+        {
+            setter(parser(value));
+        }
+        catch (Exception exception)
+        {
+            throw CreateBindingException(value, valueSection.Path, typeof(T), exception);
+        }
+    }
+
+    private static InvalidOperationException CreateBindingException(string? value, string path, Type type, Exception innerException)
+        => new($"Failed to convert configuration value '{value ?? "null"}' at '{path}' to type '{type}'.", innerException);
+}

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggingOptionsConfigureOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggingOptionsConfigureOptions.cs
@@ -80,6 +80,7 @@ internal sealed class LoggingOptionsConfigureOptions : IConfigureNamedOptions<Lo
 
     private static DataClassification ParseDataClassification(IConfigurationSection section)
     {
+        // A classification is either a string ("None", "Unknown" or "Taxonomy:Value") or a { TaxonomyName, Value } object.
         try
         {
 #pragma warning disable EXTEXP0002 // DataClassificationTypeConverter is experimental.
@@ -89,7 +90,6 @@ internal sealed class LoggingOptionsConfigureOptions : IConfigureNamedOptions<Lo
             }
 #pragma warning restore EXTEXP0002
 
-            // The configuration binding source generator used to accept the object form, so it stays supported.
             return new DataClassification(
                 section[nameof(DataClassification.TaxonomyName)]!,
                 section[nameof(DataClassification.Value)]!);
@@ -128,7 +128,7 @@ internal sealed class LoggingOptionsConfigureOptions : IConfigureNamedOptions<Lo
         }
     }
 
-    // Deliberately excludes the offending value: configuration can hold secrets.
+    // Only the path is reported, since a configuration value may be a secret.
     private static InvalidOperationException CreateBindingException(string path, Type type, Exception innerException)
         => new($"Failed to convert configuration value at '{path}' to type '{type}'.", innerException);
 }

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Logging/HttpLoggingServiceExtensionsTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Logging/HttpLoggingServiceExtensionsTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Compliance.Classification;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -50,6 +51,107 @@ public class HttpLoggingServiceExtensionsTests
 
         Assert.Contains("/path0toexclude", options.ExcludePathStartsWith);
         Assert.Contains("/path1toexclude", options.ExcludePathStartsWith);
+    }
+
+    [Fact]
+    public void AddHttpLogging_WhenDataClassesConfiguredUsingConfigurationSection_IsCorrect()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[]
+        {
+            new KeyValuePair<string, string?>("HttpLogging:IncludeUnmatchedRoutes", "true"),
+            new KeyValuePair<string, string?>("HttpLogging:ExcludePathStartsWith:[0]", "/probe/live"),
+            new KeyValuePair<string, string?>("HttpLogging:ExcludePathStartsWith:[1]", null),
+            new KeyValuePair<string, string?>("HttpLogging:RequestPathLoggingMode", "Structured"),
+            new KeyValuePair<string, string?>("HttpLogging:RequestPathParameterRedactionMode", "None"),
+            new KeyValuePair<string, string?>("HttpLogging:RequestHeadersDataClasses:User-Agent", "None"),
+            new KeyValuePair<string, string?>("HttpLogging:ResponseHeadersDataClasses:Content-Type", "Unknown"),
+            new KeyValuePair<string, string?>("HttpLogging:RouteParameterDataClasses:userId", "MyTaxonomy:EUII"),
+            new KeyValuePair<string, string?>("HttpLogging:RouteParameterDataClasses:userContent:TaxonomyName", "MyTaxonomy"),
+            new KeyValuePair<string, string?>("HttpLogging:RouteParameterDataClasses:userContent:Value", "CustomerContent"),
+        }).Build();
+        var configurationSection = configuration.GetSection("HttpLogging");
+
+        services.AddHttpLoggingRedaction(configurationSection);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<LoggingRedactionOptions>>().Value;
+
+        Assert.Equal(
+            typeof(LoggingRedactionOptions).GetProperties()
+                .Where(property => property.SetMethod?.IsPublic is true)
+                .Select(property => property.Name)
+                .OrderBy(name => name, StringComparer.Ordinal),
+            configurationSection.GetChildren()
+                .Select(child => child.Key)
+                .OrderBy(name => name, StringComparer.Ordinal));
+        Assert.True(options.IncludeUnmatchedRoutes);
+        Assert.Contains("/probe/live", options.ExcludePathStartsWith);
+        Assert.Equal(IncomingPathLoggingMode.Structured, options.RequestPathLoggingMode);
+        Assert.Equal(HttpRouteParameterRedactionMode.None, options.RequestPathParameterRedactionMode);
+        Assert.Equal(DataClassification.None, options.RequestHeadersDataClasses["User-Agent"]);
+        Assert.Equal(DataClassification.Unknown, options.ResponseHeadersDataClasses["Content-Type"]);
+        Assert.Equal(new DataClassification("MyTaxonomy", "EUII"), options.RouteParameterDataClasses["userId"]);
+        Assert.Equal(new DataClassification("MyTaxonomy", "CustomerContent"), options.RouteParameterDataClasses["userContent"]);
+    }
+
+    [Fact]
+    public void AddHttpLogging_WhenDataClassIsInvalid_Throws()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[]
+        {
+            new KeyValuePair<string, string?>("HttpLogging:RequestHeadersDataClasses:User-Agent", "invalid"),
+        }).Build();
+
+        services.AddHttpLoggingRedaction(configuration.GetSection("HttpLogging"));
+
+        using var provider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => provider.GetRequiredService<IOptions<LoggingRedactionOptions>>().Value);
+
+        Assert.Contains("HttpLogging:RequestHeadersDataClasses:User-Agent", exception.Message);
+    }
+
+    [Fact]
+    public void AddHttpLogging_WhenScalarValueIsInvalid_Throws()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[]
+        {
+            new KeyValuePair<string, string?>("HttpLogging:RequestPathLoggingMode", "invalid"),
+        }).Build();
+
+        services.AddHttpLoggingRedaction(configuration.GetSection("HttpLogging"));
+
+        using var provider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => provider.GetRequiredService<IOptions<LoggingRedactionOptions>>().Value);
+
+        Assert.Contains("HttpLogging:RequestPathLoggingMode", exception.Message);
+    }
+
+    [Fact]
+    public void AddHttpLogging_WhenConfigurationSectionIsMissing_UsesDefaults()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddHttpLoggingRedaction(configuration.GetSection("Missing"));
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<LoggingRedactionOptions>>().Value;
+        var defaults = new LoggingRedactionOptions();
+
+        Assert.Equal(defaults.RequestPathLoggingMode, options.RequestPathLoggingMode);
+        Assert.Equal(defaults.RequestPathParameterRedactionMode, options.RequestPathParameterRedactionMode);
+        Assert.Empty(options.RouteParameterDataClasses);
+        Assert.Empty(options.RequestHeadersDataClasses);
+        Assert.Empty(options.ResponseHeadersDataClasses);
+        Assert.Empty(options.ExcludePathStartsWith);
+        Assert.Equal(defaults.IncludeUnmatchedRoutes, options.IncludeUnmatchedRoutes);
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpClientLoggingExtensionsTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpClientLoggingExtensionsTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -18,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Hosting.Testing;
 using Microsoft.Extensions.Http.Diagnostics;
+using Microsoft.Extensions.Http.Logging.Internal;
 using Microsoft.Extensions.Http.Logging.Test.Internal;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -254,6 +256,7 @@ public class HttpClientLoggingExtensionsTest
                 [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.BodySizeLimit)}"] = "1024",
                 [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.BodyReadTimeout)}"] = "00:00:02",
                 [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestBodyContentTypes)}:0"] = "application/json",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestBodyContentTypes)}:1"] = null,
                 [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.ResponseBodyContentTypes)}:0"] = "text/plain",
                 [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestHeadersDataClasses)}:User-Agent"] = "None",
                 [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.ResponseHeadersDataClasses)}:Content-Type"] = "Unknown",
@@ -263,15 +266,20 @@ public class HttpClientLoggingExtensionsTest
                 [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.LogContentHeaders)}"] = "true",
             })
             .Build();
+        var configurationSection = configuration.GetSection(nameof(LoggingOptions));
 
         using var provider = new ServiceCollection()
             .AddHttpClient("test")
-            .AddExtendedHttpClientLogging(configuration.GetSection(nameof(LoggingOptions)))
+            .AddExtendedHttpClientLogging(configurationSection)
             .Services
             .BuildServiceProvider();
 
         var options = provider.GetRequiredService<IOptionsMonitor<LoggingOptions>>().Get("test");
 
+        configurationSection.GetChildren().Select(child => child.Key).Should().BeEquivalentTo(
+            typeof(LoggingOptions).GetProperties()
+                .Where(property => property.SetMethod?.IsPublic is true)
+                .Select(property => property.Name));
         options.LogRequestStart.Should().BeTrue();
         options.RequestQueryParametersDataClasses.Should().Contain("search", new DataClassification("MyTaxonomy", "PrivateData"));
         options.LogBody.Should().BeTrue();
@@ -285,6 +293,43 @@ public class HttpClientLoggingExtensionsTest
         options.RequestPathParameterRedactionMode.Should().Be(HttpRouteParameterRedactionMode.None);
         options.RouteParameterDataClasses.Should().Contain("userId", new DataClassification("MyTaxonomy", "EUII"));
         options.LogContentHeaders.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LoggingOptionsConfigureOptions_HandlesOptionNamesAndMissingSections()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.BodySizeLimit)}"] = "1024",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.LogBody)}"] = "false",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.LogContentHeaders)}"] = "false",
+            })
+            .Build();
+        var section = configuration.GetSection(nameof(LoggingOptions));
+        int defaultBodySizeLimit = new LoggingOptions().BodySizeLimit;
+
+        var defaultOptions = new LoggingOptions
+        {
+            LogBody = true,
+            LogContentHeaders = true,
+        };
+        var defaultConfigurator = new LoggingOptionsConfigureOptions(Microsoft.Extensions.Options.Options.DefaultName, section);
+        ((IConfigureOptions<LoggingOptions>)defaultConfigurator).Configure(defaultOptions);
+
+        defaultOptions.BodySizeLimit.Should().Be(1024);
+        defaultOptions.LogBody.Should().BeFalse();
+        defaultOptions.LogContentHeaders.Should().BeFalse();
+
+        var mismatchedOptions = new LoggingOptions();
+        new LoggingOptionsConfigureOptions("test", section).Configure("other", mismatchedOptions);
+
+        mismatchedOptions.BodySizeLimit.Should().Be(defaultBodySizeLimit);
+
+        var missingSectionOptions = new LoggingOptions();
+        new LoggingOptionsConfigureOptions("test", configuration.GetSection("Missing")).Configure("test", missingSectionOptions);
+
+        missingSectionOptions.BodySizeLimit.Should().Be(defaultBodySizeLimit);
     }
 
     [Fact]
@@ -357,6 +402,28 @@ public class HttpClientLoggingExtensionsTest
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*LoggingOptions:RequestHeadersDataClasses:User-Agent*");
+    }
+
+    [Fact]
+    public void AddHttpClientLogging_GivenInvalidScalarValue_Throws()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestPathLoggingMode)}"] = "invalid",
+            })
+            .Build();
+
+        using var provider = new ServiceCollection()
+            .AddHttpClient("test")
+            .AddExtendedHttpClientLogging(configuration.GetSection(nameof(LoggingOptions)))
+            .Services
+            .BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IOptionsMonitor<LoggingOptions>>().Get("test");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*LoggingOptions:RequestPathLoggingMode*");
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpClientLoggingExtensionsTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpClientLoggingExtensionsTest.cs
@@ -240,6 +240,103 @@ public class HttpClientLoggingExtensionsTest
     }
 
     [Fact]
+    public void AddHttpClientLogging_GivenConfigurationSection_BindsDataClasses()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.LogRequestStart)}"] = "true",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestQueryParametersDataClasses)}:search:{nameof(DataClassification.TaxonomyName)}"] = "MyTaxonomy",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestQueryParametersDataClasses)}:search:{nameof(DataClassification.Value)}"] = "PrivateData",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.LogBody)}"] = "true",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.BodySizeLimit)}"] = "1024",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.BodyReadTimeout)}"] = "00:00:02",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestBodyContentTypes)}:0"] = "application/json",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.ResponseBodyContentTypes)}:0"] = "text/plain",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestHeadersDataClasses)}:User-Agent"] = "None",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.ResponseHeadersDataClasses)}:Content-Type"] = "Unknown",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestPathLoggingMode)}"] = "Structured",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestPathParameterRedactionMode)}"] = "None",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RouteParameterDataClasses)}:userId"] = "MyTaxonomy:EUII",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.LogContentHeaders)}"] = "true",
+            })
+            .Build();
+
+        using var provider = new ServiceCollection()
+            .AddHttpClient("test")
+            .AddExtendedHttpClientLogging(configuration.GetSection(nameof(LoggingOptions)))
+            .Services
+            .BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptionsMonitor<LoggingOptions>>().Get("test");
+
+        options.LogRequestStart.Should().BeTrue();
+        options.RequestQueryParametersDataClasses.Should().Contain("search", new DataClassification("MyTaxonomy", "PrivateData"));
+        options.LogBody.Should().BeTrue();
+        options.BodySizeLimit.Should().Be(1024);
+        options.BodyReadTimeout.Should().Be(TimeSpan.FromSeconds(2));
+        options.RequestBodyContentTypes.Should().ContainSingle("application/json");
+        options.ResponseBodyContentTypes.Should().ContainSingle("text/plain");
+        options.RequestHeadersDataClasses.Should().Contain("User-Agent", DataClassification.None);
+        options.ResponseHeadersDataClasses.Should().Contain("Content-Type", DataClassification.Unknown);
+        options.RequestPathLoggingMode.Should().Be(OutgoingPathLoggingMode.Structured);
+        options.RequestPathParameterRedactionMode.Should().Be(HttpRouteParameterRedactionMode.None);
+        options.RouteParameterDataClasses.Should().Contain("userId", new DataClassification("MyTaxonomy", "EUII"));
+        options.LogContentHeaders.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddHttpClientLogging_GivenInvalidDataClassification_Throws()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestHeadersDataClasses)}:User-Agent"] = "invalid",
+            })
+            .Build();
+
+        using var provider = new ServiceCollection()
+            .AddHttpClient("test")
+            .AddExtendedHttpClientLogging(configuration.GetSection(nameof(LoggingOptions)))
+            .Services
+            .BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IOptionsMonitor<LoggingOptions>>().Get("test");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*LoggingOptions:RequestHeadersDataClasses:User-Agent*");
+    }
+
+    [Fact]
+    public void AddHttpClientLogging_GivenConfigurationReload_UpdatesOptions()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.BodySizeLimit)}"] = "1024",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestHeadersDataClasses)}:User-Agent"] = "None",
+            })
+            .Build();
+
+        using var provider = new ServiceCollection()
+            .AddHttpClient("test")
+            .AddExtendedHttpClientLogging(configuration.GetSection(nameof(LoggingOptions)))
+            .Services
+            .BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<LoggingOptions>>();
+
+        options.Get("test").BodySizeLimit.Should().Be(1024);
+        options.Get("test").RequestHeadersDataClasses.Should().Contain("User-Agent", DataClassification.None);
+
+        configuration[$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.BodySizeLimit)}"] = "2048";
+        configuration[$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestHeadersDataClasses)}:User-Agent"] = "Unknown";
+        configuration.Reload();
+
+        options.Get("test").BodySizeLimit.Should().Be(2048);
+        options.Get("test").RequestHeadersDataClasses.Should().Contain("User-Agent", DataClassification.Unknown);
+    }
+
+    [Fact]
     public void AddHttpClientLogEnricher_RegistersEnricherInDI()
     {
         using var provider = new ServiceCollection()
@@ -390,6 +487,32 @@ public class HttpClientLoggingExtensionsTest
 
         using var httpClient = provider.GetRequiredService<IHttpClientFactory>().CreateClient();
         Assert.NotNull(httpClient);
+    }
+
+    [Fact]
+    public void AddHttpClientLogging_ServiceCollection_GivenConfigurationSection_BindsDataClasses()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestQueryParametersDataClasses)}:search"] = "MyTaxonomy:PrivateData",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RequestHeadersDataClasses)}:User-Agent"] = "None",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.ResponseHeadersDataClasses)}:Content-Type"] = "Unknown",
+                [$"{nameof(LoggingOptions)}:{nameof(LoggingOptions.RouteParameterDataClasses)}:userId"] = "MyTaxonomy:EUII",
+            })
+            .Build();
+
+        using var provider = new ServiceCollection()
+            .AddHttpClient()
+            .AddExtendedHttpClientLogging(configuration.GetSection(nameof(LoggingOptions)))
+            .BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<LoggingOptions>>().Value;
+
+        options.RequestQueryParametersDataClasses.Should().Contain("search", new DataClassification("MyTaxonomy", "PrivateData"));
+        options.RequestHeadersDataClasses.Should().Contain("User-Agent", DataClassification.None);
+        options.ResponseHeadersDataClasses.Should().Contain("Content-Type", DataClassification.Unknown);
+        options.RouteParameterDataClasses.Should().Contain("userId", new DataClassification("MyTaxonomy", "EUII"));
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpClientLoggingExtensionsTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpClientLoggingExtensionsTest.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture;
@@ -275,14 +277,64 @@ public class HttpClientLoggingExtensionsTest
         options.LogBody.Should().BeTrue();
         options.BodySizeLimit.Should().Be(1024);
         options.BodyReadTimeout.Should().Be(TimeSpan.FromSeconds(2));
-        options.RequestBodyContentTypes.Should().ContainSingle("application/json");
-        options.ResponseBodyContentTypes.Should().ContainSingle("text/plain");
+        options.RequestBodyContentTypes.Should().Equal("application/json");
+        options.ResponseBodyContentTypes.Should().Equal("text/plain");
         options.RequestHeadersDataClasses.Should().Contain("User-Agent", DataClassification.None);
         options.ResponseHeadersDataClasses.Should().Contain("Content-Type", DataClassification.Unknown);
         options.RequestPathLoggingMode.Should().Be(OutgoingPathLoggingMode.Structured);
         options.RequestPathParameterRedactionMode.Should().Be(HttpRouteParameterRedactionMode.None);
         options.RouteParameterDataClasses.Should().Contain("userId", new DataClassification("MyTaxonomy", "EUII"));
         options.LogContentHeaders.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddHttpClientLogging_GivenDocumentedConfigurationSample_CreatesClient()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("""
+        {
+          "HttpClientLogging": {
+            "LogRequestStart": false,
+            "LogBody": false,
+            "BodySizeLimit": 32768,
+            "BodyReadTimeout": "00:00:01",
+            "RequestHeadersDataClasses": {
+              "User-Agent": "None",
+              "Content-Type": "None"
+            },
+            "ResponseHeadersDataClasses": {
+              "Content-Type": "None"
+            },
+            "RequestPathLoggingMode": "Formatted",
+            "RequestPathParameterRedactionMode": "Strict"
+          }
+        }
+        """));
+
+        var configuration = new ConfigurationBuilder()
+            .AddJsonStream(stream)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRedaction();
+        services.AddHttpClient("test")
+            .AddExtendedHttpClientLogging(configuration.GetSection("HttpClientLogging"));
+
+        using var provider = services.BuildServiceProvider();
+
+        using var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("test");
+        client.Should().NotBeNull();
+
+        var options = provider.GetRequiredService<IOptionsMonitor<LoggingOptions>>().Get("test");
+        options.LogRequestStart.Should().BeFalse();
+        options.LogBody.Should().BeFalse();
+        options.BodySizeLimit.Should().Be(32768);
+        options.BodyReadTimeout.Should().Be(TimeSpan.FromSeconds(1));
+        options.RequestHeadersDataClasses.Should().Contain("User-Agent", DataClassification.None);
+        options.RequestHeadersDataClasses.Should().Contain("Content-Type", DataClassification.None);
+        options.ResponseHeadersDataClasses.Should().Contain("Content-Type", DataClassification.None);
+        options.RequestPathLoggingMode.Should().Be(OutgoingPathLoggingMode.Formatted);
+        options.RequestPathParameterRedactionMode.Should().Be(HttpRouteParameterRedactionMode.Strict);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #7551

Use a static options configurator instead of generated configuration
binding. The generated binder treats DataClassification values as complex
objects because it does not honor their type converter.

Preserve named options and configuration reload support. Add regression
coverage for both registration paths, supported classification formats,
invalid values, and reloads.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7691)