### PR TITLE
[MEAI] Add OpenTelemetry GenAI semantic convention selection

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -78,6 +78,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     /// <summary>The <see cref="ActivitySource"/> to use for telemetry.</summary>
     /// <remarks>This component does not own the instance and should not dispose it.</remarks>
     private readonly ActivitySource? _activitySource;
+    private readonly OpenTelemetryGenAISemanticConvention _defaultSemanticConvention;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FunctionInvokingChatClient"/> class.
@@ -90,6 +91,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     {
         _logger = (ILogger?)loggerFactory?.CreateLogger<FunctionInvokingChatClient>() ?? NullLogger.Instance;
         _activitySource = innerClient.GetService<ActivitySource>();
+        _defaultSemanticConvention = TelemetryHelpers.GetGenAISemanticConventionDefault();
         FunctionInvocationServices = functionInvocationServices;
     }
 
@@ -101,7 +103,12 @@ public class FunctionInvokingChatClient : DelegatingChatClient
         invokeAgentActivity =>
             invokeAgentActivity is not null
                 ? invokeAgentActivity.GetCustomProperty(OpenTelemetryChatClient.SensitiveDataEnabledCustomKey) as string is OpenTelemetryChatClient.SensitiveDataEnabledTrueValue
-                : InnerClient.GetService<OpenTelemetryChatClient>()?.EnableSensitiveData is true);
+                : InnerClient.GetService<OpenTelemetryChatClient>()?.EnableSensitiveData is true,
+        invokeAgentActivity =>
+            invokeAgentActivity?.GetCustomProperty(OpenTelemetryChatClient.SemanticConventionCustomKey) is OpenTelemetryGenAISemanticConvention semanticConvention ?
+                semanticConvention :
+                InnerClient.GetService<OpenTelemetryChatClient>()?.SemanticConvention ??
+                    _defaultSemanticConvention);
 
     /// <summary>
     /// Gets or sets the <see cref="FunctionInvocationContext"/> for the current function invocation.

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -11,6 +12,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 #pragma warning disable CA1307 // Specify StringComparison for clarity
@@ -22,13 +24,17 @@ namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a delegating chat client that implements the OpenTelemetry Semantic Conventions for Generative AI systems.</summary>
 /// <remarks>
-/// This class provides an implementation of the Semantic Conventions for Generative AI systems v1.41, defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
-/// The specification is still experimental and subject to change; as such, the telemetry output by this client is also subject to change.
+/// This class provides implementations of the OpenTelemetry GenAI Semantic Conventions, beginning with v1.36,
+/// defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
+/// The conventions have Development status and are subject to change; as such, the telemetry output by this client is also subject to change.
 /// </remarks>
 public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
 {
+    private const LogLevel EventLogLevel = LogLevel.Information;
+
     internal const string SensitiveDataEnabledCustomKey = "__EnableSensitiveData__";
     internal const string SensitiveDataEnabledTrueValue = "true";
+    internal const string SemanticConventionCustomKey = "__GenAISemanticConvention__";
 
     private readonly ActivitySource _activitySource;
     private readonly Meter _meter;
@@ -46,6 +52,12 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
     private readonly int _serverPort;
 
     private JsonSerializerOptions _jsonSerializerOptions;
+
+    private static string? GetV136MessageContent(IEnumerable<AIContent> contents)
+    {
+        string content = string.Concat(contents.OfType<TextContent>());
+        return content.Length > 0 ? content : null;
+    }
 
     /// <summary>Initializes a new instance of the <see cref="OpenTelemetryChatClient"/> class.</summary>
     /// <param name="innerClient">The underlying <see cref="IChatClient"/>.</param>
@@ -126,6 +138,18 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
     /// </remarks>
     public bool EnableSensitiveData { get; set; } = TelemetryHelpers.EnableSensitiveDataDefault;
 
+    /// <summary>Gets or sets the OpenTelemetry GenAI semantic convention representation to emit.</summary>
+    /// <value>
+    /// The default is <see cref="OpenTelemetryGenAISemanticConvention.LatestExperimental"/> when
+    /// <c>OTEL_SEMCONV_STABILITY_OPT_IN</c> is not defined. When the variable is defined, a list containing
+    /// <c>gen_ai_latest_experimental</c> selects <see cref="OpenTelemetryGenAISemanticConvention.LatestExperimental"/>;
+    /// otherwise, it selects <see cref="OpenTelemetryGenAISemanticConvention.Version1_36"/>.
+    /// Explicitly setting this property overrides the environment variable for this instance.
+    /// </value>
+    [Experimental(DiagnosticIds.Experiments.AIOpenTelemetryGenAISemanticConvention, UrlFormat = DiagnosticIds.UrlFormat)]
+    public OpenTelemetryGenAISemanticConvention SemanticConvention { get; set; } =
+        TelemetryHelpers.GetGenAISemanticConventionDefault();
+
     /// <inheritdoc/>
     public override object? GetService(Type serviceType, object? serviceKey = null) =>
         serviceType == typeof(ActivitySource) ? _activitySource :
@@ -142,7 +166,7 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
         Stopwatch? stopwatch = _operationDurationHistogram.Enabled ? Stopwatch.StartNew() : null;
         string? requestModelId = options?.ModelId ?? _defaultModelId;
 
-        AddInputMessagesTags(messages, options, activity);
+        TraceInputMessages(messages, options, activity);
 
         ChatResponse? response = null;
         Exception? error = null;
@@ -170,11 +194,13 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
         _jsonSerializerOptions.MakeReadOnly();
 
         using Activity? activity = CreateAndConfigureActivity(options, streaming: true);
-        bool recordChunkHistograms = _timeToFirstChunkHistogram.Enabled || _timePerOutputChunkHistogram.Enabled;
+        bool recordChunkHistograms =
+            SemanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental &&
+            (_timeToFirstChunkHistogram.Enabled || _timePerOutputChunkHistogram.Enabled);
         Stopwatch? stopwatch = _operationDurationHistogram.Enabled || recordChunkHistograms || activity is not null ? Stopwatch.StartNew() : null;
         string? requestModelId = options?.ModelId ?? _defaultModelId;
 
-        AddInputMessagesTags(messages, options, activity);
+        TraceInputMessages(messages, options, activity);
 
         IAsyncEnumerable<ChatResponseUpdate> updates;
         try
@@ -282,6 +308,8 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
                 string.IsNullOrWhiteSpace(modelId) ? OpenTelemetryConsts.GenAI.ChatName : $"{OpenTelemetryConsts.GenAI.ChatName} {modelId}",
                 ActivityKind.Client);
 
+            activity?.SetCustomProperty(SemanticConventionCustomKey, SemanticConvention);
+
             if (EnableSensitiveData)
             {
                 activity?.SetCustomProperty(SensitiveDataEnabledCustomKey, SensitiveDataEnabledTrueValue);
@@ -292,9 +320,9 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
                 _ = activity
                     .AddTag(OpenTelemetryConsts.GenAI.Operation.Name, OpenTelemetryConsts.GenAI.ChatName)
                     .AddTag(OpenTelemetryConsts.GenAI.Request.Model, modelId)
-                    .AddTag(OpenTelemetryConsts.GenAI.Provider.Name, _providerName);
+                    .AddTag(TelemetryHelpers.GetGenAIProviderAttributeName(SemanticConvention), _providerName);
 
-                if (streaming)
+                if (streaming && SemanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental)
                 {
                     _ = activity.AddTag(OpenTelemetryConsts.GenAI.Request.Stream, true);
                 }
@@ -366,7 +394,8 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
                         }
                     }
 
-                    if (options.Tools is { Count: > 0 })
+                    if (SemanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental &&
+                        options.Tools is { Count: > 0 })
                     {
                         _ = activity.AddTag(
                             OpenTelemetryConsts.GenAI.Tool.Definitions,
@@ -381,7 +410,11 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
                         {
                             foreach (KeyValuePair<string, object?> prop in props)
                             {
-                                _ = activity.AddTag(prop.Key, prop.Value);
+                                string key =
+                                    SemanticConvention == OpenTelemetryGenAISemanticConvention.Version1_36 && _providerName is not null ?
+                                        OpenTelemetryConsts.GenAI.Request.PerProvider(_providerName, JsonNamingPolicy.SnakeCaseLower.ConvertName(prop.Key)) :
+                                        prop.Key;
+                                _ = activity.AddTag(key, prop.Value);
                             }
                         }
                     }
@@ -437,7 +470,7 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
 
         if (response is not null)
         {
-            AddOutputMessagesTags(response, activity);
+            TraceOutputMessages(response, activity);
 
             if (activity is not null)
             {
@@ -458,7 +491,8 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
                     _ = activity.AddTag(OpenTelemetryConsts.GenAI.Response.Model, response.ModelId);
                 }
 
-                if (timeToFirstChunk is double timeToFirstChunkValue)
+                if (SemanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental &&
+                    timeToFirstChunk is double timeToFirstChunkValue)
                 {
                     _ = activity.AddTag(OpenTelemetryConsts.GenAI.Response.TimeToFirstChunk, timeToFirstChunkValue);
                 }
@@ -473,12 +507,14 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
                     _ = activity.AddTag(OpenTelemetryConsts.GenAI.Usage.OutputTokens, (int)outputTokens);
                 }
 
-                if (response.Usage?.CachedInputTokenCount is long cachedInputTokens)
+                if (SemanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental &&
+                    response.Usage?.CachedInputTokenCount is long cachedInputTokens)
                 {
                     _ = activity.AddTag(OpenTelemetryConsts.GenAI.Usage.CacheReadInputTokens, (int)cachedInputTokens);
                 }
 
-                if (response.Usage?.ReasoningTokenCount is long reasoningTokens)
+                if (SemanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental &&
+                    response.Usage?.ReasoningTokenCount is long reasoningTokens)
                 {
                     _ = activity.AddTag(OpenTelemetryConsts.GenAI.Usage.ReasoningOutputTokens, (int)reasoningTokens);
                 }
@@ -489,7 +525,11 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
                 {
                     foreach (KeyValuePair<string, object?> prop in props)
                     {
-                        _ = activity.AddTag(prop.Key, prop.Value);
+                        string key =
+                            SemanticConvention == OpenTelemetryGenAISemanticConvention.Version1_36 && _providerName is not null ?
+                                OpenTelemetryConsts.GenAI.Response.PerProvider(_providerName, JsonNamingPolicy.SnakeCaseLower.ConvertName(prop.Key)) :
+                                prop.Key;
+                        _ = activity.AddTag(key, prop.Value);
                     }
                 }
             }
@@ -505,7 +545,7 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
             tags.Add(OpenTelemetryConsts.GenAI.Request.Model, requestModelId);
         }
 
-        tags.Add(OpenTelemetryConsts.GenAI.Provider.Name, _providerName);
+        tags.Add(TelemetryHelpers.GetGenAIProviderAttributeName(SemanticConvention), _providerName);
 
         if (_serverAddress is string endpointAddress)
         {
@@ -516,6 +556,30 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
         if (response?.ModelId is string responseModel)
         {
             tags.Add(OpenTelemetryConsts.GenAI.Response.Model, responseModel);
+        }
+    }
+
+    private void TraceInputMessages(IEnumerable<ChatMessage> messages, ChatOptions? options, Activity? activity)
+    {
+        if (SemanticConvention == OpenTelemetryGenAISemanticConvention.Version1_36)
+        {
+            LogV136InputMessageEvents(messages, options?.Instructions);
+        }
+        else
+        {
+            AddInputMessagesTags(messages, options, activity);
+        }
+    }
+
+    private void TraceOutputMessages(ChatResponse response, Activity? activity)
+    {
+        if (SemanticConvention == OpenTelemetryGenAISemanticConvention.Version1_36)
+        {
+            LogV136OutputMessageEvents(response);
+        }
+        else
+        {
+            AddOutputMessagesTags(response, activity);
         }
     }
 
@@ -546,64 +610,124 @@ public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
         }
     }
 
-    // Chat-specific OTel serialization POCOs.
-    //
-    // Types whose layout is shared 1:1 with OpenTelemetryRealtimeClientSession live in
-    // Common/OtelMessageParts.cs. The types below are either entirely chat-specific or
-    // contain chat-specific fields. The shared JsonSerializerContext lives in Common/OtelContext.cs,
-    // and the shared serialization helpers live in Common/OtelMessageSerializer.cs.
-}
+    private void LogV136InputMessageEvents(IEnumerable<ChatMessage> messages, string? instructions)
+    {
+        if (!EnableSensitiveData || _logger?.IsEnabled(EventLogLevel) is not true)
+        {
+            return;
+        }
 
-#pragma warning disable SA1402 // File may only contain a single type — chat-specific OTel POCOs are co-located with the chat client.
+        if (!string.IsNullOrWhiteSpace(instructions))
+        {
+            LogV136Event(
+                new(1, OpenTelemetryConsts.GenAI.System.Message),
+                JsonSerializer.Serialize(
+                    new OtelV136.SystemOrUserEvent { Content = instructions },
+                    OtelMessageSerializer.DefaultOptions.GetTypeInfo(typeof(OtelV136.SystemOrUserEvent))));
+        }
 
-internal sealed class OtelMessage
-{
-    public string? Role { get; set; }
-    public string? Name { get; set; }
-    public List<object> Parts { get; set; } = [];
-    public string? FinishReason { get; set; }
-}
+        foreach (ChatMessage message in messages)
+        {
+            if (message.Role == ChatRole.Assistant)
+            {
+                LogV136Event(
+                    new(1, OpenTelemetryConsts.GenAI.Assistant.Message),
+                    JsonSerializer.Serialize(
+                        CreateV136AssistantEvent(message.Contents),
+                        OtelMessageSerializer.DefaultOptions.GetTypeInfo(typeof(OtelV136.AssistantEvent))));
+            }
+            else if (message.Role == ChatRole.Tool)
+            {
+                foreach (FunctionResultContent functionResult in message.Contents.OfType<FunctionResultContent>())
+                {
+                    LogV136Event(
+                        new(1, OpenTelemetryConsts.GenAI.Tool.Message),
+                        JsonSerializer.Serialize(
+                            new OtelV136.ToolEvent
+                            {
+                                Id = functionResult.CallId,
+                                Content = functionResult.Result is object result ?
+                                    JsonSerializer.SerializeToNode(result, _jsonSerializerOptions.GetTypeInfo(result.GetType())) :
+                                    null,
+                            },
+                            OtelMessageSerializer.DefaultOptions.GetTypeInfo(typeof(OtelV136.ToolEvent))));
+                }
+            }
+            else
+            {
+                LogV136Event(
+                    new(1, message.Role == ChatRole.System ? OpenTelemetryConsts.GenAI.System.Message : OpenTelemetryConsts.GenAI.User.Message),
+                    JsonSerializer.Serialize(
+                        new OtelV136.SystemOrUserEvent
+                        {
+                            Role =
+                                message.Role != ChatRole.System &&
+                                message.Role != ChatRole.User &&
+                                !string.IsNullOrWhiteSpace(message.Role.Value) ?
+                                    message.Role.Value :
+                                    null,
+                            Content = GetV136MessageContent(message.Contents),
+                        },
+                        OtelMessageSerializer.DefaultOptions.GetTypeInfo(typeof(OtelV136.SystemOrUserEvent))));
+            }
+        }
+    }
 
-internal sealed class OtelToolCallRequestPart
-{
-    public string Type { get; set; } = "tool_call";
-    public string? Id { get; set; }
-    public string? Name { get; set; }
-    public IDictionary<string, object?>? Arguments { get; set; }
-}
+    private void LogV136OutputMessageEvents(ChatResponse response)
+    {
+        if (!EnableSensitiveData || _logger?.IsEnabled(EventLogLevel) is not true)
+        {
+            return;
+        }
 
-internal sealed class OtelCodeInterpreterToolCall
-{
-    public string Type { get; set; } = "code_interpreter";
-    public string? Code { get; set; }
-}
+        IEnumerable<AIContent> contents =
+            response.Messages is { Count: 1 } ?
+                response.Messages[0].Contents :
+                response.Messages.SelectMany(message => message.Contents);
 
-internal sealed class OtelCodeInterpreterToolCallResponse
-{
-    public string Type { get; set; } = "code_interpreter";
-    public object? Output { get; set; }
-}
+        LogV136Event(
+            new(1, OpenTelemetryConsts.GenAI.Choice),
+            JsonSerializer.Serialize(
+                new OtelV136.ChoiceEvent
+                {
+                    FinishReason = response.FinishReason?.Value ?? "error",
+                    Index = 0,
+                    Message = CreateV136AssistantEvent(contents),
+                },
+                OtelMessageSerializer.DefaultOptions.GetTypeInfo(typeof(OtelV136.ChoiceEvent))));
+    }
 
-internal sealed class OtelImageGenerationToolCall
-{
-    public string Type { get; set; } = "image_generation";
-}
+    private void LogV136Event(EventId id, [StringSyntax(StringSyntaxAttribute.Json)] string eventBodyJson)
+    {
+        Debug.Assert(_logger is not null, "The caller verified that the logger is enabled.");
 
-internal sealed class OtelImageGenerationToolCallResponse
-{
-    public string Type { get; set; } = "image_generation";
-    public object? Output { get; set; }
-}
+        KeyValuePair<string, object?>[] tags =
+        [
+            new(OpenTelemetryConsts.Event.Name, id.Name),
+            new(OpenTelemetryConsts.GenAI.SystemName, _providerName),
+        ];
 
-internal sealed class OtelMcpApprovalRequest
-{
-    public string Type { get; set; } = "mcp_approval_request";
-    public string? ServerName { get; set; }
-    public IDictionary<string, object?>? Arguments { get; set; }
-}
+        _logger!.Log(EventLogLevel, id, tags, null, (_, _) => eventBodyJson);
+    }
 
-internal sealed class OtelMcpApprovalResponse
-{
-    public string Type { get; set; } = "mcp_approval_response";
-    public bool Approved { get; set; }
+    private OtelV136.AssistantEvent CreateV136AssistantEvent(IEnumerable<AIContent> contents)
+    {
+        var toolCalls = contents.OfType<FunctionCallContent>().Select(functionCall => new OtelV136.ToolCall
+        {
+            Id = functionCall.CallId,
+            Function = new()
+            {
+                Name = functionCall.Name,
+                Arguments = JsonSerializer.SerializeToNode(
+                    functionCall.Arguments,
+                    _jsonSerializerOptions.GetTypeInfo(typeof(IDictionary<string, object?>))),
+            },
+        }).ToArray();
+
+        return new()
+        {
+            Content = GetV136MessageContent(contents),
+            ToolCalls = toolCalls.Length > 0 ? toolCalls : null,
+        };
+    }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClientBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClientBuilderExtensions.cs
@@ -17,6 +17,11 @@ public static class OpenTelemetryChatClientBuilderExtensions
     /// <remarks>
     /// The draft specification this follows is available at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
     /// The specification is still experimental and subject to change; as such, the telemetry output by this client is also subject to change.
+    /// <para>
+    /// When <c>OTEL_SEMCONV_STABILITY_OPT_IN</c> is not defined, the client preserves the latest experimental representation.
+    /// When the variable is defined, include <c>gen_ai_latest_experimental</c> to select that representation; otherwise, the client
+    /// emits the v1.36 representation. The <paramref name="configure"/> callback can override this selection.
+    /// </para>
     /// </remarks>
     /// <param name="builder">The <see cref="ChatClientBuilder"/>.</param>
     /// <param name="loggerFactory">An optional <see cref="ILoggerFactory"/> to use to create a logger for logging events.</param>

--- a/src/Libraries/Microsoft.Extensions.AI/Common/FunctionInvocationProcessor.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Common/FunctionInvocationProcessor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -24,6 +24,7 @@ internal sealed class FunctionInvocationProcessor
     private readonly ActivitySource? _activitySource;
     private readonly Func<FunctionInvocationContext, CancellationToken, ValueTask<object?>> _invokeFunction;
     private readonly Func<Activity?, bool> _isSensitiveDataEnabled;
+    private readonly Func<Activity?, OpenTelemetryGenAISemanticConvention> _getSemanticConvention;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FunctionInvocationProcessor"/> class.
@@ -36,16 +37,19 @@ internal sealed class FunctionInvocationProcessor
     /// Receives the invoke agent activity (or null if not in agent context).
     /// Returns true if sensitive data should be logged/tagged, false otherwise.
     /// </param>
+    /// <param name="getSemanticConvention">A delegate that gets the semantic convention representation for the invocation.</param>
     public FunctionInvocationProcessor(
         ILogger logger,
         ActivitySource? activitySource,
         Func<FunctionInvocationContext, CancellationToken, ValueTask<object?>> invokeFunction,
-        Func<Activity?, bool>? isSensitiveDataEnabled = null)
+        Func<Activity?, bool>? isSensitiveDataEnabled = null,
+        Func<Activity?, OpenTelemetryGenAISemanticConvention>? getSemanticConvention = null)
     {
         _logger = logger;
         _activitySource = activitySource;
         _invokeFunction = invokeFunction;
         _isSensitiveDataEnabled = isSensitiveDataEnabled ?? (_ => false);
+        _getSemanticConvention = getSemanticConvention ?? (_ => OpenTelemetryGenAISemanticConvention.LatestExperimental);
     }
 
     /// <summary>
@@ -156,18 +160,26 @@ internal sealed class FunctionInvocationProcessor
     {
         Activity? invokeAgentActivity = FunctionInvocationHelpers.CurrentActivityIsInvokeAgent ? Activity.Current : null;
         ActivitySource? source = invokeAgentActivity?.Source ?? _activitySource;
+        OpenTelemetryGenAISemanticConvention semanticConvention = _getSemanticConvention(invokeAgentActivity);
+
+        ActivityTagsCollection tags =
+        [
+            new(OpenTelemetryConsts.GenAI.Operation.Name, OpenTelemetryConsts.GenAI.ExecuteToolName),
+            new(OpenTelemetryConsts.GenAI.Tool.Call.Id, context.CallContent.CallId),
+            new(OpenTelemetryConsts.GenAI.Tool.Name, context.Function.Name),
+            new(OpenTelemetryConsts.GenAI.Tool.Description, context.Function.Description),
+        ];
+
+        if (semanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental)
+        {
+            tags.Add(OpenTelemetryConsts.GenAI.Tool.Type, OpenTelemetryConsts.ToolTypeFunction);
+        }
 
         using Activity? activity = source?.StartActivity(
             $"{OpenTelemetryConsts.GenAI.ExecuteToolName} {context.Function.Name}",
             ActivityKind.Internal,
             default(ActivityContext),
-            [
-                new(OpenTelemetryConsts.GenAI.Operation.Name, OpenTelemetryConsts.GenAI.ExecuteToolName),
-                new(OpenTelemetryConsts.GenAI.Tool.Type, OpenTelemetryConsts.ToolTypeFunction),
-                new(OpenTelemetryConsts.GenAI.Tool.Call.Id, context.CallContent.CallId),
-                new(OpenTelemetryConsts.GenAI.Tool.Name, context.Function.Name),
-                new(OpenTelemetryConsts.GenAI.Tool.Description, context.Function.Description),
-            ]);
+            tags);
 
         long startingTimestamp = Stopwatch.GetTimestamp();
 
@@ -181,7 +193,7 @@ internal sealed class FunctionInvocationProcessor
         {
             string functionArguments = TelemetryHelpers.AsJson(context.Arguments, context.Function.JsonSerializerOptions);
 
-            if (enableSensitiveData)
+            if (enableSensitiveData && semanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental)
             {
                 _ = activity?.SetTag(OpenTelemetryConsts.GenAI.Tool.Call.Arguments, functionArguments);
             }
@@ -229,7 +241,7 @@ internal sealed class FunctionInvocationProcessor
             {
                 string functionResult = TelemetryHelpers.AsJson(result, context.Function.JsonSerializerOptions);
 
-                if (enableSensitiveData)
+                if (enableSensitiveData && semanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental)
                 {
                     _ = activity?.SetTag(OpenTelemetryConsts.GenAI.Tool.Call.Result, functionResult);
                 }

--- a/src/Libraries/Microsoft.Extensions.AI/Common/OtelContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Common/OtelContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -24,17 +24,23 @@ namespace Microsoft.Extensions.AI;
 [JsonSerializable(typeof(OtelToolCallResponsePart))]
 [JsonSerializable(typeof(IEnumerable<OtelFunction>))]
 
-// Chat-specific
-[JsonSerializable(typeof(OtelMessage))]
-[JsonSerializable(typeof(OtelToolCallRequestPart))]
-[JsonSerializable(typeof(OtelServerToolCallPart<OtelCodeInterpreterToolCall>))]
-[JsonSerializable(typeof(OtelServerToolCallResponsePart<OtelCodeInterpreterToolCallResponse>))]
-[JsonSerializable(typeof(OtelServerToolCallPart<OtelImageGenerationToolCall>))]
-[JsonSerializable(typeof(OtelServerToolCallResponsePart<OtelImageGenerationToolCallResponse>))]
+// Latest experimental chat representation
+[JsonSerializable(typeof(OtelLatest.Message))]
+[JsonSerializable(typeof(OtelLatest.ToolCallRequestPart))]
+[JsonSerializable(typeof(OtelServerToolCallPart<OtelLatest.CodeInterpreterToolCall>))]
+[JsonSerializable(typeof(OtelServerToolCallResponsePart<OtelLatest.CodeInterpreterToolCallResponse>))]
+[JsonSerializable(typeof(OtelServerToolCallPart<OtelLatest.ImageGenerationToolCall>))]
+[JsonSerializable(typeof(OtelServerToolCallResponsePart<OtelLatest.ImageGenerationToolCallResponse>))]
 [JsonSerializable(typeof(OtelServerToolCallPart<OtelMcpToolCall>))]
 [JsonSerializable(typeof(OtelServerToolCallResponsePart<OtelMcpToolCallResponse>))]
-[JsonSerializable(typeof(OtelServerToolCallPart<OtelMcpApprovalRequest>))]
-[JsonSerializable(typeof(OtelServerToolCallResponsePart<OtelMcpApprovalResponse>))]
+[JsonSerializable(typeof(OtelServerToolCallPart<OtelLatest.McpApprovalRequest>))]
+[JsonSerializable(typeof(OtelServerToolCallResponsePart<OtelLatest.McpApprovalResponse>))]
+
+// v1.36 chat representation
+[JsonSerializable(typeof(OtelV136.SystemOrUserEvent))]
+[JsonSerializable(typeof(OtelV136.AssistantEvent))]
+[JsonSerializable(typeof(OtelV136.ToolEvent))]
+[JsonSerializable(typeof(OtelV136.ChoiceEvent))]
 
 // Realtime-specific
 [JsonSerializable(typeof(IEnumerable<RealtimeOtelMessage>))]

--- a/src/Libraries/Microsoft.Extensions.AI/Common/OtelLatest.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Common/OtelLatest.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Serialization models for the latest experimental GenAI semantic convention representation.</summary>
+internal static class OtelLatest
+{
+    internal sealed class Message
+    {
+        public string? Role { get; set; }
+        public string? Name { get; set; }
+        public List<object> Parts { get; set; } = [];
+        public string? FinishReason { get; set; }
+    }
+
+    internal sealed class ToolCallRequestPart
+    {
+        public string Type { get; set; } = "tool_call";
+        public string? Id { get; set; }
+        public string? Name { get; set; }
+        public IDictionary<string, object?>? Arguments { get; set; }
+    }
+
+    internal sealed class CodeInterpreterToolCall
+    {
+        public string Type { get; set; } = "code_interpreter";
+        public string? Code { get; set; }
+    }
+
+    internal sealed class CodeInterpreterToolCallResponse
+    {
+        public string Type { get; set; } = "code_interpreter";
+        public object? Output { get; set; }
+    }
+
+    internal sealed class ImageGenerationToolCall
+    {
+        public string Type { get; set; } = "image_generation";
+    }
+
+    internal sealed class ImageGenerationToolCallResponse
+    {
+        public string Type { get; set; } = "image_generation";
+        public object? Output { get; set; }
+    }
+
+    internal sealed class McpApprovalRequest
+    {
+        public string Type { get; set; } = "mcp_approval_request";
+        public string? ServerName { get; set; }
+        public IDictionary<string, object?>? Arguments { get; set; }
+    }
+
+    internal sealed class McpApprovalResponse
+    {
+        public string Type { get; set; } = "mcp_approval_response";
+        public bool Approved { get; set; }
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI/Common/OtelMessageSerializer.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Common/OtelMessageSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -49,7 +49,7 @@ internal static class OtelMessageSerializer
 
         foreach (ChatMessage message in messages)
         {
-            OtelMessage m = new()
+            OtelLatest.Message m = new()
             {
                 FinishReason = finishReason,
                 Role =
@@ -75,7 +75,7 @@ internal static class OtelMessageSerializer
                         break;
 
                     case FunctionCallContent fcc:
-                        m.Parts.Add(new OtelToolCallRequestPart
+                        m.Parts.Add(new OtelLatest.ToolCallRequestPart
                         {
                             Id = fcc.CallId,
                             Name = fcc.Name,
@@ -131,11 +131,11 @@ internal static class OtelMessageSerializer
                     // Server tool call content types as specified in the OpenTelemetry semantic conventions:
 
                     case CodeInterpreterToolCallContent citcc:
-                        m.Parts.Add(new OtelServerToolCallPart<OtelCodeInterpreterToolCall>
+                        m.Parts.Add(new OtelServerToolCallPart<OtelLatest.CodeInterpreterToolCall>
                         {
                             Id = citcc.CallId,
                             Name = "code_interpreter",
-                            ServerToolCall = new OtelCodeInterpreterToolCall
+                            ServerToolCall = new OtelLatest.CodeInterpreterToolCall
                             {
                                 Code = ExtractCodeFromInputs(citcc.Inputs),
                             },
@@ -143,10 +143,10 @@ internal static class OtelMessageSerializer
                         break;
 
                     case CodeInterpreterToolResultContent citrc:
-                        m.Parts.Add(new OtelServerToolCallResponsePart<OtelCodeInterpreterToolCallResponse>
+                        m.Parts.Add(new OtelServerToolCallResponsePart<OtelLatest.CodeInterpreterToolCallResponse>
                         {
                             Id = citrc.CallId,
-                            ServerToolCallResponse = new OtelCodeInterpreterToolCallResponse
+                            ServerToolCallResponse = new OtelLatest.CodeInterpreterToolCallResponse
                             {
                                 Output = citrc.Outputs,
                             },
@@ -154,19 +154,19 @@ internal static class OtelMessageSerializer
                         break;
 
                     case ImageGenerationToolCallContent igtcc:
-                        m.Parts.Add(new OtelServerToolCallPart<OtelImageGenerationToolCall>
+                        m.Parts.Add(new OtelServerToolCallPart<OtelLatest.ImageGenerationToolCall>
                         {
                             Id = igtcc.CallId,
                             Name = "image_generation",
-                            ServerToolCall = new OtelImageGenerationToolCall(),
+                            ServerToolCall = new OtelLatest.ImageGenerationToolCall(),
                         });
                         break;
 
                     case ImageGenerationToolResultContent igtrc:
-                        m.Parts.Add(new OtelServerToolCallResponsePart<OtelImageGenerationToolCallResponse>
+                        m.Parts.Add(new OtelServerToolCallResponsePart<OtelLatest.ImageGenerationToolCallResponse>
                         {
                             Id = igtrc.CallId,
-                            ServerToolCallResponse = new OtelImageGenerationToolCallResponse
+                            ServerToolCallResponse = new OtelLatest.ImageGenerationToolCallResponse
                             {
                                 Output = igtrc.Outputs,
                             },
@@ -198,11 +198,11 @@ internal static class OtelMessageSerializer
                         break;
 
                     case ToolApprovalRequestContent fareqc when fareqc.ToolCall is McpServerToolCallContent mcpToolCall:
-                        m.Parts.Add(new OtelServerToolCallPart<OtelMcpApprovalRequest>
+                        m.Parts.Add(new OtelServerToolCallPart<OtelLatest.McpApprovalRequest>
                         {
                             Id = fareqc.RequestId,
                             Name = mcpToolCall.Name,
-                            ServerToolCall = new OtelMcpApprovalRequest
+                            ServerToolCall = new OtelLatest.McpApprovalRequest
                             {
                                 Arguments = mcpToolCall.Arguments,
                                 ServerName = mcpToolCall.ServerName,
@@ -211,10 +211,10 @@ internal static class OtelMessageSerializer
                         break;
 
                     case ToolApprovalResponseContent farespc when farespc.ToolCall is McpServerToolCallContent:
-                        m.Parts.Add(new OtelServerToolCallResponsePart<OtelMcpApprovalResponse>
+                        m.Parts.Add(new OtelServerToolCallResponsePart<OtelLatest.McpApprovalResponse>
                         {
                             Id = farespc.RequestId,
-                            ServerToolCallResponse = new OtelMcpApprovalResponse
+                            ServerToolCallResponse = new OtelLatest.McpApprovalResponse
                             {
                                 Approved = farespc.Approved,
                             },

--- a/src/Libraries/Microsoft.Extensions.AI/Common/OtelV136.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Common/OtelV136.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Serialization models for the GenAI semantic conventions v1.36 representation.</summary>
+internal static class OtelV136
+{
+    internal sealed class SystemOrUserEvent
+    {
+        public string? Role { get; set; }
+        public string? Content { get; set; }
+    }
+
+    internal sealed class AssistantEvent
+    {
+        public string? Content { get; set; }
+        public ToolCall[]? ToolCalls { get; set; }
+    }
+
+    internal sealed class ToolEvent
+    {
+        public string? Id { get; set; }
+        public JsonNode? Content { get; set; }
+    }
+
+    internal sealed class ChoiceEvent
+    {
+        public string? FinishReason { get; set; }
+        public int Index { get; set; }
+        public AssistantEvent? Message { get; set; }
+    }
+
+    internal sealed class ToolCall
+    {
+        public string? Id { get; set; }
+        public string Type { get; set; } = OpenTelemetryConsts.ToolTypeFunction;
+        public ToolCallFunction? Function { get; set; }
+    }
+
+    internal sealed class ToolCallFunction
+    {
+        public string? Name { get; set; }
+        public JsonNode? Arguments { get; set; }
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
@@ -4,11 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 #pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
@@ -18,8 +21,9 @@ namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a delegating embedding generator that implements the OpenTelemetry Semantic Conventions for Generative AI systems.</summary>
 /// <remarks>
-/// This class provides an implementation of the Semantic Conventions for Generative AI systems v1.41, defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
-/// The specification is still experimental and subject to change; as such, the telemetry output by this client is also subject to change.
+/// This class provides implementations of the OpenTelemetry GenAI Semantic Conventions, beginning with v1.36,
+/// defined at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
+/// The conventions have Development status and are subject to change; as such, the telemetry output by this generator is also subject to change.
 /// </remarks>
 /// <typeparam name="TInput">The type of input used to produce embeddings.</typeparam>
 /// <typeparam name="TEmbedding">The type of embedding generated.</typeparam>
@@ -87,6 +91,18 @@ public sealed class OpenTelemetryEmbeddingGenerator<TInput, TEmbedding> : Delega
     /// </remarks>
     public bool EnableSensitiveData { get; set; } = TelemetryHelpers.EnableSensitiveDataDefault;
 
+    /// <summary>Gets or sets the OpenTelemetry GenAI semantic convention representation to emit.</summary>
+    /// <value>
+    /// The default is <see cref="OpenTelemetryGenAISemanticConvention.LatestExperimental"/> when
+    /// <c>OTEL_SEMCONV_STABILITY_OPT_IN</c> is not defined. When the variable is defined, a list containing
+    /// <c>gen_ai_latest_experimental</c> selects <see cref="OpenTelemetryGenAISemanticConvention.LatestExperimental"/>;
+    /// otherwise, it selects <see cref="OpenTelemetryGenAISemanticConvention.Version1_36"/>.
+    /// Explicitly setting this property overrides the environment variable for this instance.
+    /// </value>
+    [Experimental(DiagnosticIds.Experiments.AIOpenTelemetryGenAISemanticConvention, UrlFormat = DiagnosticIds.UrlFormat)]
+    public OpenTelemetryGenAISemanticConvention SemanticConvention { get; set; } =
+        TelemetryHelpers.GetGenAISemanticConventionDefault();
+
     /// <inheritdoc/>
     public override object? GetService(Type serviceType, object? serviceKey = null) =>
         serviceType == typeof(ActivitySource) ? _activitySource :
@@ -147,7 +163,7 @@ public sealed class OpenTelemetryEmbeddingGenerator<TInput, TEmbedding> : Delega
                 [
                     new(OpenTelemetryConsts.GenAI.Operation.Name, OpenTelemetryConsts.GenAI.EmbeddingsName),
                     new(OpenTelemetryConsts.GenAI.Request.Model, modelId),
-                    new(OpenTelemetryConsts.GenAI.Provider.Name, _providerName),
+                    new(TelemetryHelpers.GetGenAIProviderAttributeName(SemanticConvention), _providerName),
                 ]);
 
             if (activity is not null)
@@ -161,7 +177,11 @@ public sealed class OpenTelemetryEmbeddingGenerator<TInput, TEmbedding> : Delega
 
                 if ((options?.Dimensions ?? _defaultModelDimensions) is int dimensionsValue)
                 {
-                    _ = activity.AddTag(OpenTelemetryConsts.GenAI.Embeddings.Dimension.Count, dimensionsValue);
+                    _ = activity.AddTag(
+                        SemanticConvention == OpenTelemetryGenAISemanticConvention.Version1_36 ?
+                            OpenTelemetryConsts.GenAI.Request.EmbeddingDimensions :
+                            OpenTelemetryConsts.GenAI.Embeddings.Dimension.Count,
+                        dimensionsValue);
                 }
 
                 // Log all additional request options as raw values on the span.
@@ -170,7 +190,11 @@ public sealed class OpenTelemetryEmbeddingGenerator<TInput, TEmbedding> : Delega
                 {
                     foreach (KeyValuePair<string, object?> prop in props)
                     {
-                        _ = activity.AddTag(prop.Key, prop.Value);
+                        string key =
+                            SemanticConvention == OpenTelemetryGenAISemanticConvention.Version1_36 && _providerName is not null ?
+                                OpenTelemetryConsts.GenAI.Request.PerProvider(_providerName, JsonNamingPolicy.SnakeCaseLower.ConvertName(prop.Key)) :
+                                prop.Key;
+                        _ = activity.AddTag(key, prop.Value);
                     }
                 }
             }
@@ -239,7 +263,11 @@ public sealed class OpenTelemetryEmbeddingGenerator<TInput, TEmbedding> : Delega
             {
                 foreach (KeyValuePair<string, object?> prop in props)
                 {
-                    _ = activity.AddTag(prop.Key, prop.Value);
+                    string key =
+                        SemanticConvention == OpenTelemetryGenAISemanticConvention.Version1_36 && _providerName is not null ?
+                            OpenTelemetryConsts.GenAI.Response.PerProvider(_providerName, JsonNamingPolicy.SnakeCaseLower.ConvertName(prop.Key)) :
+                            prop.Key;
+                    _ = activity.AddTag(key, prop.Value);
                 }
             }
         }
@@ -254,7 +282,7 @@ public sealed class OpenTelemetryEmbeddingGenerator<TInput, TEmbedding> : Delega
             tags.Add(OpenTelemetryConsts.GenAI.Request.Model, requestModelId);
         }
 
-        tags.Add(OpenTelemetryConsts.GenAI.Provider.Name, _providerName);
+        tags.Add(TelemetryHelpers.GetGenAIProviderAttributeName(SemanticConvention), _providerName);
 
         if (_endpointAddress is string endpointAddress)
         {

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGeneratorBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGeneratorBuilderExtensions.cs
@@ -17,6 +17,11 @@ public static class OpenTelemetryEmbeddingGeneratorBuilderExtensions
     /// <remarks>
     /// The draft specification this follows is available at <see href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" />.
     /// The specification is still experimental and subject to change; as such, the telemetry output by this generator is also subject to change.
+    /// <para>
+    /// When <c>OTEL_SEMCONV_STABILITY_OPT_IN</c> is not defined, the generator preserves the latest experimental representation.
+    /// When the variable is defined, include <c>gen_ai_latest_experimental</c> to select that representation; otherwise, the generator
+    /// emits the v1.36 representation. The <paramref name="configure"/> callback can override this selection.
+    /// </para>
     /// </remarks>
     /// <typeparam name="TInput">The type of input used to produce embeddings.</typeparam>
     /// <typeparam name="TEmbedding">The type of embedding generated.</typeparam>

--- a/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.json
+++ b/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.json
@@ -1222,6 +1222,10 @@
         {
           "Member": "System.Text.Json.JsonSerializerOptions Microsoft.Extensions.AI.OpenTelemetryChatClient.JsonSerializerOptions { get; set; }",
           "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.OpenTelemetryGenAISemanticConvention Microsoft.Extensions.AI.OpenTelemetryChatClient.SemanticConvention { get; set; }",
+          "Stage": "Experimental"
         }
       ]
     },
@@ -1260,6 +1264,10 @@
         {
           "Member": "bool Microsoft.Extensions.AI.OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>.EnableSensitiveData { get; set; }",
           "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.OpenTelemetryGenAISemanticConvention Microsoft.Extensions.AI.OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>.SemanticConvention { get; set; }",
+          "Stage": "Experimental"
         }
       ]
     },
@@ -1270,6 +1278,28 @@
         {
           "Member": "static Microsoft.Extensions.AI.EmbeddingGeneratorBuilder<TInput, TEmbedding> Microsoft.Extensions.AI.OpenTelemetryEmbeddingGeneratorBuilderExtensions.UseOpenTelemetry<TInput, TEmbedding>(this Microsoft.Extensions.AI.EmbeddingGeneratorBuilder<TInput, TEmbedding> builder, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null, string? sourceName = null, System.Action<Microsoft.Extensions.AI.OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>>? configure = null);",
           "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.Extensions.AI.OpenTelemetryGenAISemanticConvention",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AI.OpenTelemetryGenAISemanticConvention.OpenTelemetryGenAISemanticConvention();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.AI.OpenTelemetryGenAISemanticConvention Microsoft.Extensions.AI.OpenTelemetryGenAISemanticConvention.Version1_36",
+          "Stage": "Experimental",
+          "Value": "0"
+        },
+        {
+          "Member": "const Microsoft.Extensions.AI.OpenTelemetryGenAISemanticConvention Microsoft.Extensions.AI.OpenTelemetryGenAISemanticConvention.LatestExperimental",
+          "Stage": "Experimental",
+          "Value": "1"
         }
       ]
     },

--- a/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryConsts.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryConsts.cs
@@ -16,6 +16,12 @@ internal static class OpenTelemetryConsts
     /// <summary>Environment variable name for controlling whether sensitive content should be captured in telemetry by default.</summary>
     public const string GenAICaptureMessageContentEnvVar = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
 
+    /// <summary>Environment variable name for selecting experimental semantic convention representations.</summary>
+    public const string SemanticConventionStabilityOptInEnvVar = "OTEL_SEMCONV_STABILITY_OPT_IN";
+
+    /// <summary>Opt-in token for selecting the latest experimental GenAI semantic conventions.</summary>
+    public const string GenAILatestExperimentalOptIn = "gen_ai_latest_experimental";
+
     public const string ToolTypeFunction = "function";
 
     public const string TypeText = "text";
@@ -35,9 +41,15 @@ internal static class OpenTelemetryConsts
         public const string Type = "error.type";
     }
 
+    public static class Event
+    {
+        public const string Name = "event.name";
+    }
+
     public static class GenAI
     {
         public const string ChatName = "chat";
+        public const string Choice = "gen_ai.choice";
         public const string EmbeddingsName = "embeddings";
         public const string ExecuteToolName = "execute_tool";
         public const string InvokeAgentName = "invoke_agent";
@@ -55,6 +67,12 @@ internal static class OpenTelemetryConsts
         public const string RealtimeName = "realtime";
 
         public const string SystemInstructions = "gen_ai.system_instructions";
+        public const string SystemName = "gen_ai.system";
+
+        public static class Assistant
+        {
+            public const string Message = "gen_ai.assistant.message";
+        }
 
         public static class Client
         {
@@ -124,6 +142,7 @@ internal static class OpenTelemetryConsts
         public static class Request
         {
             public const string ChoiceCount = "gen_ai.request.choice.count";
+            public const string EmbeddingDimensions = "gen_ai.request.embedding.dimensions";
             public const string FrequencyPenalty = "gen_ai.request.frequency_penalty";
             public const string Model = "gen_ai.request.model";
             public const string MaxTokens = "gen_ai.request.max_tokens";
@@ -134,6 +153,8 @@ internal static class OpenTelemetryConsts
             public const string Temperature = "gen_ai.request.temperature";
             public const string TopK = "gen_ai.request.top_k";
             public const string TopP = "gen_ai.request.top_p";
+
+            public static string PerProvider(string providerName, string parameterName) => $"gen_ai.{providerName}.request.{parameterName}";
         }
 
         public static class Response
@@ -142,6 +163,13 @@ internal static class OpenTelemetryConsts
             public const string Id = "gen_ai.response.id";
             public const string Model = "gen_ai.response.model";
             public const string TimeToFirstChunk = "gen_ai.response.time_to_first_chunk";
+
+            public static string PerProvider(string providerName, string parameterName) => $"gen_ai.{providerName}.response.{parameterName}";
+        }
+
+        public static class System
+        {
+            public const string Message = "gen_ai.system.message";
         }
 
         public static class Token
@@ -175,6 +203,11 @@ internal static class OpenTelemetryConsts
             public const string OutputAudioTokens = "gen_ai.usage.output_audio_tokens";
             public const string OutputTextTokens = "gen_ai.usage.output_text_tokens";
             public const string ReasoningOutputTokens = "gen_ai.usage.reasoning.output_tokens";
+        }
+
+        public static class User
+        {
+            public const string Message = "gen_ai.user.message";
         }
 
         /// <summary>

--- a/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryGenAISemanticConvention.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryGenAISemanticConvention.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Specifies the OpenTelemetry GenAI semantic convention representation to emit.</summary>
+[Experimental(DiagnosticIds.Experiments.AIOpenTelemetryGenAISemanticConvention, UrlFormat = DiagnosticIds.UrlFormat)]
+public enum OpenTelemetryGenAISemanticConvention
+{
+    /// <summary>
+    /// Emit the representation defined by the OpenTelemetry GenAI semantic conventions v1.36.
+    /// </summary>
+    Version1_36 = 0,
+
+    /// <summary>Emit the latest experimental representation supported by this package.</summary>
+    LatestExperimental = 1,
+}

--- a/src/Libraries/Microsoft.Extensions.AI/TelemetryHelpers.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/TelemetryHelpers.cs
@@ -15,6 +15,48 @@ internal static class TelemetryHelpers
         Environment.GetEnvironmentVariable(OpenTelemetryConsts.GenAICaptureMessageContentEnvVar) is string envVar &&
         string.Equals(envVar, "true", StringComparison.OrdinalIgnoreCase);
 
+    /// <summary>Gets the default GenAI semantic convention representation for a new instrumentation instance.</summary>
+    public static OpenTelemetryGenAISemanticConvention GetGenAISemanticConventionDefault() =>
+        GetGenAISemanticConvention(Environment.GetEnvironmentVariable(OpenTelemetryConsts.SemanticConventionStabilityOptInEnvVar));
+
+    /// <summary>Resolves the GenAI semantic convention representation from an OpenTelemetry stability opt-in list.</summary>
+    internal static OpenTelemetryGenAISemanticConvention GetGenAISemanticConvention(string? stabilityOptIn)
+    {
+        if (stabilityOptIn is null)
+        {
+            return OpenTelemetryGenAISemanticConvention.LatestExperimental;
+        }
+
+        int startIndex = 0;
+        while (startIndex <= stabilityOptIn.Length)
+        {
+            int separatorIndex = stabilityOptIn.IndexOf(',', startIndex);
+            string value = separatorIndex >= 0 ?
+                stabilityOptIn.Substring(startIndex, separatorIndex - startIndex) :
+                stabilityOptIn.Substring(startIndex);
+
+            if (string.Equals(value.Trim(), OpenTelemetryConsts.GenAILatestExperimentalOptIn, StringComparison.Ordinal))
+            {
+                return OpenTelemetryGenAISemanticConvention.LatestExperimental;
+            }
+
+            if (separatorIndex < 0)
+            {
+                break;
+            }
+
+            startIndex = separatorIndex + 1;
+        }
+
+        return OpenTelemetryGenAISemanticConvention.Version1_36;
+    }
+
+    /// <summary>Gets the provider attribute name for the selected GenAI semantic convention representation.</summary>
+    public static string GetGenAIProviderAttributeName(OpenTelemetryGenAISemanticConvention semanticConvention) =>
+        semanticConvention == OpenTelemetryGenAISemanticConvention.Version1_36 ?
+            OpenTelemetryConsts.GenAI.SystemName :
+            OpenTelemetryConsts.GenAI.Provider.Name;
+
     /// <summary>Serializes <paramref name="value"/> as JSON for logging purposes.</summary>
     public static string AsJson<T>(T value, JsonSerializerOptions? options)
     {

--- a/src/Shared/DiagnosticIds/DiagnosticIds.cs
+++ b/src/Shared/DiagnosticIds/DiagnosticIds.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable S1144 // Remove the unused internal class
@@ -55,6 +55,7 @@ internal static class DiagnosticIds
         internal const string AIFunctionApprovals = AIExperiments;
         internal const string AIApprovalsInvocationRequired = AIExperiments;
         internal const string AIFunctionAndParameterName = AIExperiments;
+        internal const string AIOpenTelemetryGenAISemanticConvention = AIExperiments;
 
         internal const string AIChatReduction = AIExperiments;
         internal const string AIToolSearch = AIExperiments;

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -1087,10 +1087,15 @@ public class FunctionInvokingChatClientTests
     }
 
     [Theory]
-    [InlineData(false, false)]
-    [InlineData(true, false)]
-    [InlineData(true, true)]
-    public async Task FunctionInvocationTrackedWithActivity(bool enableTelemetry, bool enableSensitiveData)
+    [InlineData(false, false, OpenTelemetryGenAISemanticConvention.LatestExperimental)]
+    [InlineData(true, false, OpenTelemetryGenAISemanticConvention.LatestExperimental)]
+    [InlineData(true, true, OpenTelemetryGenAISemanticConvention.LatestExperimental)]
+    [InlineData(true, false, OpenTelemetryGenAISemanticConvention.Version1_36)]
+    [InlineData(true, true, OpenTelemetryGenAISemanticConvention.Version1_36)]
+    public async Task FunctionInvocationTrackedWithActivity(
+        bool enableTelemetry,
+        bool enableSensitiveData,
+        OpenTelemetryGenAISemanticConvention semanticConvention)
     {
         string sourceName = Guid.NewGuid().ToString();
 
@@ -1108,7 +1113,11 @@ public class FunctionInvokingChatClientTests
         };
 
         Func<ChatClientBuilder, ChatClientBuilder> configure = b => b.Use(c =>
-            new FunctionInvokingChatClient(new OpenTelemetryChatClient(c, sourceName: sourceName) { EnableSensitiveData = enableSensitiveData }));
+            new FunctionInvokingChatClient(new OpenTelemetryChatClient(c, sourceName: sourceName)
+            {
+                EnableSensitiveData = enableSensitiveData,
+                SemanticConvention = semanticConvention,
+            }));
 
         await InvokeAsync(() => InvokeAndAssertAsync(options, plan, configurePipeline: configure));
 
@@ -1135,7 +1144,7 @@ public class FunctionInvokingChatClientTests
                     activity => Assert.Equal("orchestrate_tools", activity.DisplayName));
 
                 var executeTool = activities[1];
-                if (enableSensitiveData)
+                if (enableSensitiveData && semanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental)
                 {
                     var args = Assert.Single(executeTool.Tags, t => t.Key == "gen_ai.tool.call.arguments");
                     Assert.Equal(
@@ -1150,6 +1159,12 @@ public class FunctionInvokingChatClientTests
                     Assert.DoesNotContain(executeTool.Tags, t => t.Key == "gen_ai.tool.call.arguments");
                     Assert.DoesNotContain(executeTool.Tags, t => t.Key == "gen_ai.tool.call.result");
                 }
+
+                Assert.Equal(
+                    semanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental ?
+                        "function" :
+                        null,
+                    executeTool.GetTagItem("gen_ai.tool.type"));
 
                 for (int i = 0; i < activities.Count - 1; i++)
                 {
@@ -1942,6 +1957,68 @@ public class FunctionInvokingChatClientTests
             Assert.False(hasArguments, "Expected arguments NOT to be logged when agent EnableSensitiveData is false");
             Assert.False(hasResult, "Expected result NOT to be logged when agent EnableSensitiveData is false");
         }
+    }
+
+    [Theory]
+    [InlineData(
+        OpenTelemetryGenAISemanticConvention.Version1_36,
+        OpenTelemetryGenAISemanticConvention.LatestExperimental)]
+    [InlineData(
+        OpenTelemetryGenAISemanticConvention.LatestExperimental,
+        OpenTelemetryGenAISemanticConvention.Version1_36)]
+    public async Task SemanticConventionPropagatesFromAgentActivityWhenInvokeAgentIsParent(
+        OpenTelemetryGenAISemanticConvention agentSemanticConvention,
+        OpenTelemetryGenAISemanticConvention clientSemanticConvention)
+    {
+        string agentSourceName = Guid.NewGuid().ToString();
+        string clientSourceName = Guid.NewGuid().ToString();
+
+        List<ChatMessage> plan =
+        [
+            new ChatMessage(ChatRole.User, "hello"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent(
+                "callId1",
+                "Func1",
+                new Dictionary<string, object?> { ["arg1"] = "secret" })]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("callId1", result: "Result 1")]),
+            new ChatMessage(ChatRole.Assistant, "world"),
+        ];
+
+        ChatOptions options = new()
+        {
+            Tools = [AIFunctionFactory.Create(() => "Result 1", "Func1")]
+        };
+
+        var activities = new List<Activity>();
+        using TracerProvider tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .AddSource(agentSourceName)
+            .AddSource(clientSourceName)
+            .AddInMemoryExporter(activities)
+            .Build();
+
+        using (var agentSource = new ActivitySource(agentSourceName))
+        using (Activity? invokeAgentActivity = agentSource.StartActivity("invoke_agent"))
+        {
+            Assert.NotNull(invokeAgentActivity);
+            invokeAgentActivity.SetCustomProperty("__EnableSensitiveData__", "true");
+            invokeAgentActivity.SetCustomProperty("__GenAISemanticConvention__", agentSemanticConvention);
+
+            await InvokeAndAssertAsync(options, plan, configurePipeline: builder =>
+                builder
+                    .UseFunctionInvocation()
+                    .UseOpenTelemetry(sourceName: clientSourceName, configure: client =>
+                    {
+                        client.EnableSensitiveData = true;
+                        client.SemanticConvention = clientSemanticConvention;
+                    }));
+        }
+
+        Activity executeTool = Assert.Single(activities, activity => activity.DisplayName == "execute_tool Func1");
+        bool latestExperimental = agentSemanticConvention == OpenTelemetryGenAISemanticConvention.LatestExperimental;
+
+        Assert.Equal(latestExperimental ? "function" : null, executeTool.GetTagItem("gen_ai.tool.type"));
+        Assert.Equal(latestExperimental, executeTool.GetTagItem("gen_ai.tool.call.arguments") is not null);
+        Assert.Equal(latestExperimental, executeTool.GetTagItem("gen_ai.tool.call.result") is not null);
     }
 
     [Theory]
@@ -3640,4 +3717,3 @@ public class FunctionInvokingChatClientTests
             m.Contents.Any(c => c is FunctionResultContent frc2 && frc2.CallId == "callId1"));
     }
 }
-

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -381,6 +382,206 @@ public class OpenTelemetryChatClientTests
                   }
                 ]
                 """), ReplaceWhitespace(tags["gen_ai.tool.definitions"]));
+        }
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task CompatibilityExpectedInformationLogged_Async(bool enableSensitiveData, bool streaming)
+    {
+        var sourceName = Guid.NewGuid().ToString();
+        var activities = new List<Activity>();
+        using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .AddInMemoryExporter(activities)
+            .Build();
+
+        var collector = new FakeLogCollector();
+        using ILoggerFactory loggerFactory = LoggerFactory.Create(b => b.AddProvider(new FakeLoggerProvider(collector)));
+
+        using var innerClient = new TestChatClient
+        {
+            GetResponseAsyncCallback = async (messages, options, cancellationToken) =>
+            {
+                await Task.Yield();
+                return CreateResponse();
+            },
+            GetStreamingResponseAsyncCallback = CallbackAsync,
+            GetServiceCallback = (serviceType, serviceKey) =>
+                serviceType == typeof(ChatClientMetadata) ?
+                    new ChatClientMetadata("testservice", new Uri("http://localhost:12345/something"), "defaultmodel") :
+                    null,
+        };
+
+        static ChatResponse CreateResponse() =>
+            new(
+            [
+                new ChatMessage(ChatRole.Assistant, "Hello "),
+                new ChatMessage(ChatRole.Assistant, "Roger."),
+            ])
+            {
+                ResponseId = "id123",
+                ModelId = "responsemodel",
+                FinishReason = ChatFinishReason.Stop,
+                Usage = new UsageDetails
+                {
+                    InputTokenCount = 10,
+                    OutputTokenCount = 20,
+                    CachedInputTokenCount = 5,
+                    ReasoningTokenCount = 8,
+                },
+                AdditionalProperties = new()
+                {
+                    ["system_fingerprint"] = "abcdefgh",
+                },
+            };
+
+        static async IAsyncEnumerable<ChatResponseUpdate> CallbackAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "Hello Roger.")
+            {
+                ResponseId = "id123",
+                ModelId = "responsemodel",
+                FinishReason = ChatFinishReason.Stop,
+                Contents =
+                [
+                    new TextContent("Hello Roger."),
+                    new UsageContent(new UsageDetails
+                    {
+                        InputTokenCount = 10,
+                        OutputTokenCount = 20,
+                        CachedInputTokenCount = 5,
+                        ReasoningTokenCount = 8,
+                    }),
+                ],
+                AdditionalProperties = new()
+                {
+                    ["system_fingerprint"] = "abcdefgh",
+                },
+            };
+        }
+
+        using var chatClient = innerClient
+            .AsBuilder()
+            .UseOpenTelemetry(loggerFactory, sourceName, configure: instance =>
+            {
+                instance.EnableSensitiveData = enableSensitiveData;
+                instance.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;
+                instance.SemanticConvention = OpenTelemetryGenAISemanticConvention.Version1_36;
+            })
+            .Build();
+
+        using var durationCollector = new MetricCollector<double>(
+            null,
+            sourceName,
+            "gen_ai.client.operation.duration");
+        using var timeToFirstChunkCollector = new MetricCollector<double>(
+            null,
+            sourceName,
+            "gen_ai.client.operation.time_to_first_chunk");
+        using var timePerOutputChunkCollector = new MetricCollector<double>(
+            null,
+            sourceName,
+            "gen_ai.client.operation.time_per_output_chunk");
+
+        List<ChatMessage> messages =
+        [
+            new(ChatRole.System, "You are a close friend."),
+            new(ChatRole.User, "Hello."),
+            new(ChatRole.Assistant, [new FunctionCallContent(
+                "12345",
+                "GetPersonName",
+                new Dictionary<string, object?> { ["personId"] = 42 })]),
+            new(ChatRole.Tool, [new FunctionResultContent("12345", "Roger")]),
+        ];
+
+        var options = new ChatOptions
+        {
+            Instructions = "Always greet the user.",
+            ModelId = "replacementmodel",
+            AdditionalProperties = new()
+            {
+                ["service_tier"] = "value1",
+            },
+            Tools = [AIFunctionFactory.Create(() => "Roger", "GetPersonName")],
+        };
+
+        if (streaming)
+        {
+            await foreach (ChatResponseUpdate update in chatClient.GetStreamingResponseAsync(messages, options))
+            {
+                _ = update;
+            }
+        }
+        else
+        {
+            _ = await chatClient.GetResponseAsync(messages, options);
+        }
+
+        Activity activity = Assert.Single(activities);
+        Assert.Equal("testservice", activity.GetTagItem("gen_ai.system"));
+        Assert.Null(activity.GetTagItem("gen_ai.provider.name"));
+        Assert.Null(activity.GetTagItem("gen_ai.request.stream"));
+        Assert.Null(activity.GetTagItem("gen_ai.input.messages"));
+        Assert.Null(activity.GetTagItem("gen_ai.output.messages"));
+        Assert.Null(activity.GetTagItem("gen_ai.system_instructions"));
+        Assert.Null(activity.GetTagItem("gen_ai.tool.definitions"));
+        Assert.Null(activity.GetTagItem("gen_ai.usage.cache_read.input_tokens"));
+        Assert.Null(activity.GetTagItem("gen_ai.usage.reasoning.output_tokens"));
+        Assert.Null(activity.GetTagItem("gen_ai.response.time_to_first_chunk"));
+        Assert.Equal(
+            enableSensitiveData ? "value1" : null,
+            activity.GetTagItem("gen_ai.testservice.request.service_tier"));
+        Assert.Equal(
+            enableSensitiveData ? "abcdefgh" : null,
+            activity.GetTagItem("gen_ai.testservice.response.system_fingerprint"));
+
+        var duration = Assert.Single(durationCollector.GetMeasurementSnapshot());
+        Assert.True(duration.ContainsTags(
+            new KeyValuePair<string, object?>("gen_ai.operation.name", "chat"),
+            new KeyValuePair<string, object?>("gen_ai.system", "testservice")));
+        Assert.False(duration.ContainsTags(
+            new KeyValuePair<string, object?>("gen_ai.provider.name", "testservice")));
+        Assert.Empty(timeToFirstChunkCollector.GetMeasurementSnapshot());
+        Assert.Empty(timePerOutputChunkCollector.GetMeasurementSnapshot());
+
+        var logs = collector.GetSnapshot();
+        if (!enableSensitiveData)
+        {
+            Assert.Empty(logs);
+            return;
+        }
+
+        Assert.Collection(
+            logs,
+            log => AssertV136Event(log, "gen_ai.system.message", """{"content":"Always greet the user."}"""),
+            log => AssertV136Event(log, "gen_ai.system.message", """{"content":"You are a close friend."}"""),
+            log => AssertV136Event(log, "gen_ai.user.message", """{"content":"Hello."}"""),
+            log => AssertV136Event(
+                log,
+                "gen_ai.assistant.message",
+                """{"tool_calls":[{"id":"12345","type":"function","function":{"name":"GetPersonName","arguments":{"personId":42}}}]}"""),
+            log => AssertV136Event(log, "gen_ai.tool.message", """{"id":"12345","content":"Roger"}"""),
+            log => AssertV136Event(
+                log,
+                "gen_ai.choice",
+                """{"finish_reason":"stop","index":0,"message":{"content":"Hello Roger."}}"""));
+
+        static void AssertV136Event(FakeLogRecord log, string eventName, string body)
+        {
+            Assert.Equal(eventName, log.Id.Name);
+            using JsonDocument expected = JsonDocument.Parse(body);
+            using JsonDocument actual = JsonDocument.Parse(log.Message);
+            Assert.True(JsonElement.DeepEquals(expected.RootElement, actual.RootElement));
+            Assert.Contains(log.StructuredState!, pair => pair.Key == "event.name" && pair.Value == eventName);
+            Assert.Contains(log.StructuredState!, pair => pair.Key == "gen_ai.system" && pair.Value == "testservice");
         }
     }
 
@@ -1038,6 +1239,7 @@ public class OpenTelemetryChatClientTests
                 {
                     _ = update;
                 }
+
             });
         }
         else
@@ -1107,4 +1309,3 @@ public class OpenTelemetryChatClientTests
         }
     }
 }
-

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryEnvironmentVariableTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryEnvironmentVariableTests.cs
@@ -1,0 +1,131 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+#pragma warning disable SA1402 // Collection definition and its tests are intentionally colocated.
+
+[Collection(nameof(OpenTelemetryEnvironmentVariableTests))]
+public class OpenTelemetryEnvironmentVariableTests
+{
+    [Theory]
+    [InlineData(null, OpenTelemetryGenAISemanticConvention.LatestExperimental)]
+    [InlineData(" ", OpenTelemetryGenAISemanticConvention.Version1_36)]
+    [InlineData("http", OpenTelemetryGenAISemanticConvention.Version1_36)]
+    [InlineData("http,gen_ai_latest_experimental", OpenTelemetryGenAISemanticConvention.LatestExperimental)]
+    [InlineData(" http , gen_ai_latest_experimental ", OpenTelemetryGenAISemanticConvention.LatestExperimental)]
+    [InlineData("GEN_AI_LATEST_EXPERIMENTAL", OpenTelemetryGenAISemanticConvention.Version1_36)]
+    public void SemanticConventionResolvedFromStabilityOptIn(
+        string? stabilityOptIn,
+        OpenTelemetryGenAISemanticConvention expected)
+    {
+        const string VariableName = "OTEL_SEMCONV_STABILITY_OPT_IN";
+        string? previousValue = Environment.GetEnvironmentVariable(VariableName);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(VariableName, stabilityOptIn);
+            using var innerClient = new TestChatClient();
+            using var client = new OpenTelemetryChatClient(innerClient);
+            Assert.Equal(expected, client.SemanticConvention);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(VariableName, previousValue);
+        }
+    }
+
+    [Fact]
+    public void ExplicitSemanticConventionOverridesEnvironmentAndIsStableForInstance()
+    {
+        const string VariableName = "OTEL_SEMCONV_STABILITY_OPT_IN";
+        string? previousValue = Environment.GetEnvironmentVariable(VariableName);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(VariableName, " ");
+            using var firstInnerClient = new TestChatClient();
+            using var firstClient = new OpenTelemetryChatClient(firstInnerClient);
+            Assert.Equal(OpenTelemetryGenAISemanticConvention.Version1_36, firstClient.SemanticConvention);
+
+            Environment.SetEnvironmentVariable(VariableName, "gen_ai_latest_experimental");
+            Assert.Equal(OpenTelemetryGenAISemanticConvention.Version1_36, firstClient.SemanticConvention);
+
+            firstClient.SemanticConvention = OpenTelemetryGenAISemanticConvention.LatestExperimental;
+            Assert.Equal(OpenTelemetryGenAISemanticConvention.LatestExperimental, firstClient.SemanticConvention);
+
+            using var secondInnerClient = new TestChatClient();
+            using var secondClient = new OpenTelemetryChatClient(secondInnerClient);
+            Assert.Equal(OpenTelemetryGenAISemanticConvention.LatestExperimental, secondClient.SemanticConvention);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(VariableName, previousValue);
+        }
+    }
+
+    [Fact]
+    public async Task FunctionInvocationUsesEnvironmentWhenNoTelemetryClientProvidesMode()
+    {
+        const string VariableName = "OTEL_SEMCONV_STABILITY_OPT_IN";
+        string? previousValue = Environment.GetEnvironmentVariable(VariableName);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(VariableName, " ");
+
+            string sourceName = Guid.NewGuid().ToString();
+            var activities = new List<Activity>();
+            using TracerProvider tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+                .AddSource(sourceName)
+                .AddInMemoryExporter(activities)
+                .Build();
+
+            int invocation = 0;
+            using var innerClient = new TestChatClient
+            {
+                GetResponseAsyncCallback = (messages, options, cancellationToken) =>
+                    Task.FromResult(
+                        invocation++ == 0 ?
+                            new ChatResponse(new ChatMessage(
+                                ChatRole.Assistant,
+                                [new FunctionCallContent("callId", "TestFunction")])) :
+                            new ChatResponse(new ChatMessage(ChatRole.Assistant, "done"))),
+            };
+            using var client = new FunctionInvokingChatClient(innerClient);
+            using var source = new ActivitySource(sourceName);
+
+            using (Activity? activity = source.StartActivity("invoke_agent"))
+            {
+                Assert.NotNull(activity);
+                _ = await client.GetResponseAsync(
+                    [new ChatMessage(ChatRole.User, "run")],
+                    new ChatOptions
+                    {
+                        Tools = [AIFunctionFactory.Create(() => "result", "TestFunction")],
+                    });
+            }
+
+            Activity executeTool = Assert.Single(
+                activities,
+                activity => activity.DisplayName == "execute_tool TestFunction");
+            Assert.Null(executeTool.GetTagItem("gen_ai.tool.type"));
+            Assert.DoesNotContain(executeTool.Tags, tag => tag.Key == "gen_ai.tool.call.arguments");
+            Assert.DoesNotContain(executeTool.Tags, tag => tag.Key == "gen_ai.tool.call.result");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(VariableName, previousValue);
+        }
+    }
+
+    [CollectionDefinition(nameof(OpenTelemetryEnvironmentVariableTests), DisableParallelization = true)]
+    public sealed class OpenTelemetryEnvironmentVariableTestCollection;
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/OpenTelemetryEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/OpenTelemetryEmbeddingGeneratorTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using OpenTelemetry.Trace;
@@ -93,6 +94,70 @@ public class OpenTelemetryEmbeddingGeneratorTests
         Assert.Equal(enableSensitiveData ? "value3" : null, activity.GetTagItem("AndSomethingElse"));
 
         Assert.True(activity.Duration.TotalMilliseconds > 0);
+    }
+
+    [Fact]
+    public async Task CompatibilityExpectedInformationLogged_Async()
+    {
+        var sourceName = Guid.NewGuid().ToString();
+        var activities = new List<Activity>();
+        using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .AddInMemoryExporter(activities)
+            .Build();
+
+        using var innerGenerator = new TestEmbeddingGenerator
+        {
+            GenerateAsyncCallback = async (values, options, cancellationToken) =>
+            {
+                await Task.Yield();
+                return new GeneratedEmbeddings<Embedding<float>>([new Embedding<float>(new float[] { 1, 2, 3 })])
+                {
+                    Usage = new() { InputTokenCount = 10 },
+                    AdditionalProperties = new() { ["system_fingerprint"] = "abcdefgh" },
+                };
+            },
+            GetServiceCallback = (serviceType, serviceKey) =>
+                serviceType == typeof(EmbeddingGeneratorMetadata) ?
+                    new EmbeddingGeneratorMetadata("testservice", new Uri("http://localhost:12345/something"), "defaultmodel", 1234) :
+                    null,
+        };
+
+        using var generator = innerGenerator
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: sourceName, configure: instance =>
+            {
+                instance.EnableSensitiveData = true;
+                instance.SemanticConvention = OpenTelemetryGenAISemanticConvention.Version1_36;
+            })
+            .Build();
+
+        using var durationCollector = new MetricCollector<double>(
+            null,
+            sourceName,
+            "gen_ai.client.operation.duration");
+
+        await generator.GenerateVectorAsync(
+            "hello",
+            new EmbeddingGenerationOptions
+            {
+                AdditionalProperties = new() { ["service_tier"] = "value1" },
+            });
+
+        Activity activity = Assert.Single(activities);
+        Assert.Equal("testservice", activity.GetTagItem("gen_ai.system"));
+        Assert.Null(activity.GetTagItem("gen_ai.provider.name"));
+        Assert.Equal(1234, activity.GetTagItem("gen_ai.request.embedding.dimensions"));
+        Assert.Null(activity.GetTagItem("gen_ai.embeddings.dimension.count"));
+        Assert.Equal("value1", activity.GetTagItem("gen_ai.testservice.request.service_tier"));
+        Assert.Equal("abcdefgh", activity.GetTagItem("gen_ai.testservice.response.system_fingerprint"));
+
+        var duration = Assert.Single(durationCollector.GetMeasurementSnapshot());
+        Assert.True(duration.ContainsTags(
+            new KeyValuePair<string, object?>("gen_ai.operation.name", "embeddings"),
+            new KeyValuePair<string, object?>("gen_ai.system", "testservice")));
+        Assert.False(duration.ContainsTags(
+            new KeyValuePair<string, object?>("gen_ai.provider.name", "testservice")));
     }
 
     [Fact]


### PR DESCRIPTION
## Motivation and context

`Microsoft.Extensions.AI` currently emits only the latest GenAI semantic conventions supported by the package. It does not honor `OTEL_SEMCONV_STABILITY_OPT_IN`, so applications cannot select the v1.36 compatibility representation.

This change adds both the v1.36 compatibility representation and the latest experimental representation. It keeps the existing default when the environment variable is absent, avoiding a breaking telemetry change for current users. Applications can select v1.36 by defining `OTEL_SEMCONV_STABILITY_OPT_IN` without `gen_ai_latest_experimental`.

This support also unblocks consistent .NET observability in Microsoft Agent Framework, which uses `OpenTelemetryChatClient` for agent, chat, and tool execution telemetry.

Fixes #7709

## Description

### Semantic convention selection

The resolved mode follows this precedence:

1. Explicit API configuration
2. `OTEL_SEMCONV_STABILITY_OPT_IN`
3. The existing latest experimental default

| Configuration | Emitted representation |
|---|---|
| Variable absent | Latest experimental |
| List containing `gen_ai_latest_experimental` | Latest experimental |
| Variable defined without the token | v1.36 compatibility |
| Explicit API selection | Explicitly selected mode |

The environment value is parsed as a comma-separated list. The resolved mode is fixed for the lifetime of each instrumentation instance and is exposed for wrappers that need to emit related spans consistently.

### v1.36 compatibility representation

The compatibility mode restores the telemetry contract that `Microsoft.Extensions.AI` emitted before dotnet/extensions#6767:

* Uses `gen_ai.system` instead of `gen_ai.provider.name`.
* Emits system, user, assistant, tool, and choice messages as structured events.
* Uses the v1.36 message and function call body formats.
* Omits attributes, metrics, and values introduced after v1.36.

### Latest experimental representation

The latest experimental mode preserves the current behavior:

* Uses `gen_ai.provider.name`.
* Emits input and output messages through `gen_ai.input.messages` and `gen_ai.output.messages`.
* Emits separate instructions through `gen_ai.system_instructions`.
* Continues to support convention updates after v1.36.

### Sensitive content

`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` continues to control message bodies, system instructions, function arguments, and function results in both modes.

The change does not introduce the Agent Framework specific `ENABLE_MESSAGE_EVENTS` setting.

### Scope

This pull request updates:

* `OpenTelemetryChatClient`
* `FunctionInvokingChatClient` and `FunctionInvocationProcessor`
* `OpenTelemetryEmbeddingGenerator`
* Shared OpenTelemetry constants, serializers, and metric helpers
* Public API metadata for semantic convention selection

## Compatibility

The recommended behavior preserves the telemetry emitted when no new configuration is provided.

Defining `OTEL_SEMCONV_STABILITY_OPT_IN` without `gen_ai_latest_experimental` intentionally changes that instrumentation instance to the v1.36 compatibility representation. Consumers should not expect provider fields or message representations from both modes in the same operation.

The v1.36 GenAI conventions have `Development` status. This pull request describes them as a compatibility representation rather than a stable representation.

## API

The new API is experimental pending owner review:

```csharp
namespace Microsoft.Extensions.AI;

public enum OpenTelemetryGenAISemanticConvention
{
    Version1_36,
    LatestExperimental,
}

public sealed partial class OpenTelemetryChatClient
{
    public OpenTelemetryGenAISemanticConvention SemanticConvention { get; set; }
}
```

## Testing

The implementation is covered by:

* Environment parsing and unrelated category tokens
* Explicit API precedence
* Per-instance stability after environment changes
* Sensitive content enabled and disabled
* Non-streaming and streaming chat
* Success, failure, and cancellation
* Tool success and failure
* Parent `invoke_agent` and `invoke_workflow` mode propagation
* Environment fallback when no telemetry client supplies a mode
* Chat and embedding spans and metrics
* v1.36 structured message events
* Multi-message response aggregation into one v1.36 choice
* Mode-specific field presence and absence
* Duplicate emission prevention

The filtered AI solution builds and tests successfully. The final full build reports existing `IDE0055` warnings in unchanged lines of `FunctionInvokingChatClient.cs`.

## Checklist

* [ ] The API shape has owner approval.
* [x] The behavior for an absent environment variable is documented.
* [x] Both representations have positive and negative tests.
* [x] Public API metadata is updated.
* [x] XML documentation uses `Development` and compatibility terminology correctly.
* [ ] The Microsoft Agent Framework integration has been validated against the produced package.
