### PR TITLE
Update Polly to 8.7.0

### DIFF
--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -18,10 +18,10 @@
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="$(MicrosoftMLTokenizersVersion)" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.2.0" />
     <PackageVersion Include="OpenAI" Version="2.13.0" />
-    <PackageVersion Include="Polly" Version="8.4.2" />
-    <PackageVersion Include="Polly.Core" Version="8.4.2" />
-    <PackageVersion Include="Polly.Extensions" Version="8.4.2" />
-    <PackageVersion Include="Polly.RateLimiting" Version="8.4.2" />
+    <PackageVersion Include="Polly" Version="8.7.0" />
+    <PackageVersion Include="Polly.Core" Version="8.7.0" />
+    <PackageVersion Include="Polly.Extensions" Version="8.7.0" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.7.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.4" />

--- a/eng/packages/Tests.props
+++ b/eng/packages/Tests.props
@@ -28,7 +28,7 @@
     <!-- Lift CVE-impacted transitive dependency; remove once the direct dependency updates. -->
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
-    <PackageVersion Include="Polly.Testing" Version="8.4.2" />
+    <PackageVersion Include="Polly.Testing" Version="8.7.0" />
     <PackageVersion Include="SharpFuzz" Version="2.1.1" />
     <PackageVersion Include="StrongNamer" Version="0.2.5" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/GrpcResilienceTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/GrpcResilienceTests.cs
@@ -97,7 +97,7 @@ public class GrpcResilienceTests
         // with a transient failure that the retry strategy is configured to handle.
         var client = CreateClient(
             builder => builder.AddStandardResilienceHandler(),
-            new TestHandlerStub((_, _) =>
+            () => new TestHandlerStub((_, _) =>
             {
                 cts.Cancel();
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Version = HttpVersion.Version20 });
@@ -136,7 +136,7 @@ public class GrpcResilienceTests
         }
     }
 
-    private Greeter.GreeterClient CreateClient(Action<IHttpClientBuilder>? configure = null, HttpMessageHandler? primaryHandler = null)
+    private Greeter.GreeterClient CreateClient(Action<IHttpClientBuilder>? configure = null, Func<HttpMessageHandler>? primaryHandler = null)
     {
         var services = new ServiceCollection();
         var clientBuilder = services
@@ -144,7 +144,7 @@ public class GrpcResilienceTests
             {
                 options.Address = _host.GetTestServer().BaseAddress;
             })
-            .ConfigurePrimaryHttpMessageHandler(() => primaryHandler ?? _handler);
+            .ConfigurePrimaryHttpMessageHandler(primaryHandler ?? (() => _handler));
 
         configure?.Invoke(clientBuilder);
 

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/GrpcResilienceTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/GrpcResilienceTests.cs
@@ -4,7 +4,9 @@
 #if !NETFRAMEWORK
 
 using System;
+using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Grpc.Core;
@@ -14,6 +16,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Http.Resilience.Test.Grpc;
+using Microsoft.Extensions.Http.Resilience.Test.Helpers;
 using Polly;
 using Xunit;
 
@@ -84,6 +87,41 @@ public class GrpcResilienceTests
         response.Message.Should().Be("HI!");
     }
 
+    [Theory]
+    [CombinatorialData]
+    public async Task SayHello_StandardResilience_CancelledWhileAttemptCompletes_Cancelled(bool asynchronous)
+    {
+        using var cts = new CancellationTokenSource();
+
+        // The caller cancels while the attempt is in flight, and the attempt then completes
+        // with a transient failure that the retry strategy is configured to handle.
+        var client = CreateClient(
+            builder => builder.AddStandardResilienceHandler(),
+            new TestHandlerStub((_, _) =>
+            {
+                cts.Cancel();
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Version = HttpVersion.Version20 });
+            }));
+
+        var act = () => SendRequest(client, asynchronous, cts.Token);
+
+        (await act.Should().ThrowAsync<RpcException>()).Which.StatusCode.Should().Be(StatusCode.Cancelled);
+    }
+
+    private static Task<HelloReply> SendRequest(Greeter.GreeterClient client, bool asynchronous, CancellationToken cancellationToken)
+    {
+        var request = new HelloRequest { Name = "dummy" };
+
+        if (asynchronous)
+        {
+            return client.SayHelloAsync(request, cancellationToken: cancellationToken).ResponseAsync;
+        }
+        else
+        {
+            return Task.FromResult(client.SayHello(request, cancellationToken: cancellationToken));
+        }
+    }
+
     private static Task<HelloReply> SendRequest(Greeter.GreeterClient client, bool asynchronous)
     {
         var request = new HelloRequest { Name = "dummy" };
@@ -98,7 +136,7 @@ public class GrpcResilienceTests
         }
     }
 
-    private Greeter.GreeterClient CreateClient(Action<IHttpClientBuilder>? configure = null)
+    private Greeter.GreeterClient CreateClient(Action<IHttpClientBuilder>? configure = null, HttpMessageHandler? primaryHandler = null)
     {
         var services = new ServiceCollection();
         var clientBuilder = services
@@ -106,7 +144,7 @@ public class GrpcResilienceTests
             {
                 options.Address = _host.GetTestServer().BaseAddress;
             })
-            .ConfigurePrimaryHttpMessageHandler(() => _handler);
+            .ConfigurePrimaryHttpMessageHandler(() => primaryHandler ?? _handler);
 
         configure?.Invoke(clientBuilder);
 


### PR DESCRIPTION
Fixes #7741

With Polly 8.4.2 the retry strategy returns the last failed outcome instead of throwing when the caller's token is cancelled. Behind `AddStandardResilienceHandler`, a gRPC client that the caller cancels during an attempt ending in a retryable failure therefore reports `StatusCode.Unavailable` (or `Unknown` / `Internal`, depending on the failure) instead of `StatusCode.Cancelled`. Polly changed this in 8.5.2 (App-vNext/Polly#2456).

Two commits:

- a test in `GrpcResilienceTests` for that scenario — fails on `main`;
- Polly, Polly.Core, Polly.Extensions, Polly.RateLimiting and Polly.Testing to 8.7.0 — makes it pass.

The behaviour change is the fix: with a cancelled token, a retryable failure now surfaces as `OperationCanceledException` rather than as the outcome of the last attempt. Non-retryable outcomes are returned as before.

_I used Claude Code for the investigation and to draft the test; I ran the tests myself._
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7742)