### PR TITLE
Fail closed when a quality metric has no valid score

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/EvaluationMetricExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/EvaluationMetricExtensions.cs
@@ -25,12 +25,25 @@ internal static class EvaluationMetricExtensions
         };
 
         const double MinimumPassingScore = 4.0;
-        return metric.Value is double value && value < MinimumPassingScore
-            ? new EvaluationMetricInterpretation(
-                rating,
-                failed: true,
-                reason: $"{metric.Name} is less than {MinimumPassingScore}.")
-            : new EvaluationMetricInterpretation(rating);
+        return metric.Value switch
+        {
+            null =>
+                new EvaluationMetricInterpretation(
+                    rating,
+                    failed: true,
+                    reason: $"{metric.Name} has no score."),
+            double value when value < MinimumPassingScore =>
+                new EvaluationMetricInterpretation(
+                    rating,
+                    failed: true,
+                    reason: $"{metric.Name} is less than {MinimumPassingScore}."),
+            _ when rating is EvaluationRating.Inconclusive =>
+                new EvaluationMetricInterpretation(
+                    rating,
+                    failed: true,
+                    reason: $"{metric.Name} is outside the valid range."),
+            _ => new EvaluationMetricInterpretation(rating),
+        };
     }
 
     internal static EvaluationMetricInterpretation InterpretScore(

--- a/test/Libraries/Microsoft.Extensions.AI.Evaluation.Tests/EvaluationMetricExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Evaluation.Tests/EvaluationMetricExtensionsTests.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+extern alias Evaluation;
+using Evaluation::Microsoft.Extensions.AI.Evaluation;
+using Microsoft.Extensions.AI.Evaluation.Quality;
+using Xunit;
+
+namespace Microsoft.Extensions.AI.Evaluation.Tests;
+
+public class EvaluationMetricExtensionsTests
+{
+    [Fact]
+    public void MetricWithNoScoreIsFailed()
+    {
+        var metric = new NumericMetric("test");
+
+        EvaluationMetricInterpretation interpretation = metric.InterpretScore();
+
+        Assert.Equal(EvaluationRating.Inconclusive, interpretation.Rating);
+        Assert.True(interpretation.Failed);
+    }
+
+    [Theory]
+    [InlineData(5.1)]
+    [InlineData(7.0)]
+    public void ScoreAboveTheMaximumIsFailed(double value)
+    {
+        var metric = new NumericMetric("test", value);
+
+        EvaluationMetricInterpretation interpretation = metric.InterpretScore();
+
+        Assert.Equal(EvaluationRating.Inconclusive, interpretation.Rating);
+        Assert.True(interpretation.Failed);
+    }
+
+    [Fact]
+    public void ScoreThatIsNotANumberIsFailed()
+    {
+        var metric = new NumericMetric("test", double.NaN);
+
+        EvaluationMetricInterpretation interpretation = metric.InterpretScore();
+
+        Assert.Equal(EvaluationRating.Inconclusive, interpretation.Rating);
+        Assert.True(interpretation.Failed);
+    }
+
+    [Theory]
+    [InlineData(-1.0)]
+    [InlineData(0.0)]
+    [InlineData(1.0)]
+    [InlineData(3.9)]
+    public void ScoreBelowTheMinimumPassingScoreIsFailed(double value)
+    {
+        var metric = new NumericMetric("test", value);
+
+        EvaluationMetricInterpretation interpretation = metric.InterpretScore();
+
+        Assert.True(interpretation.Failed);
+    }
+
+    [Theory]
+    [InlineData(4.0)]
+    [InlineData(4.5)]
+    [InlineData(5.0)]
+    public void ScoreAtOrAboveTheMinimumPassingScoreIsNotFailed(double value)
+    {
+        var metric = new NumericMetric("test", value);
+
+        EvaluationMetricInterpretation interpretation = metric.InterpretScore();
+
+        Assert.False(interpretation.Failed);
+    }
+
+    [Fact]
+    public void BooleanMetricWithNoValueIsFailed()
+    {
+        var metric = new BooleanMetric("test");
+
+        EvaluationMetricInterpretation interpretation = metric.InterpretScore();
+
+        Assert.Equal(EvaluationRating.Inconclusive, interpretation.Rating);
+        Assert.True(interpretation.Failed);
+    }
+}


### PR DESCRIPTION
Fixes #7665

The quality evaluators interpret their own score through `InterpretScore(NumericMetric)`. That method only reached the failed branch when the metric's value parsed to a double below the minimum passing score of 4.0, so two cases fell through to not-failed:

- the value is null, which is what happens when the judge returns text the evaluator cannot parse a score out of
- the value is outside the scale the ratings cover: above 5.0, or NaN and infinity, both of which `double.TryParse` accepts

Both already produced an Inconclusive rating, so the metric carried a rating saying nothing was concluded alongside a result that reads as a pass. A pipeline gating on `Failed` treats a metric that was never successfully scored as green.

This marks both cases as failed. The `BooleanMetric` overload in the same file already fails closed on a null value, and the report UI already counts a metric with an error diagnostic as failed, which every parse failure produces. So the flag now agrees with what the rest of the library already treats as a failure.

On the compatibility guidance in CONTRIBUTING: this does change observable behavior. A run that previously reported no failures can now report one, in exactly the cases where the judge did not return a usable score. Values inside the scale are unaffected, including the 4.0 boundary and the existing reason text for scores below it.

The same shape exists in `InterpretContentSafetyScore` and `InterpretContentHarmScore` in the Safety package, and in the NLP package's `ScoreInterpretationExtensions`. I left those alone since the issue is scoped to Quality, and can follow up if you want them consistent.

Verified locally with the pinned SDK on net10.0, net9.0, net8.0 and net472. With the fix reverted and the new tests present, the test project fails 3 of 173; with the fix applied, 174 of 174 pass on every target.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7735)