### PR TITLE
Fix duplicate separator in HTTP logging

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/Log.cs
@@ -164,11 +164,32 @@ internal static partial class Log
         var httpMethod = request[startIndex].Value;
         var httpHost = request[startIndex + 1].Value;
         var httpPath = request[startIndex + 2].Value;
-        var separator = httpPath is string path && path.Length > 0 && path[0] == '/' ? string.Empty : "/";
+        var hasLeadingSlash =
+            httpPath is string path &&
+            path.Length > 0 &&
+            path[0] == '/';
 #if NET
-        return string.Create(CultureInfo.InvariantCulture, stackalloc char[256], $"{httpMethod} {httpHost}{separator}{httpPath}");
+        if (hasLeadingSlash)
+        {
+            return string.Create(
+                CultureInfo.InvariantCulture,
+                stackalloc char[256],
+                $"{httpMethod} {httpHost}{httpPath}");
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            stackalloc char[256],
+            $"{httpMethod} {httpHost}/{httpPath}");
 #else
-        return FormattableString.Invariant($"{httpMethod} {httpHost}{separator}{httpPath}");
+        if (hasLeadingSlash)
+        {
+            return FormattableString.Invariant(
+                $"{httpMethod} {httpHost}{httpPath}");
+        }
+
+        return FormattableString.Invariant(
+            $"{httpMethod} {httpHost}/{httpPath}");
 #endif
     }
 

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/Log.cs
@@ -164,10 +164,11 @@ internal static partial class Log
         var httpMethod = request[startIndex].Value;
         var httpHost = request[startIndex + 1].Value;
         var httpPath = request[startIndex + 2].Value;
+        var separator = httpPath is string path && path.Length > 0 && path[0] == '/' ? string.Empty : "/";
 #if NET
-        return string.Create(CultureInfo.InvariantCulture, stackalloc char[256], $"{httpMethod} {httpHost}/{httpPath}");
+        return string.Create(CultureInfo.InvariantCulture, stackalloc char[256], $"{httpMethod} {httpHost}{separator}{httpPath}");
 #else
-        return FormattableString.Invariant($"{httpMethod} {httpHost}/{httpPath}");
+        return FormattableString.Invariant($"{httpMethod} {httpHost}{separator}{httpPath}");
 #endif
     }
 

--- a/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpClientLoggerTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpClientLoggerTest.cs
@@ -256,6 +256,35 @@ public class HttpClientLoggerTest
     }
 
     [Fact]
+    public async Task HttpLoggingHandler_UnredactedPath_DoesNotDuplicateSeparator()
+    {
+        var options = new LoggingOptions
+        {
+            RequestPathParameterRedactionMode = HttpRouteParameterRedactionMode.None
+        };
+        var fakeLogger = new FakeLogger<HttpClientLogger>();
+        var headersReader = new HttpHeadersReader(options.ToOptionsMonitor(), Mock.Of<IHttpHeadersRedactor>());
+        var requestReader = new HttpRequestReader(
+            options,
+            GetHttpRouteFormatter(),
+            Mock.Of<IHttpRouteParser>(),
+            headersReader,
+            RequestMetadataContext);
+
+        using var handler = new TestLoggingHandler(
+            new HttpClientLogger(fakeLogger, requestReader, Array.Empty<IHttpClientLogEnricher>(), options),
+            new TestingHandlerStub((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK))));
+        using var client = new HttpClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://default-uri.com/foo/bar");
+
+        await client.SendAsync(request, It.IsAny<CancellationToken>());
+
+        var logRecord = Assert.Single(fakeLogger.Collector.GetSnapshot());
+        Assert.Equal("GET default-uri.com/foo/bar", logRecord.Message);
+        logRecord.GetStructuredState().Contains(HttpClientLoggingTagNames.Path, "/foo/bar");
+    }
+
+    [Fact]
     public async Task HttpLoggingHandler_AllOptionsWithLogRequestStart_LogsOutgoingRequestWithTwoRecords()
     {
         var requestContent = _fixture.Create<string>();


### PR DESCRIPTION
Fixes #7737

When path redaction is disabled, `RequestUri.AbsolutePath` already begins with `/`. The outgoing request formatter was adding another separator, producing messages such as `GET github.com//dotnet/extensions`.

Use a separator only when the logged path does not already start with `/`, while leaving the structured `url.path` value unchanged. The regression test covers the unredacted path mode.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/7749)