### PR TITLE
Fix ChatResponseUpdate.Clone dropping ContinuationToken

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseUpdate.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseUpdate.cs
@@ -71,6 +71,7 @@ public class ChatResponseUpdate
             AdditionalProperties = AdditionalProperties,
             AuthorName = AuthorName,
             Contents = Contents,
+            ContinuationToken = ContinuationToken,
             CreatedAt = CreatedAt,
             ConversationId = ConversationId,
             FinishReason = FinishReason,

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseUpdateTests.cs
@@ -246,12 +246,14 @@ public class ChatResponseUpdateTests
         var originalContents = new List<AIContent> { new TextContent("text1"), new TextContent("text2") };
         var originalRawRepresentation = new object();
         var originalCreatedAt = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var originalContinuationToken = ResponseContinuationToken.FromBytes(new byte[] { 1, 2, 3 });
 
         var original = new ChatResponseUpdate
         {
             AdditionalProperties = originalAdditionalProperties,
             AuthorName = "author",
             Contents = originalContents,
+            ContinuationToken = originalContinuationToken,
             CreatedAt = originalCreatedAt,
             ConversationId = "conv123",
             FinishReason = ChatFinishReason.ContentFilter,
@@ -282,6 +284,7 @@ public class ChatResponseUpdateTests
         Assert.Same(original.AdditionalProperties, clone.AdditionalProperties);
         Assert.Same(original.Contents, clone.Contents);
         Assert.Same(original.RawRepresentation, clone.RawRepresentation);
+        Assert.Same(original.ContinuationToken, clone.ContinuationToken);
     }
 
     [Fact]


### PR DESCRIPTION
`ChatResponseUpdate.Clone()` assigns every settable property on the type except `ContinuationToken`, so the token is silently dropped from the clone. The doc comment says the result is "a new ChatResponseUpdate object with the same property values as the current instance", and `ContinuationToken` predates `Clone()`, so this reads as an omission rather than a deliberate exclusion.

It is reachable in the box. `ImageGeneratingChatClient.GetStreamingResponseAsync` clones an update whenever it rewrites that update's contents, and yields the clone in place of the original, so for those updates the consumer sees `ContinuationToken == null`. The remarks on `ChatResponseUpdate.ContinuationToken` tell callers to pass the token from the latest received update to `ChatOptions.ContinuationToken` in order to resume an interrupted background stream, which a clone cannot support.

Fix: copy `ContinuationToken` in `Clone()`.

Validation: extended the existing `Clone_CreatesShallowCopy` test to set and assert `ContinuationToken`. Against unmodified sources it fails with

```
Assert.Same() Failure: Values are not the same instance
Expected: ResponseContinuationToken { }
Actual:   null
```

and passes with the change. `Microsoft.Extensions.AI.Abstractions.Tests`: 1642 passed, 0 failed, 1 skipped. `Microsoft.Extensions.AI.Tests`: 761 passed, 0 failed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7699)