### PR TITLE
OpenAI: Avoid null implicit conversions for image options

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -334,7 +334,10 @@ internal sealed partial class OpenAIChatClient : IChatClient
             {
                 string detailString => new ChatImageDetailLevel(detailString),
                 ChatImageDetailLevel detail => detail,
-                _ => null
+
+                // The SDK defines nullable and non-nullable op_Implicit conversions from string. Force a nullable result so
+                // null does not bind to the non-nullable conversion, which throws ArgumentNullException.
+                _ => (ChatImageDetailLevel?)null
             };
         }
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs
@@ -780,6 +780,9 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
                             "image/png" => ImageGenerationToolOutputFileFormat.Png,
                             "image/jpeg" => ImageGenerationToolOutputFileFormat.Jpeg,
                             "image/webp" => ImageGenerationToolOutputFileFormat.Webp,
+
+                            // The SDK defines nullable and non-nullable op_Implicit conversions from string. Force a nullable result so
+                            // null does not bind to the non-nullable conversion, which throws ArgumentNullException.
                             _ => (ImageGenerationToolOutputFileFormat?)null,
                         } :
                         null,
@@ -2058,7 +2061,10 @@ internal sealed class OpenAIResponsesChatClient : IChatClient
             {
                 string detailString => new ResponseImageDetailLevel(detailString),
                 ResponseImageDetailLevel detail => detail,
-                _ => null
+
+                // The SDK defines nullable and non-nullable op_Implicit conversions from string. Force a nullable result so
+                // null does not bind to the non-nullable conversion, which throws ArgumentNullException.
+                _ => (ResponseImageDetailLevel?)null
             };
         }
 

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
@@ -1515,8 +1515,13 @@ public class OpenAIChatClientTests
     public Task DataContentMessage_Image_AdditionalProperty_StringDetail_NonStreaming()
         => DataContentMessage_Image_AdditionalPropertyDetail_NonStreaming(ChatImageDetailLevel.High);
 
-    private static async Task DataContentMessage_Image_AdditionalPropertyDetail_NonStreaming(object detailValue)
+    [Fact]
+    public Task DataContentMessage_Image_AdditionalProperty_InvalidDetail_NonStreaming()
+        => DataContentMessage_Image_AdditionalPropertyDetail_NonStreaming(42, expectedDetail: null);
+
+    private static async Task DataContentMessage_Image_AdditionalPropertyDetail_NonStreaming(object detailValue, string? expectedDetail = "high")
     {
+        string detailProperty = expectedDetail is not null ? $"\"detail\": \"{expectedDetail}\"," : string.Empty;
         string input = $$"""
             {
               "messages": [
@@ -1530,7 +1535,7 @@ public class OpenAIChatClientTests
                     {
                       "type": "image_url",
                       "image_url": {
-                        "detail": "high",
+                        {{detailProperty}}
                         "url": "{{ImageDataUri.GetImageDataUri()}}"
                       }
                     }

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIConversionTests.cs
@@ -380,6 +380,18 @@ public class OpenAIConversionTests
     }
 
     [Fact]
+    public void AsOpenAIResponseTool_WithHostedImageGenerationToolWithoutMediaType_PreservesUnspecifiedOutputFileFormat()
+    {
+        var imageGenTool = new HostedImageGenerationTool();
+
+        var result = imageGenTool.AsOpenAIResponseTool();
+
+        Assert.NotNull(result);
+        var tool = Assert.IsType<ImageGenerationTool>(result);
+        Assert.Null(tool.OutputFileFormat);
+    }
+
+    [Fact]
     public void AsOpenAIResponseTool_WithHostedImageGenerationToolWithOptions_ProducesValidImageGenerationTool()
     {
         var imageGenTool = new HostedImageGenerationTool

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIResponseClientTests.cs
@@ -5585,6 +5585,51 @@ public class OpenAIResponseClientTests
     }
 
     [Fact]
+    public async Task UserMessageWithInvalidImageDetail_OmitsDetail()
+    {
+        const string Input = """
+            {
+                "model":"gpt-4o-mini",
+                "input":[
+                    {
+                        "type":"message",
+                        "role":"user",
+                        "content":[
+                            {"type":"input_image","image_url":"data:image/png;base64,iVBORw0KGgo="}
+                        ]
+                    }
+                ]
+            }
+            """;
+
+        const string Output = """
+            {
+              "id":"resp_001",
+              "object":"response",
+              "created_at":1741892091,
+              "status":"completed",
+              "model":"gpt-4o-mini",
+              "output":[{"type":"message","id":"msg_001","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Done","annotations":[]}]}]
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateResponseClient(httpClient, "gpt-4o-mini");
+
+        var response = await client.GetResponseAsync([
+            new ChatMessage(ChatRole.User, [
+                new DataContent(Convert.FromBase64String("iVBORw0KGgo="), "image/png")
+                {
+                    AdditionalProperties = new AdditionalPropertiesDictionary { ["detail"] = 42 }
+                }
+            ])
+        ]);
+
+        Assert.Equal("Done", response.Text);
+    }
+
+    [Fact]
     public async Task NonStreamingResponseWithIncompleteReason_MapsFinishReason()
     {
         const string Input = """


### PR DESCRIPTION
## Summary

- add regression coverage for preserving an unspecified image-generation output format
- avoid throwing non-nullable OpenAI SDK string conversions for unsupported Chat Completions and Responses image-detail values
- document why the nullable casts are required when the SDK exposes both nullable and non-nullable `op_Implicit` conversions

## Context

The output-format `ArgumentNullException` reported in #7721 was already fixed in #7544 while upgrading OpenAI from 2.10.0 to 2.11.0. That change explicitly typed the switch fallback as `ImageGenerationToolOutputFileFormat?`, but it did not add focused unit coverage or explain why the cast was necessary.

Auditing the MEAI source for the same pattern found two additional occurrences in the Chat Completions and Responses image-detail conversions. Unsupported `AdditionalProperties["detail"]` value types selected an untyped `null` fallback, which bound to the SDK's non-nullable string conversion and threw `ArgumentNullException`. This change makes those fallbacks explicitly nullable and verifies that unsupported detail values are omitted from requests.

## Validation

- `dotnet build test\Libraries\Microsoft.Extensions.AI.OpenAI.Tests\Microsoft.Extensions.AI.OpenAI.Tests.csproj -f net10.0 --no-restore`
- `OpenAIChatClientTests.DataContentMessage_Image_AdditionalProperty_InvalidDetail_NonStreaming`
- `OpenAIResponseClientTests.UserMessageWithInvalidImageDetail_OmitsDetail`
- `OpenAIConversionTests.AsOpenAIResponseTool_WithHostedImageGenerationToolWithoutMediaType_PreservesUnspecifiedOutputFileFormat`

All targeted tests pass. The exact pre-10.7 output-format expression and both original image-detail fallbacks were also verified to fail with `ArgumentNullException` before their respective nullable casts.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7727)