### PR TITLE
Add ReasoningEffort.Max

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ReasoningEffort.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ReasoningEffort.cs
@@ -34,7 +34,12 @@ public enum ReasoningEffort
     High,
 
     /// <summary>
-    /// Extra high reasoning effort. Maximum reasoning for the most demanding tasks.
+    /// Extra high reasoning effort. More extensive reasoning than <see cref="High"/>.
     /// </summary>
     ExtraHigh,
+
+    /// <summary>
+    /// Maximum reasoning effort. The highest level available, for the most demanding tasks.
+    /// </summary>
+    Max,
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.json
@@ -3768,6 +3768,11 @@
           "Value": "1"
         },
         {
+          "Member": "const Microsoft.Extensions.AI.ReasoningEffort Microsoft.Extensions.AI.ReasoningEffort.Max",
+          "Stage": "Stable",
+          "Value": "5"
+        },
+        {
           "Member": "const Microsoft.Extensions.AI.ReasoningEffort Microsoft.Extensions.AI.ReasoningEffort.Medium",
           "Stage": "Stable",
           "Value": "2"

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -711,6 +711,7 @@ internal sealed partial class OpenAIChatClient : IChatClient
             ReasoningEffort.Medium => ChatReasoningEffortLevel.Medium,
             ReasoningEffort.High => ChatReasoningEffortLevel.High,
             ReasoningEffort.ExtraHigh => new ChatReasoningEffortLevel("xhigh"),
+            ReasoningEffort.Max => new ChatReasoningEffortLevel("max"),
             _ => (ChatReasoningEffortLevel?)null,
         };
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -1257,6 +1257,7 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
             ReasoningEffort.Medium => ResponseReasoningEffortLevel.Medium,
             ReasoningEffort.High => ResponseReasoningEffortLevel.High,
             ReasoningEffort.ExtraHigh => new ResponseReasoningEffortLevel("xhigh"),
+            ReasoningEffort.Max => new ResponseReasoningEffortLevel("max"),
             _ => (ResponseReasoningEffortLevel?)null,
         };
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ReasoningOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ReasoningOptionsTests.cs
@@ -23,6 +23,7 @@ public class ReasoningOptionsTests
     [InlineData(ReasoningEffort.Medium)]
     [InlineData(ReasoningEffort.High)]
     [InlineData(ReasoningEffort.ExtraHigh)]
+    [InlineData(ReasoningEffort.Max)]
     public void Effort_Roundtrips(ReasoningEffort effort)
     {
         ReasoningOptions options = new() { Effort = effort };
@@ -99,7 +100,7 @@ public class ReasoningOptionsTests
     public void JsonSerialization_AllEffortValues_SerializeAsStrings()
     {
         // Test all ReasoningEffort values serialize correctly
-        foreach (ReasoningEffort effort in new[] { ReasoningEffort.None, ReasoningEffort.Low, ReasoningEffort.Medium, ReasoningEffort.High, ReasoningEffort.ExtraHigh })
+        foreach (ReasoningEffort effort in new[] { ReasoningEffort.None, ReasoningEffort.Low, ReasoningEffort.Medium, ReasoningEffort.High, ReasoningEffort.ExtraHigh, ReasoningEffort.Max })
         {
             string json = JsonSerializer.Serialize(effort, TestJsonSerializerContext.Default.ReasoningEffort);
             ReasoningEffort? deserialized = JsonSerializer.Deserialize(json, TestJsonSerializerContext.Default.ReasoningEffort);

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
@@ -1826,6 +1826,7 @@ public class OpenAIChatClientTests
     [InlineData(ReasoningEffort.Medium, "medium")]
     [InlineData(ReasoningEffort.High, "high")]
     [InlineData(ReasoningEffort.ExtraHigh, "xhigh")]
+    [InlineData(ReasoningEffort.Max, "max")]
     public async Task ReasoningOptions_Effort_ProducesExpectedJson(ReasoningEffort effort, string expectedEffortString)
     {
         string input = $$"""

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -6654,6 +6654,7 @@ public class OpenAIResponseClientTests
     [InlineData(ReasoningEffort.Medium, ReasoningOutput.Full, "medium", "detailed")]
     [InlineData(ReasoningEffort.High, ReasoningOutput.Summary, "high", "concise")]
     [InlineData(ReasoningEffort.ExtraHigh, ReasoningOutput.Full, "xhigh", "detailed")]
+    [InlineData(ReasoningEffort.Max, ReasoningOutput.Full, "max", "detailed")]
     public async Task ReasoningOptions_EffortAndOutput_ProducesExpectedJson(
         ReasoningEffort effort,
         ReasoningOutput output,


### PR DESCRIPTION
Adds a `Max` level to `ReasoningEffort`, one tier above `ExtraHigh`. Both providers with
first-party `IChatClient` adapters now expose it: OpenAI added `"max"` to
`ResponseReasoningEffortLevel` in
[openai-dotnet#1289](https://github.com/openai/openai-dotnet/pull/1289), and Anthropic
12.42.0 already exposes `Max` on `Anthropic.Models.Messages.Effort`. Since `ReasoningOptions`
is `sealed` with only `Effort` and `Output`, there is currently no provider-neutral way to
request the top tier.

Implements the API proposed in #7715.

### Changes

- **`ReasoningEffort.cs`**: Add `Max`. Reword the `ExtraHigh` summary, which claimed
  "Maximum reasoning for the most demanding tasks".
- **`OpenAIChatClient.cs`** / **`OpenAIResponsesChatClient.cs`**: Map `ReasoningEffort.Max`
  to `new ChatReasoningEffortLevel("max")` / `new ResponseReasoningEffortLevel("max")`,
  using the string constructor as `"xhigh"` does today (#7319). These can move to the
  generated `.Max` property once a release containing openai-dotnet#1289 is picked up.
- **`Microsoft.Extensions.AI.Abstractions.json`**: Add the new stable field to the API
  baseline.
- **Tests**: Add `Max` as `[InlineData]` on the existing parameterized theories in
  `ReasoningOptionsTests`, `OpenAIChatClientTests`, and `OpenAIResponseClientTests`. The
  latter two assert the emitted `"max"` wire value.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7717)