### PR TITLE
Validate path segments in Azure storage result store and response cache

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Microsoft.Extensions.AI.Evaluation.Reporting.Azure.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Microsoft.Extensions.AI.Evaluation.Reporting.Azure.csproj
@@ -18,6 +18,7 @@
     <Compile Include="..\Microsoft.Extensions.AI.Evaluation.Reporting\CSharp\JsonSerialization\CamelCaseEnumConverter.cs" Link="JsonSerialization\CamelCaseEnumConverter.cs" />
     <Compile Include="..\Microsoft.Extensions.AI.Evaluation.Reporting\CSharp\JsonSerialization\EvaluationContextConverter.cs" Link="JsonSerialization\EvaluationContextConverter.cs" />
     <Compile Include="..\Microsoft.Extensions.AI.Evaluation.Reporting\CSharp\JsonSerialization\TimeSpanConverter.cs" Link="JsonSerialization\TimeSpanConverter.cs" />
+    <Compile Include="..\Microsoft.Extensions.AI.Evaluation.Reporting\CSharp\Utilities\PathValidation.cs" Link="Utilities\PathValidation.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResponseCache.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResponseCache.cs
@@ -16,6 +16,7 @@ using Azure;
 using Azure.Storage.Files.DataLake;
 using Azure.Storage.Files.DataLake.Models;
 using Azure.Storage.Files.DataLake.Specialized;
+using Microsoft.Extensions.AI.Evaluation.Reporting.Utilities;
 using Microsoft.Extensions.Caching.Distributed;
 
 namespace Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
@@ -34,7 +35,7 @@ internal sealed partial class AzureStorageResponseCache(
     private const string ContentsFileNotFound = "Cache contents file {0} was not found.";
     private const string EntryAndContentsFilesNotFound = "Cache entry file {0} and contents file {1} were not found.";
 
-    private readonly string _iterationPath = $"cache/{scenarioName}/{iterationName}";
+    private readonly string _iterationPath = BuildIterationPath(scenarioName, iterationName);
     private readonly Func<DateTime> _provideDateTime = provideDateTime;
     private readonly TimeSpan _timeToLiveForCacheEntries =
         timeToLiveForCacheEntries ?? Defaults.DefaultTimeToLiveForCacheEntries;
@@ -219,8 +220,18 @@ internal sealed partial class AzureStorageResponseCache(
         }
     }
 
+    private static string BuildIterationPath(string scenarioName, string iterationName)
+    {
+        PathValidation.ValidatePathSegment(scenarioName, nameof(scenarioName));
+        PathValidation.ValidatePathSegment(iterationName, nameof(iterationName));
+
+        return $"cache/{scenarioName}/{iterationName}";
+    }
+
     private (string entryFilePath, string contentsFilePath) GetPaths(string key)
     {
+        PathValidation.ValidatePathSegment(key, nameof(key));
+
         string entryFilePath = $"{_iterationPath}/{key}/{EntryFileName}";
         string contentsFilePath = $"{_iterationPath}/{key}/{ContentsFileName}";
 

--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResultStore.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Azure/Storage/AzureStorageResultStore.cs
@@ -15,6 +15,7 @@ using Azure.Storage.Files.DataLake;
 using Azure.Storage.Files.DataLake.Models;
 using Azure.Storage.Files.DataLake.Specialized;
 using Microsoft.Extensions.AI.Evaluation.Reporting.JsonSerialization;
+using Microsoft.Extensions.AI.Evaluation.Reporting.Utilities;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
@@ -189,6 +190,10 @@ public sealed class AzureStorageResultStore(DataLakeDirectoryClient client) : IE
         string? scenarioName = null,
         string? iterationName = null)
     {
+        PathValidation.ValidatePathSegment(executionName, nameof(executionName));
+        PathValidation.ValidatePathSegment(scenarioName, nameof(scenarioName));
+        PathValidation.ValidatePathSegment(iterationName, nameof(iterationName));
+
         if (executionName is null)
         {
             return ($"{ResultsRootPrefix}/", isDir: true);

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/AzureStorage/AzureStoragePathValidationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/AzureStorage/AzureStoragePathValidationTests.cs
@@ -1,0 +1,175 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Storage.Files.DataLake;
+using Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
+using Microsoft.Extensions.Caching.Distributed;
+using Xunit;
+
+namespace Microsoft.Extensions.AI.Evaluation.Reporting.Tests;
+
+/// <summary>
+/// Verifies that the Azure Storage backed <see cref="IEvaluationResultStore"/> and
+/// <see cref="IDistributedCache"/> implementations reject caller-supplied names that are not valid single
+/// path segments (mirroring the validation performed by the disk based implementations). These tests do not
+/// require a configured Azure Storage account because validation occurs before any network request is issued.
+/// </summary>
+public class AzureStoragePathValidationTests
+{
+    // A DataLakeDirectoryClient constructed from a bare Uri is anonymous and never contacts the network in
+    // these tests, since validation throws before any request is built.
+    private static DataLakeDirectoryClient CreateDummyClient()
+        => new(new Uri("https://account.dfs.core.windows.net/container/root"));
+
+    public static IEnumerable<object[]> InvalidSegments()
+    {
+        yield return new object[] { ".." };
+        yield return new object[] { "." };
+        yield return new object[] { "../x" };
+        yield return new object[] { "../../x" };
+        yield return new object[] { "foo/bar" };
+        yield return new object[] { " leading" };
+        yield return new object[] { "trailing " };
+    }
+
+    private static ScenarioRunResult CreateResult(string scenarioName, string iterationName, string executionName)
+        => new(
+            scenarioName: scenarioName,
+            iterationName: iterationName,
+            executionName: executionName,
+            creationTime: DateTime.UtcNow,
+            messages: [new ChatMessage(ChatRole.User, "User prompt")],
+            modelResponse: new ChatResponse(new ChatMessage(ChatRole.Assistant, "LLM response")),
+            evaluationResult: new EvaluationResult(new BooleanMetric("boolean", value: true)));
+
+    [Theory]
+    [MemberData(nameof(InvalidSegments))]
+    public async Task WriteResultsAsync_InvalidExecutionName_Throws(string segment)
+    {
+        var store = new AzureStorageResultStore(CreateDummyClient());
+        ScenarioRunResult result = CreateResult("scenario", "iteration", segment);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await store.WriteResultsAsync([result]));
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidSegments))]
+    public async Task WriteResultsAsync_InvalidScenarioName_Throws(string segment)
+    {
+        var store = new AzureStorageResultStore(CreateDummyClient());
+        ScenarioRunResult result = CreateResult(segment, "iteration", "execution");
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await store.WriteResultsAsync([result]));
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidSegments))]
+    public async Task WriteResultsAsync_InvalidIterationName_Throws(string segment)
+    {
+        var store = new AzureStorageResultStore(CreateDummyClient());
+        ScenarioRunResult result = CreateResult("scenario", segment, "execution");
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await store.WriteResultsAsync([result]));
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidSegments))]
+    public async Task ReadResultsAsync_InvalidExecutionName_Throws(string segment)
+    {
+        var store = new AzureStorageResultStore(CreateDummyClient());
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            await foreach (ScenarioRunResult result in store.ReadResultsAsync(segment))
+            {
+                _ = result;
+            }
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidSegments))]
+    public async Task DeleteResultsAsync_InvalidExecutionName_Throws(string segment)
+    {
+        var store = new AzureStorageResultStore(CreateDummyClient());
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await store.DeleteResultsAsync(segment));
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidSegments))]
+    public async Task GetScenarioNamesAsync_InvalidExecutionName_Throws(string segment)
+    {
+        var store = new AzureStorageResultStore(CreateDummyClient());
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            await foreach (string scenarioName in store.GetScenarioNamesAsync(segment))
+            {
+                _ = scenarioName;
+            }
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidSegments))]
+    public async Task GetIterationNamesAsync_InvalidScenarioName_Throws(string segment)
+    {
+        var store = new AzureStorageResultStore(CreateDummyClient());
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            await foreach (string iterationName in store.GetIterationNamesAsync("execution", segment))
+            {
+                _ = iterationName;
+            }
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidSegments))]
+    public async Task GetCacheAsync_InvalidScenarioName_Throws(string segment)
+    {
+        var provider = new AzureStorageResponseCacheProvider(CreateDummyClient());
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await provider.GetCacheAsync(segment, "iteration"));
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidSegments))]
+    public async Task GetCacheAsync_InvalidIterationName_Throws(string segment)
+    {
+        var provider = new AzureStorageResponseCacheProvider(CreateDummyClient());
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await provider.GetCacheAsync("scenario", segment));
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidSegments))]
+    public async Task Cache_InvalidKey_Throws(string segment)
+    {
+        var provider = new AzureStorageResponseCacheProvider(CreateDummyClient());
+        IDistributedCache cache = await provider.GetCacheAsync("scenario", "iteration");
+
+        await Assert.ThrowsAsync<ArgumentException>(async () => await cache.GetAsync(segment));
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await cache.SetAsync(segment, [1, 2, 3], new DistributedCacheEntryOptions()));
+        await Assert.ThrowsAsync<ArgumentException>(async () => await cache.RemoveAsync(segment));
+        await Assert.ThrowsAsync<ArgumentException>(async () => await cache.RefreshAsync(segment));
+
+        Assert.Throws<ArgumentException>(() => cache.Get(segment));
+        Assert.Throws<ArgumentException>(
+            () => cache.Set(segment, [1, 2, 3], new DistributedCacheEntryOptions()));
+        Assert.Throws<ArgumentException>(() => cache.Remove(segment));
+        Assert.Throws<ArgumentException>(() => cache.Refresh(segment));
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/DiskBased/PathValidationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/DiskBased/PathValidationTests.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias Reporting;
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Microsoft.Extensions.AI.Evaluation.Reporting.Utilities;
 using Xunit;
+using PathValidation = Reporting::Microsoft.Extensions.AI.Evaluation.Reporting.Utilities.PathValidation;
 
 namespace Microsoft.Extensions.AI.Evaluation.Reporting.Tests;
 

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/Microsoft.Extensions.AI.Evaluation.Reporting.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Reporting.Tests/Microsoft.Extensions.AI.Evaluation.Reporting.Tests.csproj
@@ -16,7 +16,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AI.Evaluation.Reporting.Azure\Microsoft.Extensions.AI.Evaluation.Reporting.Azure.csproj" />
-    <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AI.Evaluation.Reporting\CSharp\Microsoft.Extensions.AI.Evaluation.Reporting.csproj" />
+    <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AI.Evaluation.Reporting\CSharp\Microsoft.Extensions.AI.Evaluation.Reporting.csproj">
+      <Aliases>global, Reporting</Aliases>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Routes Azure Storage result-store and response-cache path construction through the shared `PathValidation` helper (reused from the Reporting assembly via `InternalsVisibleTo`). Execution, scenario, and iteration names, as well as cache keys, are now validated as single path segments before any request is built, consistent with the disk-based store and cache implementations.

## Changes
- `AzureStorageResultStore` validates execution/scenario/iteration names at a single choke point in `GetResultPath`.
- `AzureStorageResponseCache` validates scenario/iteration names when building the iteration path and validates the cache key in `GetPaths`.
- The Azure project now consumes the shared `PathValidation` helper and JSON converters from the Reporting assembly via `InternalsVisibleTo` instead of compiling duplicate sources (`InjectSharedThrow`/`InjectTrimAttributesOnLegacy` disabled accordingly).
- Adds tests covering rejection of invalid path segments across all public store and cache methods.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7718)